### PR TITLE
Fix attempt to delete DataHierarchy twice, in ~MainWindow()

### DIFF
--- a/HDPS/src/MainWindow.cpp
+++ b/HDPS/src/MainWindow.cpp
@@ -129,9 +129,11 @@ MainWindow::MainWindow(QWidget *parent) :
     _settingsWidget = std::make_unique<SettingsWidget>();
     _settingsWidget->setAllowedAreas(Qt::RightDockWidgetArea);
 
-    _dataHierarchy = std::make_unique<DataHierarchy>(_core->getDataManager());
-    connect(&_core->getDataManager(), &DataManager::dataChanged, _dataHierarchy.get(), &DataHierarchy::updateDataModel);
-    _settingsWidget->addWidget(_dataHierarchy.get());
+    auto dataHierarchy = std::make_unique<DataHierarchy>(_core->getDataManager());
+    connect(&_core->getDataManager(), &DataManager::dataChanged, dataHierarchy.get(), &DataHierarchy::updateDataModel);
+    // Note: addWidget takes the ownership of its argument, so it should be released from the unique_ptr.
+    _settingsWidget->addWidget(dataHierarchy.get());
+    _dataHierarchy = dataHierarchy.release();
 
     addDockWidget(Qt::RightDockWidgetArea, _settingsWidget.get());
 }

--- a/HDPS/src/MainWindow.h
+++ b/HDPS/src/MainWindow.h
@@ -90,7 +90,7 @@ private:
     std::unique_ptr<LogDockWidget> _logDockWidget;
 
     CentralWidget* _centralWidget;
-    std::unique_ptr<DataHierarchy> _dataHierarchy;
+    DataHierarchy* _dataHierarchy;
     std::unique_ptr<SettingsWidget> _settingsWidget;
 
     QByteArray _windowConfiguration;


### PR DESCRIPTION
The `DataHierarchy` created in the `MainWindow` constructor was originally deleted both by its parent, `MainWindow::_settingsWidget`, and by `MainWindow::_dataHierarchy`, which was a `unique_ptr` to the object.

This commit solves the issue by removing both `MainWindow` member variables.

Fixes the following crash, encountered with Visual C++ 2017 Debug:

> Exception thrown: read access violation.
> _Ptr->**** was 0xFFFFFFFFFFFFFFE7.

Call Stack:

> default_delete<DataHierarchy>::operator()(DataHierarchy * _Ptr) Line 2084
> unique_ptr<DataHierarchy,default_delete<DataHierarchy>>::~unique_ptr<DataHierarchy,default_delete<DataHierarchy> >() Line 2298
> MainWindow::~MainWindow() Line 141