### PR TITLE
Add Points::visitData, implemented by PointDataRange/Iterator, PointView 

### DIFF
--- a/HDPS/src/plugins/PointData/CMakeLists.txt
+++ b/HDPS/src/plugins/PointData/CMakeLists.txt
@@ -17,6 +17,10 @@ set(POINTS_SOURCES
     src/PointData.h
     src/PointData.cpp
     src/PointData.json
+    src/PointDataIterator.h
+    src/PointDataRange.h
+    src/PointView.h
+    src/RandomAccessRange.h
 )
 
 source_group( Plugin FILES ${POINTS_SOURCES})
@@ -69,6 +73,18 @@ add_custom_command(TARGET ${PROJECT} POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E copy_if_different
     "${CMAKE_CURRENT_SOURCE_DIR}/src/PointData.h"
     "${INSTALL_DIR}/$<CONFIGURATION>/include/PointData.h"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/PointDataIterator.h"
+    "${INSTALL_DIR}/$<CONFIGURATION>/include/PointDataIterator.h"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/PointDataRange.h"
+    "${INSTALL_DIR}/$<CONFIGURATION>/include/PointDataRange.h"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/PointView.h"
+    "${INSTALL_DIR}/$<CONFIGURATION>/include/PointView.h"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/RandomAccessRange.h"
+    "${INSTALL_DIR}/$<CONFIGURATION>/include/RandomAccessRange.h"
     COMMAND "${CMAKE_COMMAND}" -E copy_if_different
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../external/biovault_bfloat16/biovault_bfloat16.h"
     "${INSTALL_DIR}/$<CONFIGURATION>/include/biovault_bfloat16.h"

--- a/HDPS/src/plugins/PointData/src/PointDataIterator.h
+++ b/HDPS/src/plugins/PointData/src/PointDataIterator.h
@@ -1,0 +1,234 @@
+#ifndef HDPS_POINTDATAITERATOR_H
+#define HDPS_POINTDATAITERATOR_H
+
+#include <iterator>
+
+#include "PointView.h"
+
+namespace hdps
+{
+    template <typename ValueIteratorType, typename IndexIteratorType>
+    class PointDataIterator
+    {
+        /* For an unsigned index argument, the value of the index is the value of the argument.
+        */
+        static auto valueOfIndex(const unsigned index)
+        {
+            return index;
+        }
+
+        /* For an iterator, the value of the index comes from dereferencing the iterator.
+        */
+        template <typename T>
+        static auto valueOfIndex(T indexIterator)
+        {
+            return *indexIterator;
+        }
+
+
+        // Its data members: 
+        ValueIteratorType _valueIterator{};
+        IndexIteratorType _indexIterator{};
+        unsigned _numberOfDimensions{};
+
+        using PointViewType = PointView<ValueIteratorType>;
+    public:
+        // Types conforming the iterator requirements of the C++ standard library:
+        using difference_type = std::ptrdiff_t;
+        using value_type = PointViewType;
+        using reference = PointViewType;
+        using pointer = const PointViewType*;
+        using iterator_category = std::random_access_iterator_tag;
+
+
+        /* Explicitly defaulted default-constructor
+        */
+        PointDataIterator() = default;
+
+
+        PointDataIterator(
+            const ValueIteratorType valueIterator,
+            const IndexIteratorType indexIterator,
+            const unsigned numberOfDimensions)
+            :
+            _valueIterator{ valueIterator },
+            _indexIterator{ indexIterator },
+            _numberOfDimensions{ numberOfDimensions }
+        {
+        }
+
+
+        /**  Returns a PointView object to the current point.
+        */
+        auto operator*() const
+        {
+            const auto index = valueOfIndex(_indexIterator);
+            const auto begin = _valueIterator + (index * _numberOfDimensions);
+            const auto end = begin + _numberOfDimensions;
+            return PointViewType(begin, end, index);
+        }
+
+
+        /** Prefix increment ('++it').
+        */
+        auto& operator++()
+        {
+            ++(_indexIterator);
+            return *this;
+        }
+
+
+        /** Postfix increment ('it++').
+         * \note Usually prefix increment ('++it') is preferable.
+         */
+        auto operator++(int)
+        {
+            auto result = *this;
+            ++(*this);
+            return result;
+        }
+
+
+        /** Prefix decrement ('--it').
+        */
+        auto& operator--()
+        {
+            --_indexIterator;
+            return *this;
+        }
+
+
+        /** Postfix increment ('it--').
+         * \note  Usually prefix increment ('--it') is preferable.
+         */
+        auto operator--(int)
+        {
+            auto result = *this;
+            --(*this);
+            return result;
+        }
+
+
+
+        /** Does (it += n) for iterator 'it' and integer value 'n'.
+        */
+        friend auto& operator+=(PointDataIterator& it, const difference_type n)
+        {
+            it._indexIterator += n;
+            return it;
+        }
+
+
+        /** Returns (it1 - it2) for iterators it1 and it2.
+        */
+        friend difference_type operator-(const PointDataIterator& it1, const PointDataIterator& it2)
+        {
+            return it1._indexIterator - it2._indexIterator;
+        }
+
+
+        /** Returns (it + n) for iterator 'it' and integer value 'n'.
+        */
+        friend auto operator+(PointDataIterator it, const difference_type n)
+        {
+            return it += n;
+        }
+
+
+        /** Returns (n + it) for iterator 'it' and integer value 'n'.
+        */
+        friend auto operator+(const difference_type n, PointDataIterator it)
+        {
+            return it += n;
+        }
+
+
+        /** Returns (it - n) for iterator 'it' and integer value 'n'.
+        */
+        friend auto operator-(PointDataIterator it, const difference_type n)
+        {
+            return it += (-n);
+        }
+
+
+        /** Returns it[n] for iterator 'it' and integer value 'n'.
+        */
+        auto operator[](const difference_type n) const
+        {
+            return *(*this + n);
+        }
+
+
+        /** Returns (it1 == it2) for iterators it1 and it2.
+        */
+        friend bool operator==(const PointDataIterator& it1, const PointDataIterator& it2)
+        {
+            return it1._indexIterator == it2._indexIterator;
+        }
+
+
+        /** Returns (it1 != it2) for iterators it1 and it2.
+        */
+        friend bool operator!=(const PointDataIterator& it1, const PointDataIterator& it2)
+        {
+            return ! (it1 == it2);
+        }
+
+
+        /** Returns (it1 < it2) for iterators it1 and it2.
+        */
+        friend bool operator<(const PointDataIterator& it1, const PointDataIterator& it2)
+        {
+            return it1._indexIterator < it2._indexIterator;
+        }
+
+
+        /** Returns (it1 > it2) for iterators it1 and it2.
+        */
+        friend bool operator>(const PointDataIterator& it1, const PointDataIterator& it2)
+        {
+            // Implemented just like the corresponding std::rel_ops operator.
+            return it2 < it2;
+        }
+
+
+        /** Returns (it1 <= it2) for iterators it1 and it2.
+        */
+        friend bool operator<=(const PointDataIterator& it1, const PointDataIterator& it2)
+        {
+            // Implemented just like the corresponding std::rel_ops operator.
+            return !(it2 < it1);
+        }
+
+
+        /** Returns (it1 >= it2) for iterators it1 and it2.
+        */
+        friend bool operator>=(const PointDataIterator& it1, const PointDataIterator& it2)
+        {
+            // Implemented just like the corresponding std::rel_ops operator.
+            return !(it1 < it2);
+        }
+
+
+        /** Does (it -= n) for iterator 'it' and integer value 'n'.
+        */
+        friend auto& operator-=(PointDataIterator& it, const difference_type n)
+        {
+            it += (-n);
+            return it;
+        }
+
+
+        /** Returns the index of the current point.
+        */
+        friend auto index(const PointDataIterator& arg)
+        {
+            return valueOfIndex(arg._indexIterator);
+        }
+
+    };
+
+}
+
+
+#endif // HDPS_POINTDATAITERATOR_H

--- a/HDPS/src/plugins/PointData/src/PointDataRange.h
+++ b/HDPS/src/plugins/PointData/src/PointDataRange.h
@@ -1,0 +1,60 @@
+#ifndef HDPS_POINTDATARANGE_H
+#define HDPS_POINTDATARANGE_H
+
+#include "PointDataIterator.h"
+#include "RandomAccessRange.h"
+
+#include <iterator> // For begin and end.
+
+namespace hdps
+{
+    /* A PointDataRange is a random access range between two iterators of type PointDataIterator.
+    */
+    template <typename ValueIteratorType, typename IndexIteratorType>
+    using PointDataRange = RandomAccessRange<PointDataIterator<ValueIteratorType, IndexIteratorType>>;
+
+
+    /* Makes a PointDataRange object for a subset of the values specified by the
+    * first parameter. The subset is specified by the indices provided by the
+    * second parameter.
+    */
+    template <typename ValueIteratorType, typename IndexContainerType>
+    auto makePointDataRange(
+        const ValueIteratorType beginOfValueContainer,
+        const IndexContainerType& indices,
+        const unsigned numberOfDimensions)
+    {
+        using IndexIteratorType = decltype(begin(indices));
+        using PointDataIteratorType = PointDataIterator<ValueIteratorType, IndexIteratorType>;
+
+        return PointDataRange<ValueIteratorType, IndexIteratorType>
+        {
+            PointDataIteratorType(beginOfValueContainer, begin(indices), numberOfDimensions),
+                PointDataIteratorType(beginOfValueContainer, end(indices), numberOfDimensions)
+        };
+    }
+
+
+    /* Makes a PointDataRange object for a full set of values.
+    */
+    template <typename ValueIteratorType>
+    auto makePointDataRange(
+        const ValueIteratorType beginOfValueContainer,
+        const ValueIteratorType endOfValueContainer,
+        const unsigned numberOfDimensions)
+    {
+        using PointDataIteratorType = PointDataIterator<ValueIteratorType, unsigned>;
+        const auto numberOfPoints = static_cast<unsigned>( (endOfValueContainer - beginOfValueContainer) / numberOfDimensions);
+
+        return PointDataRange<ValueIteratorType, unsigned>
+        {
+            PointDataIteratorType(beginOfValueContainer, 0U, numberOfDimensions),
+                PointDataIteratorType(beginOfValueContainer, numberOfPoints, numberOfDimensions)
+        };
+    }
+
+
+}
+
+
+#endif // HDPS_POINTDATARANGE_H

--- a/HDPS/src/plugins/PointData/src/PointView.h
+++ b/HDPS/src/plugins/PointData/src/PointView.h
@@ -1,0 +1,80 @@
+#ifndef HDPS_POINTVIEW_H
+#define HDPS_POINTVIEW_H
+
+#include <cstddef> // For size_t
+#include <cassert>
+
+namespace hdps
+{
+    /* Allows iterating over the values of a single point from a point data buffer.
+    Supports using a range-based for-loop, like `for (auto& value: pointView)`.
+    */
+    template <typename DataIteratorType>
+    class PointView
+    {
+    public:
+        using iterator = DataIteratorType;
+
+        PointView() = default;
+
+        PointView(
+            const iterator begin,
+            const iterator end,
+            const unsigned index)
+            :
+            _begin{ begin },
+            _end{ end },
+            _index{ index }
+        {
+            assert(begin <= end);
+        }
+
+        iterator begin() const
+        {
+            return _begin;
+        }
+
+        iterator end() const
+        {
+            return _end;
+        }
+
+        auto& operator[](std::size_t i) const
+        {
+            return _begin[i];
+        }
+
+        std::size_t size() const
+        {
+            return _end - _begin;
+        }
+
+        bool empty() const
+        {
+            return _begin == _end;
+        }
+
+        auto index() const
+        {
+            return _index;
+        }
+
+        friend bool operator==(const PointView& lhs, const PointView& rhs)
+        {
+            return (lhs._begin == rhs._begin) && (lhs._end == rhs._end);
+        }
+
+        friend bool operator!=(const PointView& lhs, const PointView& rhs)
+        {
+            return ! (lhs == rhs);
+        }
+
+    private:
+        iterator _begin{};
+        iterator _end{};
+        unsigned _index{};
+    };
+}
+
+
+#endif // HDPS_POINTVIEW_H

--- a/HDPS/src/plugins/PointData/src/RandomAccessRange.h
+++ b/HDPS/src/plugins/PointData/src/RandomAccessRange.h
@@ -1,0 +1,68 @@
+#ifndef HDPS_RANDOMACCESSRANGE_H
+#define HDPS_RANDOMACCESSRANGE_H
+
+#include <cstddef> // For size_t
+#include <cassert>
+
+namespace hdps
+{
+    template <typename RandomAccessIteratorType>
+    class RandomAccessRange
+    {
+    public:
+        using iterator = RandomAccessIteratorType;
+
+        RandomAccessRange() = default;
+
+        RandomAccessRange(const iterator begin, const iterator end)
+            :
+            _begin{ begin },
+            _end{ end }
+        {
+            assert(begin <= end);
+        }
+
+        iterator begin() const
+        {
+            return _begin;
+        }
+
+        iterator end() const
+        {
+            return _end;
+        }
+
+        decltype(auto) operator[](std::size_t i) const
+        {
+            return _begin[i];
+        }
+
+        std::size_t size() const
+        {
+            return _end - _begin;
+        }
+
+        bool empty() const
+        {
+            return _begin == _end;
+        }
+
+        friend bool operator==(const RandomAccessRange& lhs, const RandomAccessRange& rhs)
+        {
+            return (lhs._begin == rhs._begin) && (lhs._end == rhs._end);
+        }
+
+        friend bool operator!=(const RandomAccessRange& lhs, const RandomAccessRange& rhs)
+        {
+            return ! (lhs == rhs);
+        }
+
+    private:
+        iterator _begin{};
+        iterator _end{};
+    };
+
+}
+
+
+#endif // HDPS_RANDOMACCESSRANGE_H


### PR DESCRIPTION
Example use cases:

    // Print the internal data of points:
    points.visitData([](auto pointData) {
        for (auto pointView : pointData)
            for (const auto dataValue : pointView)
                std::cout << dataValue;
    });

    // Retrieve the points and stores them at the position
    // that corresponds to their index:
    points.visitData([&outputData](auto pointData) {
        for (auto pointView : pointData) {

            const auto numberOfDimensions = pointView.size();
            auto dataValueIndex = pointView.index() * numberOfDimensions;

            for (const auto dataValue : pointView)
            {
                outputData[dataValueIndex] = dataValue;
                ++dataValueIndex;
            }
        }
    });

    // Fill the internal data of points:
    points.visitData([](auto pointData) {
        for (auto pointView : pointData)
            std::fill(pointView.begin(), pointView.end(), 42);
    });

Note that `visitData` visits the subset when the data set is not full.