### PR TITLE
Remove deprecated points.getData() calls in ScatterplotPlugin

### DIFF
--- a/Scatterplot/src/ScatterplotPlugin.cpp
+++ b/Scatterplot/src/ScatterplotPlugin.cpp
@@ -157,7 +157,11 @@ void ScatterplotPlugin::onColorDataInput(QString dataSetName)
             qWarning("Number of points used for coloring does not match number of points in data, aborting attempt to color plot");
             return;
         }
-        scalars.insert(scalars.begin(), points.getData().begin(), points.getData().end());
+
+        points.visitFromBeginToEnd([&scalars](auto begin, auto end)
+            {
+                scalars.insert(scalars.begin(), begin, end);
+            });
 
         _scatterPlotWidget->setScalars(scalars);
         _scatterPlotWidget->setScalarEffect(PointEffect::Color);


### PR DESCRIPTION
Replace `points.getData()` calls within `ScatterplotPlugin::onColorDataInput` by `points.visitFromBeginToEnd([](begin, end) {...})`

Fixes warnings, introduced by HDPS core pull request #65 (Support bfloat16 and small integer types as data element type of PointData), which said:

> ScatterplotPlugin.cpp(160,47): warning C4996: 'Points::getData': Deprecated: Assumes that point data is always 32-bit float!

Allows supporting point data element types other than `float`.