### PR TITLE
Move small member functions of Vector2f and Selection to header file

### DIFF
--- a/HDPS/src/graphics/Selection.cpp
+++ b/HDPS/src/graphics/Selection.cpp
@@ -4,17 +4,10 @@
 
 namespace hdps
 {
-    Selection::Selection()
-    {
-        set(Vector2f(0, 0), Vector2f(0, 0));
-    }
-
     Selection::Selection(Vector2f start, Vector2f end)
     {
         set(start, end);
     }
-
-    Selection::~Selection() { }
 
     void Selection::set(Vector2f start, Vector2f end)
     {
@@ -34,65 +27,6 @@ namespace hdps
         set(_start, end);
     }
 
-    Vector2f Selection::getStart() const
-    {
-        return _start;
-    }
-
-    Vector2f Selection::getEnd() const
-    {
-        return _end;
-    }
-
-    Vector2f Selection::getCenter() const
-    {
-        return Vector2f((_left + _right) / 2, (_bottom + _top) / 2);
-    }
-
-    float Selection::getLeft() const
-    {
-        return _left;
-    }
-    float Selection::getRight() const
-    {
-        return _right;
-    }
-
-    float Selection::getBottom() const
-    {
-        return _bottom;
-    }
-
-    float Selection::getTop() const
-    {
-        return _top;
-    }
-
-    Vector2f Selection::topLeft() const
-    {
-        return Vector2f(_left, _top);
-    }
-
-    Vector2f Selection::bottomLeft() const
-    {
-        return Vector2f(_left, _bottom);
-    }
-
-    Vector2f Selection::bottomRight() const
-    {
-        return Vector2f(_right, _bottom);
-    }
-
-    Vector2f Selection::topRight() const
-    {
-        return Vector2f(_right, _top);
-    }
-
-    bool Selection::contains(Vector2f point) const
-    {
-        return point.x >= _left && point.x <= _right && point.y >= _bottom && point.y <= _top;
-    }
-
     void Selection::updateProperties()
     {
         _left = std::min(_start.x, _end.x);
@@ -100,5 +34,19 @@ namespace hdps
         _bottom = std::min(_start.y, _end.y);
         _top = std::max(_start.y, _end.y);
     }
+
+
+    static_assert(Selection{}.getStart() == Vector2f{}, "Compile-time unit test");
+    static_assert(Selection{}.getEnd() == Vector2f{}, "Compile-time unit test");
+    static_assert(Selection{}.getCenter() == Vector2f{}, "Compile-time unit test");
+    static_assert(Selection{}.getLeft() == 0.0f, "Compile-time unit test");
+    static_assert(Selection{}.getRight() == 0.0f, "Compile-time unit test");
+    static_assert(Selection{}.getBottom() == 0.0f, "Compile-time unit test");
+    static_assert(Selection{}.getTop() == 0.0f, "Compile-time unit test");
+    static_assert(Selection{}.topLeft() == Vector2f{}, "Compile-time unit test");
+    static_assert(Selection{}.bottomLeft() == Vector2f{}, "Compile-time unit test");
+    static_assert(Selection{}.bottomRight() == Vector2f{}, "Compile-time unit test");
+    static_assert(Selection{}.topRight() == Vector2f{}, "Compile-time unit test");
+    static_assert(Selection{}.contains(Vector2f{}), "Compile-time unit test");
 
 } // namespace hdps

--- a/HDPS/src/graphics/Selection.h
+++ b/HDPS/src/graphics/Selection.h
@@ -7,36 +7,83 @@ namespace hdps
     class Selection
     {
     public:
-        Selection();
+        // C++ Rule of Zero: Implicitly defined destructor and copy member functions are fine for this class.
+
+        Selection() = default;
+
         Selection(Vector2f start, Vector2f end);
-        ~Selection();
 
         void set(Vector2f start, Vector2f end);
 
         void setStart(Vector2f start);
         void setEnd(Vector2f end);
 
-        Vector2f getStart() const;
-        Vector2f getEnd() const;
-        Vector2f getCenter() const;
+        constexpr Vector2f getStart() const
+        {
+            return _start;
+        }
 
-        float getLeft() const;
-        float getRight() const;
-        float getBottom() const;
-        float getTop() const;
-        Vector2f topLeft() const;
-        Vector2f bottomLeft() const;
-        Vector2f bottomRight() const;
-        Vector2f topRight() const;
+        constexpr Vector2f getEnd() const
+        {
+            return _end;
+        }
 
-        bool contains(Vector2f point) const;
+        constexpr Vector2f getCenter() const
+        {
+            return Vector2f((_left + _right) / 2, (_bottom + _top) / 2);
+        }
+
+        constexpr float getLeft() const
+        {
+            return _left;
+        }
+
+        constexpr float getRight() const
+        {
+            return _right;
+        }
+
+        constexpr float getBottom() const
+        {
+            return _bottom;
+        }
+
+        constexpr float getTop() const
+        {
+            return _top;
+        }
+
+        constexpr Vector2f topLeft() const
+        {
+            return Vector2f(_left, _top);
+        }
+
+        constexpr Vector2f bottomLeft() const
+        {
+            return Vector2f(_left, _bottom);
+        }
+
+        constexpr Vector2f bottomRight() const
+        {
+            return Vector2f(_right, _bottom);
+        }
+
+        constexpr Vector2f topRight() const
+        {
+            return Vector2f(_right, _top);
+        }
+
+        constexpr bool contains(Vector2f point) const
+        {
+            return point.x >= _left && point.x <= _right && point.y >= _bottom && point.y <= _top;
+        }
 
     private:
         void updateProperties();
 
         Vector2f _start, _end;
 
-        float _left, _right, _bottom, _top;
+        float _left{}, _right{}, _bottom{}, _top{};
     };
 
 } // namespace hdps

