### PR TITLE
Add setData overloads and convertData to Points and PointData

### DIFF
--- a/CsvLoader/src/CsvLoader.cpp
+++ b/CsvLoader/src/CsvLoader.cpp
@@ -88,7 +88,7 @@ void CsvLoader::dialogClosed(QString dataSetName, bool hasHeaders)
         }
     }
 
-    points.setData(data.data(), data.size() / numDimensions, numDimensions);
+    points.setData(std::move(data), numDimensions);
 
     qDebug() << "Number of dimensions: " << points.getNumDimensions();
 


### PR DESCRIPTION
Allowed efficient "move" of data vector into `PointData`, avoiding unnecessary memory allocation and copying, by doing `points.setData(std::move(data), numDimensions)`.

Adjusted the `setData<T>` member functions to always set both the data and the selected data element type of the internal storage.

Used inside `CsvLoader::dialogClosed`, to efficiently move the data from a local variable into the points.

Also added `convertData<T>` member functions, which convert the specified data to the previously set data type.