### PR TITLE
Replace #pragma once by Qt style include guards

### DIFF
--- a/HDPS/src/AnalysisPlugin.h
+++ b/HDPS/src/AnalysisPlugin.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_ANALYSISPLUGIN_H
+#define HDPS_ANALYSISPLUGIN_H
 
 #include "PluginFactory.h"
 #include "DataConsumer.h"
@@ -45,3 +46,5 @@ public:
 } // namespace hdps
 
 Q_DECLARE_INTERFACE(hdps::plugin::AnalysisPluginFactory, "cytosplore.AnalysisPluginFactory")
+
+#endif // HDPS_ANALYSISPLUGIN_H

--- a/HDPS/src/CentralWidget.h
+++ b/HDPS/src/CentralWidget.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_CENTRALWIDGET_H
+#define HDPS_CENTRALWIDGET_H
 
 #include <QSplitter>
 
@@ -18,3 +19,5 @@ namespace hdps
         };
     }
 }
+
+#endif // HDPS_CENTRALWIDGET_H

--- a/HDPS/src/Core.h
+++ b/HDPS/src/Core.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_CORE_H
+#define HDPS_CORE_H
 
 #include "CoreInterface.h"
 #include "PluginType.h"
@@ -124,3 +125,5 @@ private:
 };
 
 } // namespace hdps
+
+#endif // HDPS_CORE_H

--- a/HDPS/src/CoreInterface.h
+++ b/HDPS/src/CoreInterface.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_COREINTERFACE_H
+#define HDPS_COREINTERFACE_H
 
 #include <QString>
 
@@ -74,3 +75,5 @@ protected:
 };
 
 } // namespace hdps
+
+#endif // HDPS_COREINTERFACE_H

--- a/HDPS/src/DataConsumer.h
+++ b/HDPS/src/DataConsumer.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_DATACONSUMER_H
+#define HDPS_DATACONSUMER_H
 
 #include "RawData.h"
 
@@ -47,3 +48,5 @@ public:
 } // namespace hdps
 
 Q_DECLARE_INTERFACE(hdps::plugin::DataConsumer, "cytosplore.DataConsumer")
+
+#endif // HDPS_DATACONSUMER_H

--- a/HDPS/src/DataHierarchy.h
+++ b/HDPS/src/DataHierarchy.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_DATAHIERARCHY_H
+#define HDPS_DATAHIERARCHY_H
 
 #include <QWidget>
 #include <QTreeView>
@@ -31,3 +32,5 @@ namespace hdps
         };
     }
 }
+
+#endif // HDPS_DATAHIERARCHY_H

--- a/HDPS/src/DataHierarchyModel.h
+++ b/HDPS/src/DataHierarchyModel.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_DATAHIERARCHYMODEL_H
+#define HDPS_DATAHIERARCHYMODEL_H
 
 #include "DataManager.h"
 
@@ -117,3 +118,5 @@ namespace hdps
         DataManager& _dataManager;
     };
 }
+
+#endif // HDPS_DATAHIERARCHYMODEL_H

--- a/HDPS/src/DataManager.h
+++ b/HDPS/src/DataManager.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_DATAMANAGER_H
+#define HDPS_DATAMANAGER_H
 
 #include "RawData.h"
 #include "Set.h"
@@ -126,3 +127,5 @@ private:
 };
 
 } // namespace hdps
+
+#endif // HDPS_DATAMANAGER_H

--- a/HDPS/src/IndexSet.h
+++ b/HDPS/src/IndexSet.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_INDEXSET_H
+#define HDPS_INDEXSET_H
 
 #include "Set.h"
 
@@ -17,3 +18,5 @@ namespace hdps
         std::vector<unsigned int> indices;
     };
 } // namespace hdps
+
+#endif // HDPS_INDEXSET_H

--- a/HDPS/src/LoaderPlugin.h
+++ b/HDPS/src/LoaderPlugin.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_LOADERPLUGIN_H
+#define HDPS_LOADERPLUGIN_H
 
 #include "PluginFactory.h"
 
@@ -74,3 +75,5 @@ public:
 } // namespace hdps
 
 Q_DECLARE_INTERFACE(hdps::plugin::LoaderPluginFactory, "cytosplore.LoaderPluginFactory")
+
+#endif // HDPS_LOADERPLUGIN_H

--- a/HDPS/src/LogDockWidget.h
+++ b/HDPS/src/LogDockWidget.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_LOGDOCKWIDGET_H
+#define HDPS_LOGDOCKWIDGET_H
 
 // Qt header file:
 #include <QDockWidget>
@@ -24,3 +25,5 @@ private:
 
 } // namespace gui
 } // namespace hdps
+
+#endif // HDPS_LOGDOCKWIDGET_H

--- a/HDPS/src/LogItemModel.h
+++ b/HDPS/src/LogItemModel.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_LOGITEMMODEL_H
+#define HDPS_LOGITEMMODEL_H
 
 // Qt header file:
 #include <QAbstractItemModel>
@@ -67,3 +68,5 @@ private: // Member functions:
 
 }   //namespace gui
 }   // namespace hdps
+
+#endif // HDPS_LOGITEMMODEL_H

--- a/HDPS/src/Logger.h
+++ b/HDPS/src/Logger.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_LOGGER_H
+#define HDPS_LOGGER_H
 
 #include <QString>
 
