### PR TITLE
Remove deprecated Points::operator[] call from ImageData

### DIFF
--- a/HDPS/src/plugins/ImageData/src/ImageData.cpp
+++ b/HDPS/src/plugins/ImageData/src/ImageData.cpp
@@ -121,7 +121,7 @@ void ImageData::setNoImages(const std::uint32_t& noImages)
 
 float ImageData::pointValue(const std::uint32_t& index) const
 {
-    return (*_points)[index];
+    return _points->getValueAt(index);
 }
 
 float ImageData::pointValue(const std::uint32_t& x, const std::uint32_t& y) const


### PR DESCRIPTION
Replace `Points::operator[]` call within `ImageData::pointValue` by `getValueAt`

Fixes a warning, introduced by HDPS core pull request #65 (Support bfloat16 and small integer types as data element type of PointData), which said:

> ImageData.cpp(124,28): warning C4996: 'Points::operator []': Deprecated: Assumes that point data is always 32-bit float!

Allows supporting point data element types other than `float`.