### PR TITLE
Fix operator> (as in "it1 > it2") for PointDataIterator, add unit test

### DIFF
--- a/HDPS/src/plugins/PointData/gtest/CMakeLists.txt
+++ b/HDPS/src/plugins/PointData/gtest/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 add_executable(PointDataGTest
     PointDataGTest.cpp
+    PointDataIteratorGTest.cpp
     PointsGTest.cpp
 )
 

--- a/HDPS/src/plugins/PointData/gtest/PointDataIteratorGTest.cpp
+++ b/HDPS/src/plugins/PointData/gtest/PointDataIteratorGTest.cpp
@@ -1,0 +1,136 @@
+// The file to be tested:
+#include <PointDataRange.h>
+
+// GoogleTest header file:
+#include <gtest/gtest.h>
+
+#include <vector>
+
+// Test template instantiations for the most common template arguments:
+template class hdps::PointDataIterator<float*, unsigned*>;
+template class hdps::PointDataIterator<std::vector<float>::iterator, unsigned*>;
+template class hdps::PointDataIterator<std::vector<float>::iterator, std::vector<unsigned>::const_iterator>;
+template class hdps::PointDataIterator<std::vector<float>::const_iterator, unsigned*>;
+template class hdps::PointDataIterator<std::vector<float>::const_iterator, std::vector<unsigned>::const_iterator>;
+
+using hdps::PointDataIterator;
+
+
+TEST(PointDataIterator, satisfiesRandomAccessIteratorRequirements)
+{
+    std::vector<float> inputData{ 0.0f, 1.1f, 2.2f, 3.3f, 4.4f, 5.5f };
+    const std::vector<unsigned> indices{ 1U, 2U, 3U, 4U };
+    constexpr auto numberOfDimensions = 1;
+
+    // Unit test borrowed from TEST(ImageBufferRange, IteratorsSupportRandomAccess), from
+    // https://github.com/InsightSoftwareConsortium/ITK/blob/v5.1.0/Modules/Core/Common/test/itkImageBufferRangeGTest.cxx#L648
+
+    // Testing expressions from Table 111 "Random access iterator requirements
+    // (in addition to bidirectional iterator)", C++11 Standard, section 24.2.7
+    // "Random access iterator" [random.access.iterators].
+
+    // Note: The 1-letter identifiers (X, a, b, n, r) and the operational semantics
+    // are directly from the C++11 Standard.
+    using X = PointDataIterator<float*, const unsigned*>;
+    X a(inputData.data(), indices.data() + indices.size(), numberOfDimensions);
+    X b(inputData.data(), indices.data(), numberOfDimensions);
+
+    const X initialIterator(inputData.data(), indices.data(), numberOfDimensions);
+    X       mutableIterator = initialIterator;
+    X& r = mutableIterator;
+
+    using difference_type = std::iterator_traits<X>::difference_type;
+    using reference = std::iterator_traits<X>::reference;
+
+    {
+        // Expression to be tested: 'r += n'
+        difference_type n = 3;
+
+        r = initialIterator;
+        const auto expectedResult = [&r, n] {
+            // Operational semantics, as specified by the C++11 Standard:
+            difference_type m = n;
+            if (m >= 0)
+                while (m--)
+                    ++r;
+            else
+                while (m++)
+                    --r;
+            return r;
+        }();
+        r = initialIterator;
+        auto&& actualResult = r += n;
+        EXPECT_EQ(actualResult, expectedResult);
+        static_assert(std::is_same<decltype(actualResult), X&>::value, "Type of result 'r += n' tested");
+    }
+    {
+        // Expressions to be tested: 'a + n' and 'n + a'
+        difference_type n = 3;
+
+        static_assert(std::is_same<decltype(a + n), X>::value, "Return type tested");
+        static_assert(std::is_same<decltype(n + a), X>::value, "Return type tested");
+
+        const auto expectedResult = [a, n] {
+            // Operational semantics, as specified by the C++11 Standard:
+            X tmp = a;
+            return tmp += n;
+        }();
+
+        EXPECT_EQ(a + n, expectedResult);
+        EXPECT_TRUE(a + n == n + a);
+    }
+    {
+        // Expression to be tested: 'r -= n'
+        difference_type n = 3;
+
+        r = initialIterator;
+        const auto expectedResult = [&r, n] {
+            // Operational semantics, as specified by the C++11 Standard:
+            return r += -n;
+        }();
+        r = initialIterator;
+        auto&& actualResult = r -= n;
+        EXPECT_EQ(actualResult, expectedResult);
+        static_assert(std::is_same<decltype(actualResult), X&>::value, "Type of result 'r -= n' tested");
+    }
+    {
+        // Expression to be tested: 'a - n'
+        difference_type n = -3;
+
+        static_assert(std::is_same<decltype(a - n), X>::value, "Return type tested");
+
+        const auto expectedResult = [a, n] {
+            // Operational semantics, as specified by the C++11 Standard:
+            X tmp = a;
+            return tmp -= n;
+        }();
+
+        EXPECT_EQ(a - n, expectedResult);
+    }
+    {
+        // Expression to be tested: 'b - a'
+        static_assert(std::is_same<decltype(b - a), difference_type>::value, "Return type tested");
+
+        difference_type n = b - a;
+        EXPECT_TRUE(a + n == b);
+        EXPECT_TRUE(b == a + (b - a));
+    }
+    {
+        // Expression to be tested: 'a[n]'
+        difference_type n = 3;
+        static_assert(std::is_convertible<decltype(a[n]), reference>::value, "Return type tested");
+        EXPECT_EQ(a[n], *(a + n));
+    }
+    {
+        // Expressions to be tested: 'a < b', 'a > b', 'a >= b', and 'a <= b':
+        static_assert(std::is_convertible<decltype(a < b), bool>::value, "Return type tested");
+        static_assert(std::is_convertible<decltype(a > b), bool>::value, "Return type tested");
+        static_assert(std::is_convertible<decltype(a >= b), bool>::value, "Return type tested");
+        static_assert(std::is_convertible<decltype(a <= b), bool>::value, "Return type tested");
+        EXPECT_EQ(a < b, b - a> 0);
+        EXPECT_EQ(a > b, b < a);
+        EXPECT_EQ(a >= b, !(a < b));
+        EXPECT_EQ(a <= b, !(b < a));
+    }
+}
+

--- a/HDPS/src/plugins/PointData/src/PointDataIterator.h
+++ b/HDPS/src/plugins/PointData/src/PointDataIterator.h
@@ -188,7 +188,7 @@ namespace hdps
         friend bool operator>(const PointDataIterator& it1, const PointDataIterator& it2)
         {
             // Implemented just like the corresponding std::rel_ops operator.
-            return it2 < it2;
+            return it2 < it1;
         }
 
 


### PR DESCRIPTION
Fix a bug in `operator>`, found by the following MSVC warning:

> PointDataIterator.h(188,56): warning C4100: 'it1': unreferenced formal parameter

Added an extensive unit test to check that `PointDataIterator` satisfies the Random access iterator requirements.