@@ -38,3 +39,5 @@ public:
 #define HDPS_LOG_EXCEPTION(stdException) qCritical().noquote() << \
   ::hdps::Logger::ExceptionToText(stdException)
 
+
+#endif // HDPS_LOGGER_H

--- a/HDPS/src/MainWindow.h
+++ b/HDPS/src/MainWindow.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_MAINWINDOW_H
+#define HDPS_MAINWINDOW_H
 
 #include "ui_MainWindow.h"
 #include "Core.h"
@@ -99,3 +100,5 @@ private:
 } // namespace gui
 
 } // namespace hdps
+
+#endif // HDPS_MAINWINDOW_H

--- a/HDPS/src/Plugin.h
+++ b/HDPS/src/Plugin.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_PLUGIN_H
+#define HDPS_PLUGIN_H
 
 #include "CoreInterface.h"
 #include "PluginType.h"
@@ -77,3 +78,5 @@ private:
 } // namespace plugin
 
 } // namespace hdps
+
+#endif // HDPS_PLUGIN_H

--- a/HDPS/src/PluginFactory.h
+++ b/HDPS/src/PluginFactory.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_PLUGINFACTORY_H
+#define HDPS_PLUGINFACTORY_H
 
 #include "Plugin.h"
 
@@ -24,3 +25,5 @@ public:
 } // namespace hdps
 
 Q_DECLARE_INTERFACE(hdps::plugin::PluginFactory, "cytosplore.PluginFactory")
+
+#endif // HDPS_PLUGINFACTORY_H

--- a/HDPS/src/PluginManager.h
+++ b/HDPS/src/PluginManager.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_PLUGINMANAGER_H
+#define HDPS_PLUGINMANAGER_H
 
 #include "Core.h"
 
@@ -51,3 +52,5 @@ private slots:
 } // namespace plugin
 
 } // namespace hdps
+
+#endif // HDPS_PLUGINMANAGER_H

--- a/HDPS/src/PluginType.h
+++ b/HDPS/src/PluginType.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_PLUGINTYPE_H
+#define HDPS_PLUGINTYPE_H
 
 /**
  * Provides all possible types of plugins.
@@ -28,3 +29,5 @@ namespace plugin
 } // namespace plugin
 
 } // namespace hdps
+
+#endif // HDPS_PLUGINTYPE_H

--- a/HDPS/src/RawData.h
+++ b/HDPS/src/RawData.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_RAWDATA_H
+#define HDPS_RAWDATA_H
 
 #include "PluginFactory.h"
 
@@ -96,3 +97,5 @@ namespace plugin {
 } // namespace hdps
 
 Q_DECLARE_INTERFACE(hdps::plugin::RawDataFactory, "hdps.RawDataFactory")
+
+#endif // HDPS_RAWDATA_H

--- a/HDPS/src/SelectionListener.h
+++ b/HDPS/src/SelectionListener.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_SELECTIONLISTENER_H
+#define HDPS_SELECTIONLISTENER_H
 
 #include "graphics/Selection.h"
 
@@ -30,3 +31,5 @@ public:
 } // namespace hdps
 
 Q_DECLARE_INTERFACE(hdps::plugin::SelectionListener, "cytosplore.SelectionListener")
+
+#endif // HDPS_SELECTIONLISTENER_H

--- a/HDPS/src/Set.h
+++ b/HDPS/src/Set.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef HDPS_SET_H
+#define HDPS_SET_H
 
 #include "RawData.h"
 
@@ -125,3 +126,5 @@ private:
 };
 
 } // namespace hdps
+
+#endif // HDPS_SET_H

--- a/HDPS/src/ViewPlugin.h
+++ b/HDPS/src/ViewPlugin.h
@@ -1,10 +1,11 @@
+#ifndef HDPS_VIEWPLUGIN_H
+#define HDPS_VIEWPLUGIN_H
 /**
 * View.h
 *
 * Base plugin class for plugins that visualize data.
 */
 
-#pragma once
 
 #include "widgets/DockableWidget.h"
 #include "PluginFactory.h"
@@ -50,3 +51,5 @@ public:
 } // namespace hdps
 
 Q_DECLARE_INTERFACE(hdps::plugin::ViewPluginFactory, "cytosplore.ViewPluginFactory")
+
+#endif // HDPS_VIEWPLUGIN_H

--- a/HDPS/src/WriterPlugin.h
+++ b/HDPS/src/WriterPlugin.h
@@ -1,10 +1,11 @@
+#ifndef HDPS_WRITERPLUGIN_H
+#define HDPS_WRITERPLUGIN_H
 /**
 * Writer.h
 *
 * Base plugin class for plugins that write data to a file.
 */
 
-#pragma once
 
 #include "PluginFactory.h"
 
@@ -42,3 +43,5 @@ public:
 } // namespace hdps
 
 Q_DECLARE_INTERFACE(hdps::plugin::WriterPluginFactory, "cytosplore.WriterPluginFactory")
+
+#endif // HDPS_WRITERPLUGIN_H


### PR DESCRIPTION
Use include guards, similar to Qt, for example in qobject.h:

    #ifndef QOBJECT_H
    #define QOBJECT_H
    ...
    #endif // QOBJECT_H

https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qobject.h?h=5.15.0#n41

It appears that `#pragma once` does not support mixing header files from "core\HDPS\src" and <HDPS_INSTALL_DIR>\<Configuration>\include