### PR TITLE
Redirected qDebug messages to console, to text file, and dockable view 

### DIFF
--- a/HDPS/CMakeLists.txt
+++ b/HDPS/CMakeLists.txt
@@ -35,6 +35,9 @@ set( MAIN_SOURCES
 
 set( CORE_HEADERS
     ui/MainWindow.ui
+    src/Logger.h
+    src/LogItemModel.h
+    src/LogDockWidget.h
     src/MainWindow.h
     src/PluginManager.h
     src/Core.h
@@ -43,6 +46,9 @@ set( CORE_HEADERS
 )
 
 set( CORE_SOURCES
+    src/Logger.cpp
+    src/LogItemModel.cpp
+    src/LogDockWidget.cpp
     src/MainWindow.cpp
     src/PluginManager.cpp
     src/Core.cpp

--- a/HDPS/src/LogDockWidget.cpp
+++ b/HDPS/src/LogDockWidget.cpp
@@ -1,0 +1,73 @@
+// Its own header file:
+#include "LogDockWidget.h"
+
+#include "LogItemModel.h"
+
+// Qt header files:
+#include <QAbstractEventDispatcher>
+#include <QMainWindow>
+#include <QTreeView>
+
+
+namespace hdps
+{
+namespace gui
+{
+
+class LogDockWidget::Data
+{
+private:
+    LogItemModel _itemModel;
+    QMetaObject::Connection m_awakeConnection;
+
+public:
+    explicit Data(QDockWidget& dockWidget)
+    {
+        auto* treeView = new QTreeView(&dockWidget);
+        dockWidget.setWidget(treeView);
+
+        treeView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+        treeView->setRootIsDecorated(false);
+        treeView->setItemsExpandable(false);
+        treeView->setSortingEnabled(true);
+        treeView->setExpandsOnDoubleClick(false);
+        treeView->setModel(&_itemModel);
+
+        const auto numberOfColumns = int{ LogItemModel::GetNumberOfColumns() };
+
+        for (int column{}; column < numberOfColumns; ++column)
+        {
+            treeView->resizeColumnToContents(column);
+        }
+
+        // Reset the view "on idle".
+        m_awakeConnection = connect(
+            QAbstractEventDispatcher::instance(),
+            &QAbstractEventDispatcher::awake,
+            [this, treeView]
+        {
+            _itemModel.Reload();
+            treeView->reset();
+        });
+    }
+
+    ~Data()
+    {
+        disconnect(m_awakeConnection);
+    }
+};
+
+
+LogDockWidget::LogDockWidget(QMainWindow& mainWindow)
+    :
+    QDockWidget(&mainWindow),
+    _data(std::make_unique<Data>(*this))
+{
+}
+
+
+LogDockWidget::~LogDockWidget() = default;
+
+} // namespace gui
+
+} // namespace hdps

--- a/HDPS/src/LogDockWidget.h
+++ b/HDPS/src/LogDockWidget.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Qt header file:
+#include <QDockWidget>
+
+// Standard C++ header file:
+#include <memory> // For std::unique_ptr
+
+namespace hdps
+{
+namespace gui
+{
+
+class LogDockWidget final: public QDockWidget
+{
+public:
+    explicit LogDockWidget(QMainWindow&);
+    ~LogDockWidget() override;
+
+private:
+    class Data;
+    const std::unique_ptr<const Data> _data;
+};
+
+} // namespace gui
+} // namespace hdps

--- a/HDPS/src/LogItemModel.cpp
+++ b/HDPS/src/LogItemModel.cpp
@@ -1,0 +1,179 @@
+// Its own header file:
+#include "LogItemModel.h"
+
+#include "Logger.h"
+
+// Qt header files:
+#include <QBrush>
+#include <QDateTime>
+#include <QFileInfo>
+#include <QRegExp>
+#include <QStringList>
+
+// Standard C++ header files:
+#include <algorithm>
+#include <cassert>
+#include <cstdint> // For uintmax_t
+#include <tuple>
+
+
+namespace
+{
+
+enum class ColumnEnum
+{
+    category,
+    type,
+    fileAndLine,
+    function,
+    message,
+    numberOfColumns
+};
+
+constexpr auto numberOfColumns = static_cast<std::uintmax_t>(ColumnEnum::numberOfColumns);
+
+
+QString MsgTypeToString(const QtMsgType& msgType)
+{
+    switch (msgType)
+    {
+    case QtDebugMsg: return "debug";
+    case QtWarningMsg: return "warning";
+    case QtCriticalMsg: return "critical";
+    case QtFatalMsg: return "fatal";
+    case QtInfoMsg: return "info";
+    }
+    return QString{}.setNum(msgType);
+}
+
+}   // namespace
+
+namespace hdps
+{
+namespace gui
+{
+
+LogItemModel::LogItemModel()
+{
+    Logger::GetMessageRecords(m_deque);
+}
+
+
+void LogItemModel::Reload()
+{
+    Logger::GetMessageRecords(m_deque);
+}
+
+
+std::uint16_t LogItemModel::GetNumberOfColumns()
+{
+    return std::uint16_t{ numberOfColumns };
+}
+
+
+LogItemModel::~LogItemModel() = default;
+
+
+int LogItemModel::rowCount(const QModelIndex &) const
+{
+    return static_cast<int>(m_deque.size());
+}
+
+
+int LogItemModel::columnCount(const QModelIndex &) const
+{
+    return int{ numberOfColumns };
+}
+
+
+QModelIndex LogItemModel::index(const int row, const int column, const QModelIndex &) const
+{
+    return createIndex(row, column);
+}
+
+
+QModelIndex LogItemModel::parent(const QModelIndex &) const
+{
+    return{};
+}
+
+
+QVariant LogItemModel::data(const QModelIndex & modelIndex, const int role) const
+{
+    try
+    {
+        if (role == Qt::DisplayRole)
+        {
+            const auto row = modelIndex.row();
+            const auto column = modelIndex.column();
+
+            if ((row >= 0) && (static_cast<std::uintmax_t>(row) < m_deque.size())
+                && (column >= 0) && (static_cast<std::uintmax_t>(column) < numberOfColumns))
+            {
+                const auto* const messageRecord = m_deque[static_cast<unsigned>(row)];
+
+                if (messageRecord != nullptr)
+                {
+                    switch (static_cast<ColumnEnum>(column))
+                    {
+                    case ColumnEnum::category:
+                    {
+                        return messageRecord->category;
+                    }
+                    case ColumnEnum::type:
+                    {
+                        return MsgTypeToString(messageRecord->type);
+                    }
+                    case ColumnEnum::fileAndLine:
+                    {
+                        return QString("%1(%2)")
+                            .arg(messageRecord->file)
+                            .arg(messageRecord->line);
+                    }
+                    case ColumnEnum::function:
+                    {
+                        return messageRecord->function;
+                    }
+                    case ColumnEnum::message:
+                    {
+                        return messageRecord->message;
+                    }
+                    }
+                }
+            }
+        }
+    }
+    catch (const std::exception&)
+    {
+        // Out of luck.
+    }
+    return QVariant{};
+}
+
+
+QVariant LogItemModel::headerData(const int section, const Qt::Orientation orientation, const int role) const
+{
+    try
+    {
+        if (orientation == Qt::Horizontal && role == Qt::DisplayRole)
+        {
+            const char* const headers[] =
+            {
+            "Category",
+            "Type",
+            "Source file (line of code)",
+            "Function",
+            "Message"
+            };
+            return QString::fromLatin1(headers[section]);
+        }
+    }
+    catch (const std::exception&)
+    {
+        assert(!"Exceptions are not allowed here!");
+    }
+    return QAbstractItemModel::headerData(section, orientation, role);
+}
+
+}   // namespace gui
+}   // namespace hdps

--- a/HDPS/src/LogItemModel.h
+++ b/HDPS/src/LogItemModel.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// Qt header file:
+#include <QAbstractItemModel>
+
+// Standard C++ header files:
+#include <deque>
+#include <cstdint> // For uint16_t
+
+namespace hdps
+{
+struct MessageRecord;
+
+namespace gui
+{
+
+class LogItemModel final : public QAbstractItemModel
+{
+private: // Data member:
+    std::deque<const MessageRecord*> m_deque;
+
+public:
+    LogItemModel();
+    ~LogItemModel() override;
+
+    LogItemModel(const LogItemModel&) = delete;
+    LogItemModel& operator=(const LogItemModel&) = delete;
+
+    void Reload();
+    static std::uint16_t GetNumberOfColumns();
+
+private: // Member functions:
+
+    // Implementation of pure virtual functions of QAbstractItemModel
+    int rowCount(const QModelIndex &) const override;
+    int columnCount(const QModelIndex &) const override;
+    QModelIndex index(int, int, const QModelIndex &) const  override;
+    QModelIndex parent(const QModelIndex &) const override;
+    QVariant data(const QModelIndex &, int) const override;
+    QVariant headerData(int, Qt::Orientation, int) const override;
+};
+
+}   //namespace gui
+}   // namespace hdps

--- a/HDPS/src/Logger.cpp
+++ b/HDPS/src/Logger.cpp
@@ -1,0 +1,278 @@
+// Its own header file:
+#include "Logger.h"
+
+// Qt header files:
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QDir>
+#include <QStandardPaths>
+#include <QString>
+#include <QString>
+#include <QtGlobal> // For qInstallMessageHandler
+
+// Standard C++ header files:
+#include <atomic>
+#include <cstdint> // For uint8_t.
+#include <deque>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <typeinfo>
+
+
+namespace
+{
+
+constexpr auto separator = '\t';
+
+auto ConvertToQString(const char* const utf8Chars)
+{
+    return QString::fromUtf8(utf8Chars);
+}
+
+auto ConvertToQString(const wchar_t* const wideChars)
+{
+    return QString::fromWCharArray(wideChars);
+}
+
+
+auto GetLogDirectoryPathName()
+{
+    return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+}
+
+
+auto CreateLogFilePathName()
+{
+    const auto currentDateTime = QDateTime::currentDateTime();
+    const QDir logDir = GetLogDirectoryPathName();
+    const QFileInfo applicationFileInfo = QCoreApplication::applicationFilePath();
+
+    return logDir.filePath(applicationFileInfo.completeBaseName()
+        + QLatin1String("_")
+        + currentDateTime.toString(QLatin1String("yyyyMMdd_hh-mm-ss-zzz"))
+        + QLatin1String(".log"));
+}
+
+
+#ifdef _WIN32
+std::wstring ConvertToStdBasicString(const QString& str)
+{
+    const void* const utf16 = str.utf16();
+    return static_cast<const wchar_t*>(utf16);
+}
+#else
+std::string ConvertToStdBasicString(const QString& str)
+{
+    return str.toUtf8().constData();
+}
+#endif
+
+
+const auto& GetFilePathName()
+{
+    const static auto fileNamePath = ConvertToStdBasicString(CreateLogFilePathName());
+
+    return fileNamePath;
+}
+
+
+const char* MakeNullPrintable(const char* const arg, const char* const nullText)
+{
+    return (arg == nullptr) ? nullText : arg;
+}
+
+
+QtMessageHandler GetPreviousMessageHandler(const QtMessageHandler previousMessageHandler = nullptr)
+{
+    const static auto result = previousMessageHandler;
+
+    return result;
+}
+
+
+void ReplaceUnprintableAsciiCharsBySpaces(QByteArray& byteArray)
+{
+    for (auto& byte : byteArray)
+    {
+        // If the byte is an unprintable ASCII char...
+        if ((static_cast<std::uint8_t>(byte) < std::uint8_t{ ' ' }) || (byte == SCHAR_MAX))
+        {
+            // ...replace its value by a space.
+            byte = ' ';
+        }
+    }
+}
+
+
+auto& GetMessageRecords()
+{
+    static std::deque<hdps::MessageRecord> result;
+    return result;
+}
+
+
+class LogFile
+{
+private:
+    std::ofstream m_outputStream;
+public:
+
+    LogFile()
+        :
+        m_outputStream(GetFilePathName())
+    {
+        // "The Unicode Standard permits the BOM (byte order mark) in UTF-8, but
+        // does not require or recommend its use"
+        // https://en.wikipedia.org/wiki/Byte_order_mark
+        const char bom[] = { '\xEF', '\xBB', '\xBF' };
+        m_outputStream.write(bom, sizeof(bom));
+
+        m_outputStream
+            << "category"
+            << separator << "type"
+#ifdef QT_MESSAGELOGCONTEXT
+            << separator << "version"
+            << separator << "file"
+            << separator << "line"
+            << separator << "function"
+#endif
+            << separator << "message"
+            << std::endl;
+    }
+
+    std::ofstream& GetOutputStream()
+    {
+        return m_outputStream;
+    }
+
+    explicit operator bool() const
+    {
+        return m_outputStream ? true : false;
+    }
+
+    ~LogFile()
+    {
+        // Uninstall custom message handlers to avoid crashed when unloading plugins.
+        // We observed that when environment variable QT_DEBUG_PLUGINS is set,
+        // "QLibraryPrivate::unload succeeded" messages may still be passed to the
+        // message handler when the log file is already destructed.
+        qInstallMessageHandler(nullptr);
+    }
+};
+
+
+static auto& GetMutex()
+{
+    static std::mutex result;
+    return result;
+}
+
+void MessageHandler(
+    const QtMsgType type,
+    const QMessageLogContext &context,
+    const QString &message)
+{
+    // Avoid recursion.
+    static std::atomic_bool isExecutingMessageHandler{ false };
+
+    if (!isExecutingMessageHandler)
+    {
+        isExecutingMessageHandler = true;
+
+        struct ScopeGuard
+        {
+            std::atomic_bool& isExecutingMessageHandler;
+
+            ~ScopeGuard()
+            {
+                isExecutingMessageHandler = false;
+            }
+        };
+
+        const ScopeGuard scopeGuard{ isExecutingMessageHandler };
+
+        static LogFile logFile;
+        const auto previousMessageHandler = GetPreviousMessageHandler();
+
+        auto utf8Message = message.toUtf8();
+        ReplaceUnprintableAsciiCharsBySpaces(utf8Message);
+        const char* const utf8MessageData = utf8Message.constData();
+
+        if (previousMessageHandler != nullptr)
+        {
+            previousMessageHandler(type, context, message);
+        }
+
+        // Lock the mutex from here, to grant exclusive access to 
+        // MessageRecords and log file.
+        const std::lock_guard<std::mutex> guard(GetMutex());
+
+        GetMessageRecords().push_back(
+            {
+                type,
+                context.version,
+                context.line,
+                context.file,
+                context.function,
+                context.category,
+                message
+            });
+
+        if (logFile)
+        {
+            logFile.GetOutputStream()
+                << MakeNullPrintable(context.category, "<category>")
+                << separator << type
+#ifdef QT_MESSAGELOGCONTEXT
+                << separator << context.version
+                << separator << MakeNullPrintable(context.file, "<file>")
+                << separator << context.line
+                << separator << MakeNullPrintable(context.function, "<function>")
+#endif
+                << separator << '"' << utf8MessageData << '"'
+                << std::endl;
+        }
+    }
+}
+
+}   // namespace
+
+
+void hdps::Logger::Initialize()
+{
+    QDir{}.mkpath(GetLogDirectoryPathName());
+    (void)GetPreviousMessageHandler(qInstallMessageHandler(&MessageHandler));
+}
+
+
+QString hdps::Logger::GetFilePathName()
+{
+    return ConvertToQString(::GetFilePathName().c_str());
+}
+
+
+QString hdps::Logger::ExceptionToText(const std::exception& stdException)
+{
+    return QObject::tr("Caught exception: \"%1\". Type: %2")
+        .arg(stdException.what())
+        .arg(typeid(stdException).name());
+}
+
+
+void hdps::Logger::GetMessageRecords(std::deque<const MessageRecord*>& messageRecordPointers)
+{
+    // Lock the mutex from here.
+    const std::lock_guard<std::mutex> guard(GetMutex());
+
+    const auto& messageRecords = ::GetMessageRecords();
+    const auto numberOfMessages = messageRecords.size();
+
+    messageRecordPointers.resize(numberOfMessages);
+
+    for (std::size_t i{}; i < numberOfMessages; ++i)
+    {
+        messageRecordPointers[i] = &(messageRecords[i]);
+    }
+}

--- a/HDPS/src/Logger.h
+++ b/HDPS/src/Logger.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QString>
+#include <deque>
+#include <exception>
+
+namespace hdps
+{
+
+struct MessageRecord
+{
+    QtMsgType type;
+    int version;
+    int line;
+    const char *file;
+    const char *function;
+    const char *category;
+    QString message;
+};
+
+
+class Logger
+{
+public:
+    static void Initialize();
+    static QString GetFilePathName();
+    static QString ExceptionToText(const std::exception& stdException);
+    static void GetMessageRecords(std::deque<const MessageRecord*>&);
+};
+
+}   //namespace hdps
+
+#define HDPS_LOG_EXCEPTION(stdException) qCritical().noquote() << \
+  ::hdps::Logger::ExceptionToText(stdException)
+

--- a/HDPS/src/MainWindow.h
+++ b/HDPS/src/MainWindow.h
@@ -27,6 +27,7 @@ namespace gui
 {
 
 class SettingsWidget;
+class LogDockWidget;
 
 class MainWindow : public QMainWindow, private Ui::MainWindow {
     Q_OBJECT
@@ -79,6 +80,7 @@ private:
 
 private:
     std::unique_ptr<Core> _core;
+    std::unique_ptr<LogDockWidget> _logDockWidget;
 
     QByteArray _windowConfiguration;
 };

--- a/HDPS/ui/MainWindow.ui
+++ b/HDPS/ui/MainWindow.ui
@@ -59,6 +59,8 @@
     <property name="title">
      <string>Help</string>
     </property>
+    <addaction name="findLogFileAction"/>
+    <addaction name="logViewAction"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuAnalysis"/>
@@ -78,6 +80,19 @@
   <action name="exitAction">
    <property name="text">
     <string>Exit</string>
+   </property>
+  </action>
+  <action name="findLogFileAction">
+   <property name="text">
+    <string>Find Log File</string>
+   </property>
+  </action>
+  <action name="logViewAction">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Log View</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Redirected messages from `qCritical()`, `qDebug`, `qFatal()`, and `qInfo()' to the console (stderr), a UTF-8 text file, and a dockable view.

The log file can be found via the Help menu item "Find Log File". The dockable view appears via the Help menu item "Log View".

Also added `HDPS_LOG_EXCEPTION(stdException)` macro, to be used inside `catch` clauses.