### PR TITLE
Fix issue #49 Scatterplot crashes at HDPS exit when some data was shown

### DIFF
--- a/HDPS/src/util/DensityComputation.cpp
+++ b/HDPS/src/util/DensityComputation.cpp
@@ -75,7 +75,6 @@ DensityComputation::DensityComputation()
 
 DensityComputation::~DensityComputation()
 {
-    delete _points;
 }
 
 void DensityComputation::init(QOpenGLContext* ctx)

--- a/HDPS/src/util/DensityComputation.h
+++ b/HDPS/src/util/DensityComputation.h
@@ -26,6 +26,7 @@ public:
     void init(QOpenGLContext* ctx);
     void cleanup();
 
+    // Note: setData does not take the ownership of the vector specified by the argument.
     void setData(const std::vector<Vector2f>* data);
     void setBounds(float left, float right, float bottom, float top);
     void setSigma(float sigma);


### PR DESCRIPTION
The destructor of `DensityComputation` would do a `delete` on a pointer to `ScatterplotPlugin::_points`, when HDPS would be closed after having displayed some data on the scatterplot. Obviously, these points were owned already by `ScatterplotPlugin`. It caused the crash that I reported at issue #49 (Scatterplot crashes at HDPS exit when some data was shown).

This commit fixes this crash by removing the `delete`.