### PR TITLE
Imaging/0.2.0

### DIFF
--- a/HDPS/src/plugins/ImageData/src/Common.h
+++ b/HDPS/src/plugins/ImageData/src/Common.h
@@ -4,34 +4,6 @@
 
 #include "imagedata_export.h"
 
-enum class ImageCollectionType
-{
-    Undefined,
-    Sequence,
-    Stack,
-    MultiPartSequence
-};
-
-inline QString imageCollectionTypeName(const ImageCollectionType& type)
-{
-    switch (type)
-    {
-        case ImageCollectionType::Sequence:
-            return "Sequence";
-
-        case ImageCollectionType::Stack:
-            return "Stack";
-
-        case ImageCollectionType::MultiPartSequence:
-            return "MultiPartSequence";
-
-        default:
-            break;
-    }
-
-    return "";
-}
-
 enum class SelectionModifier
 {
     Replace,

--- a/HDPS/src/plugins/ImageData/src/ImageData.cpp
+++ b/HDPS/src/plugins/ImageData/src/ImageData.cpp
@@ -13,7 +13,7 @@ Q_PLUGIN_METADATA(IID "nl.tudelft.ImageData")
 
 ImageData::ImageData() :
     hdps::RawData("Image Data", ImageType),
-    _imageCollectionType(ImageCollectionType::Undefined),
+    _type(Type::Undefined),
     _noImages(0),
     _imageSize(),
     _noComponents(0),
@@ -31,14 +31,14 @@ void ImageData::init()
     _core->notifyDataAdded(_pointsName);
 }
 
-ImageCollectionType ImageData::imageCollectionType() const
+ImageData::Type ImageData::type() const
 {
-    return _imageCollectionType;
+    return _type;
 }
 
-void ImageData::setImageCollectionType(const ImageCollectionType& imageCollectionType)
+void ImageData::setType(const ImageData::Type& type)
 {
-    _imageCollectionType = imageCollectionType;
+    _type = type;
 }
 
 QSize ImageData::imageSize() const

--- a/HDPS/src/plugins/ImageData/src/ImageData.h
+++ b/HDPS/src/plugins/ImageData/src/ImageData.h
@@ -19,13 +19,42 @@ const hdps::DataType ImageType = hdps::DataType(QString("Images"));
 class IMAGEDATA_EXPORT ImageData : public hdps::RawData
 {
 public:
+    enum Type
+    {
+        Undefined,
+        Sequence,
+        Stack,
+        MultiPartSequence
+    };
+
+    static QString typeName(const Type& type)
+    {
+        switch (type)
+        {
+            case Type::Sequence:
+                return "Sequence";
+
+            case Type::Stack:
+                return "Stack";
+
+            case Type::MultiPartSequence:
+                return "MultiPartSequence";
+
+            default:
+                break;
+        }
+
+        return "";
+    }
+
+public:
     ImageData();
 
     void init() override;
 
 public:
-    ImageCollectionType imageCollectionType() const;
-    void setImageCollectionType(const ImageCollectionType& imageCollectionType);
+    Type type() const;
+    void setType(const Type& type);
     std::uint32_t noImages() const;
     void setNoImages(const std::uint32_t& noImages);
     QSize imageSize() const;
@@ -50,7 +79,7 @@ public:
     hdps::DataSet* createDataSet() const override;
 
 private:
-    ImageCollectionType     _imageCollectionType;
+    Type                    _type;
     std::uint32_t           _noImages;
     QSize                   _imageSize;
     std::uint32_t           _noComponents;

--- a/HDPS/src/plugins/ImageData/src/Images.cpp
+++ b/HDPS/src/plugins/ImageData/src/Images.cpp
@@ -13,7 +13,6 @@
 #include "PointData.h"
 
 #define PROFILE
-//#define PARALLEL_FOR_EACH
 
 Images::Images(hdps::CoreInterface* core, QString dataName) :
     DataSet(core, dataName),
@@ -62,7 +61,7 @@ void Images::createSubset() const
 
 void Images::setSequence(const std::vector<Image>& images, const QSize& size)
 {
-    _imageData->setImageCollectionType(ImageCollectionType::Sequence);
+    _imageData->setType(ImageData::Type::Sequence);
     _imageData->setNoImages(static_cast<std::uint32_t>(images.size()));
     _imageData->setImageSize(size);
     _imageData->setNoComponents(images.front().noComponents());
@@ -99,7 +98,7 @@ void Images::setSequence(const std::vector<Image>& images, const QSize& size)
 
 void Images::setStack(const std::vector<Image>& images, const QSize& size)
 {
-    _imageData->setImageCollectionType(ImageCollectionType::Stack);
+    _imageData->setType(ImageData::Type::Stack);
     _imageData->setNoImages(static_cast<std::uint32_t>(images.size()));
     _imageData->setImageSize(size);
     _imageData->setNoComponents(images.front().noComponents());
@@ -509,9 +508,9 @@ hdps::DataSet* Images::copy() const
     return images;
 }
 
-ImageCollectionType Images::imageCollectionType() const
+ImageData::Type Images::type() const
 {
-    return _imageData->imageCollectionType();
+    return _imageData->type();
 }
 
 std::uint32_t Images::noImages() const

--- a/HDPS/src/plugins/ImageData/src/Images.h
+++ b/HDPS/src/plugins/ImageData/src/Images.h
@@ -2,6 +2,7 @@
 
 #include "Common.h"
 #include "Image.h"
+#include "ImageData.h"
 
 #include <Set.h>
 
@@ -16,7 +17,6 @@
 using namespace hdps::plugin;
 
 class Points;
-class ImageData;
 
 class IMAGEDATA_EXPORT Images : public hdps::DataSet
 {
@@ -37,7 +37,7 @@ public:
 
     hdps::DataSet* copy() const override;
 
-    ImageCollectionType imageCollectionType() const;
+    ImageData::Type type() const;
     std::uint32_t noImages() const;
     QSize imageSize() const;
     std::uint32_t noComponents() const;


### PR DESCRIPTION
Main improvements to the ImageData plugin:
- Enum classes prevent polluting the global namespace
- Conversion function for image data type to string
- No need for std::shared_ptr<QImage>, as QImage manages memory for us