--- a/HDPS/src/graphics/Vector2f.cpp
+++ b/HDPS/src/graphics/Vector2f.cpp
@@ -4,23 +4,6 @@
 
 namespace hdps
 {
-    Vector2f::Vector2f()
-        : x(0), y(0)
-    {
-
-    }
-
-    Vector2f::Vector2f(float x, float y)
-        : x(x), y(y)
-    {
-
-    }
-
-    Vector2f::~Vector2f()
-    {
-
-    }
-
     void Vector2f::set(float x, float y)
     {
         this->x = x;
@@ -39,11 +22,6 @@ namespace hdps
         y -= v.y;
     }
 
-    float Vector2f::sqrMagnitude() const
-    {
-        return x * x + y * y;
-    }
-
     float Vector2f::length() const
     {
         return sqrt(sqrMagnitude());
@@ -55,16 +33,6 @@ namespace hdps
     }
 
     /* Operator overloads */
-    bool Vector2f::operator==(const Vector2f& v) const
-    {
-        return x == v.x && y == v.y;
-    }
-
-    bool Vector2f::operator!=(const Vector2f& v) const
-    {
-        return x != v.x || y != v.y;
-    }
-
     Vector2f& Vector2f::operator+=(const Vector2f& v)
     {
         x += v.x;
@@ -100,43 +68,24 @@ namespace hdps
         return *this;
     }
 
-    Vector2f Vector2f::operator+(const Vector2f& v) const
-    {
-        return Vector2f(x + v.x, y + v.y);
-    }
 
-    Vector2f Vector2f::operator+(float value) const
-    {
-        return Vector2f(x + value, y + value);
-    }
+    static_assert(Vector2f{}.x == 0.0f, "Compile-time unit test");
+    static_assert(Vector2f{}.y == 0.0f, "Compile-time unit test");
+    static_assert(Vector2f{} == Vector2f{}, "Compile-time unit test");
+    static_assert(! (Vector2f{} != Vector2f{}), "Compile-time unit test");
+    static_assert(Vector2f(0.0f, 0.0f) == Vector2f{}, "Compile-time unit test");
+    static_assert(Vector2f(0.5f, 0.5f) != Vector2f{}, "Compile-time unit test");
+    static_assert(! (Vector2f(0.5f, 0.5f) == Vector2f{}), "Compile-time unit test");
+    static_assert(Vector2f(0.5f, 0.0f).x == 0.5f, "Compile-time unit test");
+    static_assert(Vector2f(0.0f, 0.5f).y == 0.5f, "Compile-time unit test");
+    static_assert(Vector2f(0.5f, 1.0f).sqrMagnitude() == 1.25f, "Compile-time unit test");
+    static_assert(Vector2f(0.5f, 1.5f) + Vector2f(1.0f, 2.0f) == Vector2f(1.5f, 3.5f), "Compile-time unit test");
+    static_assert(Vector2f(1.0f, 2.0f) + 0.5f == Vector2f(1.5f, 2.5f), "Compile-time unit test");
+    static_assert(Vector2f(3.0f, 4.0f) - Vector2f(1.5f, 0.5f) == Vector2f(1.5f, 3.5f), "Compile-time unit test");
+    static_assert(Vector2f(2.0f, 3.0f) - 0.5f == Vector2f(1.5f, 2.5f), "Compile-time unit test");
+    static_assert(-Vector2f(0.5f, -1.5f) == Vector2f(-0.5f, 1.5f), "Compile-time unit test");
+    static_assert(Vector2f(2.0f, 3.0f) * Vector2f(1.5f, 0.5f) == Vector2f(3.0f, 1.5f), "Compile-time unit test");
+    static_assert(Vector2f(2.0f, 3.0f) * 1.5f == Vector2f(3.0f, 4.5f), "Compile-time unit test");
+    static_assert(Vector2f(1.0f, 2.0f) / 2.0f == Vector2f(0.5f, 1.0f), "Compile-time unit test");
 
-    Vector2f Vector2f::operator-(const Vector2f& v) const
-    {
-        return Vector2f(x - v.x, y - v.y);
-    }
-
-    Vector2f Vector2f::operator-(float value) const
-    {
-        return Vector2f(x - value, y - value);
-    }
-
-    Vector2f Vector2f::operator-() const
-    {
-        return Vector2f(-x, -y);
-    }
-
-    Vector2f Vector2f::operator*(const Vector2f& v) const
-    {
-        return Vector2f(x * v.x, y * v.y);
-    }
-
-    Vector2f Vector2f::operator*(float scale) const
-    {
-        return Vector2f(x * scale, y * scale);
-    }
-
-    Vector2f Vector2f::operator/(float divisor) const
-    {
-        return Vector2f(x / divisor, y / divisor);
-    }
 }

