### PR TITLE
Avoid undefined behavior in Core member functions when request fails

### DIFF
--- a/HDPS/src/Core.cpp
+++ b/HDPS/src/Core.cpp
@@ -178,6 +178,7 @@ plugin::RawData& Core::requestData(const QString name)
     }
 
     QMessageBox::critical(NULL, QString("HDPS"), QString("No plugin found with name: ").append(name), QMessageBox::Ok);
+    throw PluginNotFoundException(name);
 }
 
 /** Request a dataset from the data manager by its name. */
@@ -190,6 +191,7 @@ Set& Core::requestSet(const QString name)
     catch (SetNotFoundException e)
     {
         QMessageBox::critical(NULL, QString("HDPS"), e.what(), QMessageBox::Ok);
+        throw;
     }
 }
 

--- a/HDPS/src/Core.h
+++ b/HDPS/src/Core.h
@@ -2,12 +2,31 @@
 
 #include "CoreInterface.h"
 
+#include <exception>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
 namespace hdps
 {
+
+struct PluginNotFoundException : public std::exception
+{
+public:
+  explicit PluginNotFoundException(const QString& pluginName) :
+        message((QString::fromLatin1("Failed to find a plugin with name: ") + pluginName).toStdString())
+    { }
+
+    const char* what() const noexcept override
+    {
+        return message.c_str();
+    }
+
+private:
+    std::string message;
+};
+
 
 namespace plugin
 {


### PR DESCRIPTION
[Pull request copied from https://bitbucket.org/thoellt/pluginsystem/pull-requests/4]

Fixed the following VS2017 warnings, which identified undefined behavior when `requestData` or `requestSet` would fail:

    warning C4715: 'hdps::Core::requestData': not all control paths return a value
    warning C4715: 'hdps::Core::requestSet': not all control paths return a value

The fix consists of throwing an exception from those member functions, in case of such a failure.