### PR TITLE
Upgrade cmake_minimum_required VERSION to 3.17

### DIFF
--- a/BinLoader/CMakeLists.txt
+++ b/BinLoader/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(PROJECT "BinLoader")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists to generate a project that has all subprojects of the plugin system in one.
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(PROJECT "HdpsAllInOne")
 

--- a/CsvLoader/CMakeLists.txt
+++ b/CsvLoader/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(PROJECT "CsvLoader")
 

--- a/FcsLoader/CMakeLists.txt
+++ b/FcsLoader/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(PROJECT "FcsLoader")
 

--- a/HDPS/CMakeLists.txt
+++ b/HDPS/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(PROJECT "HDPS")
 project(${PROJECT})

--- a/HDPS/src/plugins/ClusterData/CMakeLists.txt
+++ b/HDPS/src/plugins/ClusterData/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(PROJECT "ClusterData")
 

--- a/HDPS/src/plugins/ColorData/CMakeLists.txt
+++ b/HDPS/src/plugins/ColorData/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(PROJECT "ColorData")
 

--- a/HDPS/src/plugins/ImageData/CMakeLists.txt
+++ b/HDPS/src/plugins/ImageData/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.17)
 
 set(PROJECT "ImageData")
 

--- a/HDPS/src/plugins/TextData/CMakeLists.txt
+++ b/HDPS/src/plugins/TextData/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(PROJECT "TextData")
 

--- a/Scatterplot/CMakeLists.txt
+++ b/Scatterplot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(PROJECT "ScatterplotPlugin")
 


### PR DESCRIPTION
Upgrade cmake_minimum_required VERSION from 3.9 (ImageData) and 3.1.0 (other HDPS projects) to 3.17, which is the latest major release (released on Mach 20, 2020).

Allows enabling Link Time Code Generation on Visual C++ builds, by CMake option INTERPROCEDURAL_OPTIMIZATION, among many other things.

Overview of new CMake features: https://cmake.org/cmake/help/v3.17/release/

Discussed at the 3DOMICS Developers Meeting, https://github.com/biovault/meetings/blob/master/2020-06-02.md and biovault.slack.com #hdps