### PR TITLE
~ScatterplotWidget() disconnect QOpenGLContext::aboutToBeDestroyed

### DIFF
--- a/Scatterplot/src/ScatterplotWidget.cpp
+++ b/Scatterplot/src/ScatterplotWidget.cpp
@@ -332,3 +332,9 @@ void ScatterplotWidget::cleanup()
     _densityRenderer.destroy();
     _selectionRenderer.destroy();
 }
+
+ScatterplotWidget::~ScatterplotWidget()
+{
+    disconnect(QOpenGLWidget::context(), &QOpenGLContext::aboutToBeDestroyed, this, &ScatterplotWidget::cleanup);
+    cleanup();
+}

--- a/Scatterplot/src/ScatterplotWidget.h
+++ b/Scatterplot/src/ScatterplotWidget.h
@@ -32,6 +32,8 @@ public:
 
     ScatterplotWidget();
 
+    ~ScatterplotWidget();
+
     /** Returns true when the widget was initialized and is ready to be used. */
     bool isInitialized();
 


### PR DESCRIPTION
It happened that the OpenGL context was destroyed _after_ the destruction of ScatterplotWidget, which caused a crash from calling `ScatterplotWidget::cleanup`.

Fixed by disconnecting the QOpenGLContext::aboutToBeDestroyed signal from the widget, in its destructor.