### PR TITLE
Fix Qt 5.14.1 compile error, std::hash<QString> has already been defined

### DIFF
--- a/HDPS/src/DataManager.h
+++ b/HDPS/src/DataManager.h
@@ -12,6 +12,9 @@
 #include <exception>        // Used for defining custom exceptions
 #include <functional>       // Necessary for hash function
 
+// Qt 5.14.1 has a std::hash<QString> specialization and defines the following macro.
+// Qt 5.12.4 does not! See also https://bugreports.qt.io/browse/QTBUG-33428
+#ifndef QT_SPECIALIZE_STD_HASH_TO_CALL_QHASH
 // Hash specialization for QString so we can use it as a key in the data maps
 namespace std {
     template<> struct hash<QString> {
@@ -20,6 +23,7 @@ namespace std {
         }
     };
 }
+#endif
 
 namespace hdps
 {


### PR DESCRIPTION
Fixes the following compilation error, which I encountered when switching from Qt 5.12.4 to Qt 5.14.1:

>core\HDPS\src\DataManager.h(23,6): error C2766: explicit specialization; 'std::hash<QString>' has already been defined (compiling source file core\HDPS\src\DataHierarchyModel.cpp)
>C:\Qt\Qt5.14.1\5.14.1\msvc2017_64\include\QtCore/qhashfunctions.h(204): message : see previous definition of 'hash<QString>'

See also:

 * "std::hash specializations of all types for which a qHash overload is defined", Heiko Nardmann, 10 Sep 2013, https://bugreports.qt.io/browse/QTBUG-33428
 * "qhashfunctions.h: add specializations of std::hash for some Qt types", Marc Mutz, 2019-05-15, https://code.qt.io/cgit/qt/qtbase.git/commit/src/corelib/tools/qhashfunctions.h?id=4469e36d7203a55a4e158a50f0e9effc3f2fa3c2