### PR TITLE
Fix issue #45 Crash when closing after having opened scatterplot plugin

### DIFF
--- a/Scatterplot/src/ScatterplotSettings.cpp
+++ b/Scatterplot/src/ScatterplotSettings.cpp
@@ -37,10 +37,10 @@ namespace
 }
 
 PointSettingsWidget::PointSettingsWidget(const ScatterplotPlugin& plugin) :
-    _pointSizeLabel("Point Size:"),
-    _pointOpacityLabel("Point Opacity:"),
-    _pointSizeSlider(Qt::Horizontal),
-    _pointOpacitySlider(Qt::Horizontal)
+    _pointSizeLabel(*new QLabel("Point Size:")),
+    _pointOpacityLabel(*new QLabel("Point Opacity:")),
+    _pointSizeSlider(*new QSlider(Qt::Horizontal)),
+    _pointOpacitySlider(*new QSlider(Qt::Horizontal))
 {
     connect(&_pointSizeSlider, &QSlider::valueChanged, plugin._scatterPlotWidget, &ScatterplotWidget::pointSizeChanged);
     connect(&_pointOpacitySlider, &QSlider::valueChanged, plugin._scatterPlotWidget, &ScatterplotWidget::pointOpacityChanged);
@@ -69,8 +69,8 @@ PointSettingsWidget::PointSettingsWidget(const ScatterplotPlugin& plugin) :
 }
 
 DensitySettingsWidget::DensitySettingsWidget(const ScatterplotPlugin& plugin) :
-    _sigmaLabel("Sigma:"),
-    _sigmaSlider(Qt::Horizontal)
+    _sigmaLabel(*new QLabel("Sigma:")),
+    _sigmaSlider(*new QSlider(Qt::Horizontal))
 {
     connect(&_sigmaSlider, &QSlider::valueChanged, plugin._scatterPlotWidget, &ScatterplotWidget::sigmaChanged);
 
@@ -84,8 +84,8 @@ DensitySettingsWidget::DensitySettingsWidget(const ScatterplotPlugin& plugin) :
 }
 
 PlotSettingsStack::PlotSettingsStack(const ScatterplotPlugin& plugin) :
-    _pointSettingsWidget(plugin),
-    _densitySettingsWidget(plugin)
+    _pointSettingsWidget(*new PointSettingsWidget(plugin)),
+    _densitySettingsWidget(*new DensitySettingsWidget(plugin))
 {
     addWidget(&_pointSettingsWidget);
     addWidget(&_densitySettingsWidget);
@@ -112,7 +112,7 @@ void ColorDimensionPicker::setScalarDimensions(unsigned int numDimensions, const
 }
 
 ColorDropSlot::ColorDropSlot(const ScatterplotPlugin& plugin) :
-    _loadColorData(plugin.supportedColorTypes)
+    _loadColorData(*new hdps::gui::DataSlot(plugin.supportedColorTypes))
 {
     QLabel* dropLabel = new QLabel();
     dropLabel->setFixedSize(20, 20);
@@ -132,9 +132,9 @@ ColorDropSlot::ColorDropSlot(const ScatterplotPlugin& plugin) :
 }
 
 DimensionPicker::DimensionPicker(const ScatterplotPlugin* plugin) :
-    _xDimLabel("X:"),
-    _yDimLabel("Y:"),
-    _cDimLabel("Color:")
+    _xDimLabel(*new QLabel( "X:")),
+    _yDimLabel(*new QLabel("Y:")),
+    _cDimLabel(*new QLabel("Color:"))
 {
     _layout.addWidget(&_xDimLabel, 0, 0);
     _layout.addWidget(&_yDimLabel, 1, 0);

--- a/Scatterplot/src/ScatterplotSettings.h
+++ b/Scatterplot/src/ScatterplotSettings.h
@@ -26,10 +26,10 @@ struct PointSettingsWidget : public QWidget
     const int MIN_POINT_OPACITY = 0;
     const int MAX_POINT_OPACITY = 100;
 
-    QLabel _pointSizeLabel;
-    QSlider _pointSizeSlider;
-    QLabel _pointOpacityLabel;
-    QSlider _pointOpacitySlider;
+    QLabel& _pointSizeLabel;
+    QSlider& _pointSizeSlider;
+    QLabel& _pointOpacityLabel;
+    QSlider& _pointOpacitySlider;
 };
 
 struct DensitySettingsWidget : public QWidget
@@ -39,8 +39,8 @@ struct DensitySettingsWidget : public QWidget
     const int MIN_SIGMA = 1;
     const int MAX_SIGMA = 50;
 
-    QLabel _sigmaLabel;
-    QSlider _sigmaSlider;
+    QLabel& _sigmaLabel;
+    QSlider& _sigmaSlider;
 };
 
 struct PlotSettingsStack : public QStackedWidget
@@ -48,8 +48,8 @@ struct PlotSettingsStack : public QStackedWidget
     PlotSettingsStack(const ScatterplotPlugin& plugin);
 
 private:
-    PointSettingsWidget _pointSettingsWidget;
-    DensitySettingsWidget _densitySettingsWidget;
+    PointSettingsWidget& _pointSettingsWidget;
+    DensitySettingsWidget& _densitySettingsWidget;
 };
 
 struct ColorDimensionPicker : public QWidget
@@ -73,7 +73,7 @@ public:
 private:
     QHBoxLayout* _layout;
 
-    hdps::gui::DataSlot _loadColorData;
+    hdps::gui::DataSlot& _loadColorData;
 };
 
 struct ColorSettingsStack : public QStackedWidget
@@ -112,16 +112,16 @@ protected slots:
     void colorOptionsPicked(const int index);
 
 private:
-    QLabel _xDimLabel;
-    QLabel _yDimLabel;
-    QLabel _cDimLabel;
+    QLabel& _xDimLabel;
+    QLabel& _yDimLabel;
+    QLabel& _cDimLabel;
 
-    hdps::gui::ComboBox _xDimOptions;
-    hdps::gui::ComboBox _yDimOptions;
+    hdps::gui::ComboBox& _xDimOptions = *new hdps::gui::ComboBox;
+    hdps::gui::ComboBox& _yDimOptions = *new hdps::gui::ComboBox;
     hdps::gui::ComboBox* _colorOptions;
     ColorSettingsStack* _colorSettingsStack;
 
-    QGridLayout _layout;
+    QGridLayout& _layout = *new QGridLayout;
 };
 
 class ScatterplotSettings : public QWidget
@@ -153,8 +153,8 @@ private:
     const hdps::Vector3f DEFAULT_BASE_COLOR = hdps::Vector3f(255.f / 255, 99.f / 255, 71.f / 255);
     const hdps::Vector3f DEFAULT_SELECTION_COLOR = hdps::Vector3f(72.f / 255, 61.f / 255, 139.f / 255);
 
-    hdps::gui::PushButton _subsetButton;
-    hdps::gui::ComboBox _renderMode;
+    hdps::gui::PushButton& _subsetButton = *new hdps::gui::PushButton;
+    hdps::gui::ComboBox& _renderMode = *new hdps::gui::ComboBox;
 
     QVBoxLayout* _settingsLayout;
     PlotSettingsStack* _settingsStack;


### PR DESCRIPTION
The crash was caused by having multiple destructor calls on one an the same instance of various QWidget derived class types.

The destructor of these objects was called _both_ via Qt's ownership logic (typically because they were passed as argument to `QLayout::addWidget`), _and_ by the destructor of the objects that "had" them stored as data member.

The latter is avoided by this commit, by creating those objects by `new`, and storing references (`&`) to the objects as data members, instead of storing the objects themselves as data members.