--- a/HDPS/src/graphics/Vector2f.h
+++ b/HDPS/src/graphics/Vector2f.h
@@ -7,9 +7,14 @@ namespace hdps
     class Vector2f
     {
     public:
-        Vector2f();
-        Vector2f(float x, float y);
-        ~Vector2f();
+        // C++ Rule of Zero: Implicitly defined destructor and copy member functions are fine for this class.
+
+        Vector2f() = default;
+
+        constexpr Vector2f(float x, float y)
+            : x(x), y(y)
+        {
+        }
 
         /**
         * Sets the x and y components of this vector to the given parameters.
@@ -34,7 +39,11 @@ namespace hdps
         * Returns the squared magnitude of this vector.
         * @return the squared magnitude of this vector
         */
-        float sqrMagnitude() const;
+        constexpr float sqrMagnitude() const
+        {
+            return x * x + y * y;
+        }
+
 
         /**
         * Returns the magnitude of this vector.
@@ -49,23 +58,63 @@ namespace hdps
         std::string str() const;
 
         /* Operator overloads */
-        bool operator==(const Vector2f& v) const;
-        bool operator!=(const Vector2f& v) const;
+        constexpr bool operator==(const Vector2f& v) const
+        {
+            return x == v.x && y == v.y;
+        }
+
+        constexpr bool operator!=(const Vector2f& v) const
+        {
+            return x != v.x || y != v.y;
+        }
+
         Vector2f& operator+=(const Vector2f& v);
         Vector2f& operator-=(const Vector2f& v);
         Vector2f& operator*=(const Vector2f& v);
         Vector2f& operator*=(float scale);
         Vector2f& operator/=(const Vector2f& v);
-        Vector2f operator+(const Vector2f& v) const;
-        Vector2f operator+(float value) const;
-        Vector2f operator-(const Vector2f& v) const;
-        Vector2f operator-(float value) const;
-        Vector2f operator-() const;
-        Vector2f operator*(const Vector2f& v) const;
-        Vector2f operator*(float scale) const;
-        Vector2f operator/(float divisor) const;
 
-        float x, y;
+        constexpr Vector2f operator+(const Vector2f& v) const
+        {
+            return Vector2f(x + v.x, y + v.y);
+        }
+
+        constexpr Vector2f operator+(float value) const
+        {
+            return Vector2f(x + value, y + value);
+        }
+
+        constexpr Vector2f operator-(const Vector2f& v) const
+        {
+            return Vector2f(x - v.x, y - v.y);
+        }
+
+        constexpr Vector2f operator-(float value) const
+        {
+            return Vector2f(x - value, y - value);
+        }
+
+        constexpr Vector2f operator-() const
+        {
+            return Vector2f(-x, -y);
+        }
+
+        constexpr Vector2f operator*(const Vector2f& v) const
+        {
+            return Vector2f(x * v.x, y * v.y);
+        }
+
+        constexpr Vector2f operator*(float scale) const
+        {
+            return Vector2f(x * scale, y * scale);
+        }
+
+        constexpr Vector2f operator/(float divisor) const
+        {
+            return Vector2f(x / divisor, y / divisor);
+        }
+
+        float x{}, y{};
     };
 
 } // namespace hdps


### PR DESCRIPTION
Moved the implementation of small member functions of Vector2f and Selection from their .cpp file to their .h file.

Defaulted their default-constructors.

Removed user-defined destructors, according to the C++ "Rule of Zero".

Declared them `constexpr` when possible, and added compile-time unit tests.

A significant performance improvement was observed.