### PR TITLE
Add LoaderPlugin::AskForFileName, called by the three core loaders

### DIFF
--- a/BinLoader/src/BinLoader.cpp
+++ b/BinLoader/src/BinLoader.cpp
@@ -6,7 +6,6 @@
 #include <QtCore>
 #include <QtDebug>
 
-#include <QFileDialog>
 #include <vector>
 #include <QInputDialog>
 
@@ -32,7 +31,7 @@ void BinLoader::init()
 
 void BinLoader::loadData()
 {
-    QString fileName = QFileDialog::getOpenFileName(Q_NULLPTR, "Load File", "", "BIN Files (*.bin *)");
+    const QString fileName = AskForFileName(tr("BIN Files (*.bin)"));
     
     // Don't try to load a file if the dialog was cancelled or the file name is empty
     if (fileName.isNull() || fileName.isEmpty())

--- a/CsvLoader/src/CsvLoader.cpp
+++ b/CsvLoader/src/CsvLoader.cpp
@@ -6,7 +6,6 @@
 #include <QtCore>
 #include <QtDebug>
 
-#include <QFileDialog>
 #include <QFileInfo>
 #include <QInputDialog>
 
@@ -28,20 +27,7 @@ void CsvLoader::init()
 
 void CsvLoader::loadData()
 {
-    const auto fileName = []
-    {
-        QSettings settings(QString::fromLatin1("HDPS"), QString::fromLatin1("Plugins/CsvLoader"));
-        const QLatin1String directoryPathKey("directoryPath");
-        const QString directoryPath = settings.value(directoryPathKey).toString();
-        QString fileName = QFileDialog::getOpenFileName(Q_NULLPTR, "Load File", directoryPath, "CSV Files (*.csv);;All Files (*)");
-
-        // Don't try to load a file if the dialog was cancelled or the file name is empty
-        if (fileName.isNull() || fileName.isEmpty())
-            return fileName;
-
-        settings.setValue(directoryPathKey, QFileInfo(fileName).absolutePath());
-        return fileName;
-    }();
+    const auto fileName = AskForFileName(QObject::tr("CSV Files (*.csv)"));
 
     if (fileName.isEmpty())
     {

--- a/FcsLoader/src/FcsLoader.cpp
+++ b/FcsLoader/src/FcsLoader.cpp
@@ -8,7 +8,6 @@
 #include <QtDebug>
 #include <QString>
 
-#include <QFileDialog>
 #include <QInputDialog>
 
 #include <vector>
@@ -45,7 +44,7 @@ void FcsLoader::init()
 
 void FcsLoader::loadData()
 {
-    QString fileName = QFileDialog::getOpenFileName(Q_NULLPTR, "Load File", "", "FCS Files (*.fcs *)");
+    const QString fileName = AskForFileName(QObject::tr("FCS Files (*.fcs)"));
 
     // Don't try to load a file if the dialog was cancelled or the file name is empty
     if (fileName.isNull() || fileName.isEmpty())

--- a/HDPS/CMakeLists.txt
+++ b/HDPS/CMakeLists.txt
@@ -160,6 +160,7 @@ set( PLUGIN_HEADERS
 
 set( PLUGIN_SOURCES
     src/IndexSet.cpp
+    src/LoaderPlugin.cpp
 )
 
 list(APPEND PRIVATE_HEADERS

--- a/HDPS/src/LoaderPlugin.cpp
+++ b/HDPS/src/LoaderPlugin.cpp
@@ -1,0 +1,28 @@
+#include "LoaderPlugin.h"
+
+#include <QFileDialog>
+#include <QSettings>
+#include <QString>
+
+namespace hdps {
+
+namespace plugin {
+
+QString LoaderPlugin::AskForFileName(const QString& fileNameFilter)
+{
+    QSettings settings(QLatin1String{"HDPS"}, QLatin1String{"Plugins/"} + getKind());
+    const QLatin1String directoryPathKey("directoryPath");
+    const auto directoryPath = settings.value(directoryPathKey).toString();
+    const auto fileName = QFileDialog::getOpenFileName(
+        nullptr, QObject::tr("Load File"), directoryPath, fileNameFilter + QObject::tr(";;All Files (*)"));
+
+    // Only store the directory name when the dialog has not been not canceled and the file name is non-empty.
+    if (!fileName.isEmpty())
+    {
+        settings.setValue(directoryPathKey, QFileInfo(fileName).absolutePath());
+    }
+    return fileName;
+}
+
+}
+}

--- a/HDPS/src/LoaderPlugin.h
+++ b/HDPS/src/LoaderPlugin.h
@@ -43,6 +43,15 @@ public:
     virtual void loadData() = 0;
 
     ~LoaderPlugin() override {};
+
+protected:
+    /**
+     * Asks the user for the name of a file to load data from. Opens a file dialog at the
+     * directory of the last loaded file. The path of this directory is stored with the
+     * application settings (in the registry, on Windows).
+     * `fileNameFilter` could be something like "Text Files (*.txt)".
+     */
+    QString AskForFileName(const QString& fileNameFilter);
 };
 
 


### PR DESCRIPTION
Added protected `AskForFileName(fileNameFilter)` helper function to `LoaderPlugin`, called by its derived classes, `BinLoader`, `CsvLoader`, and `FcsLoader`.

Ensures that each of these loaders stores and restores the most recently used directory, and that each of them has a separate entry for "All Files", in its file filter combo box.