### PR TITLE
Remove Points member functions that assume float as data element type

### DIFF
--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -45,11 +45,6 @@ unsigned int PointData::getNumDimensions() const
     return _numDimensions;
 }
 
-const std::vector<float>& PointData::getData() const
-{
-    return _vectorHolder.getConstVector<float>();
-}
-
 const std::vector<QString>& PointData::getDimensionNames() const
 {
     return _dimNames;
@@ -64,18 +59,6 @@ void PointData::setData(const std::nullptr_t, const std::size_t numPoints, const
 void PointData::setDimensionNames(const std::vector<QString>& dimNames)
 {
     _dimNames = dimNames;
-}
-
-// Constant subscript indexing
-const float& PointData::operator[](unsigned int index) const
-{
-    return _vectorHolder.getConstVector<float>()[index];
-}
-
-// Subscript indexing
-float& PointData::operator[](unsigned int index)
-{
-    return _vectorHolder.getVector<float>()[index];
 }
 
 float PointData::getValueAt(const std::size_t index) const
@@ -160,12 +143,6 @@ void PointData::extractDataForDimensions(std::vector<hdps::Vector2f>& result, co
 // =============================================================================
 
 
-const std::vector<float>& Points::getData() const
-{
-    return getRawData<PointData>().getData();
-}
-
-
 void Points::setData(std::nullptr_t, const std::size_t numPoints, const std::size_t numDimensions)
 {
     getRawData<PointData>().setData(nullptr, numPoints, numDimensions);
@@ -220,18 +197,6 @@ const std::vector<QString>& Points::getDimensionNames() const
 void Points::setDimensionNames(const std::vector<QString>& dimNames)
 {
     getRawData<PointData>().setDimensionNames(dimNames);
-}
-
-// Constant subscript indexing
-const float& Points::operator[](unsigned int index) const
-{
-    return getRawData<PointData>()[index];
-}
-
-// Subscript indexing
-float& Points::operator[](unsigned int index)
-{
-    return getRawData<PointData>()[index];
 }
 
 float Points::getValueAt(const std::size_t index) const

--- a/HDPS/src/plugins/PointData/src/PointData.h
+++ b/HDPS/src/plugins/PointData/src/PointData.h
@@ -35,10 +35,6 @@ const hdps::DataType PointType = hdps::DataType(QString("Points"));
 // Raw Data
 // =============================================================================
 
-#ifndef HDPS_ASSUME_FLOAT32_POINT_DATA
-#define HDPS_ASSUME_FLOAT32_POINT_DATA [[deprecated("Deprecated: Assumes that point data is always 32-bit float!")]]
-#endif
-
 class POINTDATA_EXPORT PointData : public hdps::RawData
 {
 private:
@@ -339,8 +335,6 @@ public:
             });
     }
 
-    HDPS_ASSUME_FLOAT32_POINT_DATA const std::vector<float>& getData() const;
-
     void extractFullDataForDimension(std::vector<float>& result, const int dimensionIndex) const;
     void extractFullDataForDimensions(std::vector<hdps::Vector2f>& result, const int dimensionIndex1, const int dimensionIndex2) const;
     void extractDataForDimensions(std::vector<hdps::Vector2f>& result, const int dimensionIndex1, const int dimensionIndex2, const std::vector<unsigned int>& indices) const;
@@ -479,12 +473,6 @@ public:
 
     void setDimensionNames(const std::vector<QString>& dimNames);
 
-    // Constant subscript indexing
-    HDPS_ASSUME_FLOAT32_POINT_DATA const float& operator[](unsigned int index) const;
-
-    // Subscript indexing
-    HDPS_ASSUME_FLOAT32_POINT_DATA float& operator[](unsigned int index);
-
     // Returns the value of the element at the specified position in the current
     // data vector, converted to float.
     // Will work fine, even when the internal data element type is not float.
@@ -583,8 +571,6 @@ public:
     }
 
 
-    HDPS_ASSUME_FLOAT32_POINT_DATA const std::vector<float>& getData() const;
-
     /// Just calls the corresponding member function of its PointData.
     template <typename T>
     void convertData(const T* const data, const std::size_t numPoints, const std::size_t numDimensions)
@@ -669,12 +655,6 @@ public:
     const std::vector<QString>& getDimensionNames() const;
 
     void setDimensionNames(const std::vector<QString>& dimNames);
-
-    // Constant subscript indexing
-    HDPS_ASSUME_FLOAT32_POINT_DATA const float& operator[](unsigned int index) const;
-
-    // Subscript indexing
-    HDPS_ASSUME_FLOAT32_POINT_DATA float& operator[](unsigned int index);
 
     // Returns the value of the element at the specified position in the current
     // data vector, converted to float.


### PR DESCRIPTION
Removed the six `Points` and `PointData` member functions that assume 32-bit float as internal data element type. These member functions were already marked by `HDPS_ASSUME_FLOAT32_POINT_DATA` (= deprecated).

Specifically, these are `operator[]` (both const and non-const) and `getData()`.