### PR TITLE
Simplify implementation of DataSet::getSourceData(T& set)

### DIFF
--- a/HDPS/src/Set.h
+++ b/HDPS/src/Set.h
@@ -68,7 +68,7 @@ public:
     template <class T>
     static T& getSourceData(T& set)
     {
-        return set.isDerivedData() ? getSourceData(static_cast<T&>(set._core->requestData(set._sourceSetName))) : static_cast<T&>(set._core->requestData(set._name));
+        return set.isDerivedData() ? getSourceData(static_cast<T&>(set._core->requestData(set._sourceSetName))) : set;
     }
 
     /**


### PR DESCRIPTION
Avoided calling `core->requestData` when the given set is _not_ derived.

Discussed with @JulianThijssen at slack (direct messaging).