### PR TITLE
Fix Error ("Failed to load file") when CsvLoader file dialog is canceled

### DIFF
--- a/CsvLoader/src/CsvLoader.cpp
+++ b/CsvLoader/src/CsvLoader.cpp
@@ -43,6 +43,11 @@ void CsvLoader::loadData()
         return fileName;
     }();
 
+    if (fileName.isEmpty())
+    {
+        return;
+    }
+
     qDebug() << "Loading CSV file: " << fileName;
     QFile file(fileName);
 


### PR DESCRIPTION
The previous commit, SHA-1 7dd610efeb04d1a7e85226ef34cef4f4e55d7342 introduced an Error message box, "Failed to load file at: Reason: File was not found at location", whenever the file dialog would be canceled.

Hereby fixed.