### PR TITLE
Export PointsPlugin class, using __declspec(dllexport) for Windows DLL

### DIFF
--- a/CsvLoader/CMakeLists.txt
+++ b/CsvLoader/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(${PROJECT} SHARED ${SOURCES})
 target_link_libraries(${PROJECT} Qt5::Widgets)
 target_link_libraries(${PROJECT} Qt5::WebEngineWidgets)
 target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/HDPS_Public.lib")
+target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/PointsPlugin.lib")
 
 
 add_custom_command(TARGET ${PROJECT} POST_BUILD

--- a/HDPS/CMakeLists.txt
+++ b/HDPS/CMakeLists.txt
@@ -302,13 +302,28 @@ include_directories("$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 add_library(${PROJECT} SHARED ${POINTS_SOURCES})
 
+# Generate a header file that contains the EXPORT macro for this library.
+include(GenerateExportHeader)
+generate_export_header(${PROJECT})
+
+# Retrieve the file name of the generated export header.
+file(GLOB EXPORT_HEADER_FILE_NAME
+	RELATIVE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/*_export.h)
+
 target_link_libraries(${PROJECT} Qt5::Widgets)
 target_link_libraries(${PROJECT} Qt5::WebEngineWidgets)
 target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/HDPS_Public.lib")
 
-
+# Copy the DLL, the LIB file and the export header of this library to the appropriate subdirectory
+# of the installation directory.
 add_custom_command(TARGET ${PROJECT} POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E copy_if_different
 	"$<TARGET_FILE:${PROJECT}>"
 	"$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/Plugins/$<TARGET_FILE_NAME:${PROJECT}>"
+	COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+	"$<TARGET_LINKER_FILE:${PROJECT}>"
+	"$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/$<TARGET_LINKER_FILE_NAME:${PROJECT}>"
+	COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+	"${CMAKE_CURRENT_BINARY_DIR}/${EXPORT_HEADER_FILE_NAME}"
+	"$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/include/${EXPORT_HEADER_FILE_NAME}"
 )

--- a/HDPS/src/plugins/PointsPlugin.h
+++ b/HDPS/src/plugins/PointsPlugin.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "pointsplugin_export.h"
+
 #include "RawData.h"
 
 #include "Set.h"
@@ -14,7 +16,7 @@ using namespace hdps::plugin;
 // View
 // =============================================================================
 
-class PointsPlugin : public RawData
+class POINTSPLUGIN_EXPORT PointsPlugin : public RawData
 {
 public:
     PointsPlugin() : RawData("Points") { }

--- a/HeatMap/CMakeLists.txt
+++ b/HeatMap/CMakeLists.txt
@@ -45,6 +45,7 @@ qt5_use_modules(${PROJECT} Widgets WebEngineWidgets)
 target_link_libraries(${PROJECT} Qt5::Widgets)
 target_link_libraries(${PROJECT} Qt5::WebEngineWidgets)
 target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/HDPS_Public.lib")
+target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/PointsPlugin.lib")
 
 add_custom_command(TARGET ${PROJECT} POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E copy_if_different

--- a/MeanShift/CMakeLists.txt
+++ b/MeanShift/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(${PROJECT} SHARED ${SOURCES} ${EXTERNAL_SOURCES})
 target_link_libraries(${PROJECT} Qt5::Widgets)
 target_link_libraries(${PROJECT} Qt5::WebEngineWidgets)
 target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/HDPS_Public.lib")
+target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/PointsPlugin.lib")
 
 
 add_custom_command(TARGET ${PROJECT} POST_BUILD

--- a/Scatterplot/CMakeLists.txt
+++ b/Scatterplot/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(${PROJECT} SHARED ${SOURCES})
 target_link_libraries(${PROJECT} Qt5::Widgets)
 target_link_libraries(${PROJECT} Qt5::WebEngineWidgets)
 target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/HDPS_Public.lib")
+target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/PointsPlugin.lib")
 
 
 add_custom_command(TARGET ${PROJECT} POST_BUILD

--- a/SpadeAnalysis/CMakeLists.txt
+++ b/SpadeAnalysis/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(${PROJECT} SHARED ${SOURCES} ${EXTERNAL_SOURCES})
 target_link_libraries(${PROJECT} Qt5::Widgets)
 target_link_libraries(${PROJECT} Qt5::WebEngineWidgets)
 target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/HDPS_Public.lib")
+target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/PointsPlugin.lib")
 
 
 add_custom_command(TARGET ${PROJECT} POST_BUILD

--- a/TsneAnalysis/CMakeLists.txt
+++ b/TsneAnalysis/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(${PROJECT} SHARED ${SOURCES})
 target_link_libraries(${PROJECT} Qt5::Widgets)
 target_link_libraries(${PROJECT} Qt5::WebEngineWidgets)
 target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/HDPS_Public.lib")
+target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/PointsPlugin.lib")
 
 if(MSVC)
     MESSAGE( STATUS "Linking Windows libraries...")


### PR DESCRIPTION
Generated "pointsplugin_export.h" using CMake: https://cmake.org/cmake/help/v3.15/module/GenerateExportHeader.html

Marked PointsPlugin class `POINTSPLUGIN_EXPORT` to ensure that its member functions will be DLL-exported, even when they are implemented in its cpp file.

Linked client projects explicitly to "PointsPlugin.lib".