### PR TITLE
Add Points::visitSourceData

### DIFF
--- a/HDPS/src/plugins/PointData/gtest/PointDataIteratorGTest.cpp
+++ b/HDPS/src/plugins/PointData/gtest/PointDataIteratorGTest.cpp
@@ -7,11 +7,11 @@
 #include <vector>
 
 // Test template instantiations for the most common template arguments:
-template class hdps::PointDataIterator<float*, unsigned*>;
-template class hdps::PointDataIterator<std::vector<float>::iterator, unsigned*>;
-template class hdps::PointDataIterator<std::vector<float>::iterator, std::vector<unsigned>::const_iterator>;
-template class hdps::PointDataIterator<std::vector<float>::const_iterator, unsigned*>;
-template class hdps::PointDataIterator<std::vector<float>::const_iterator, std::vector<unsigned>::const_iterator>;
+template class hdps::PointDataIterator<float*, const unsigned*, unsigned(*)(const unsigned*)>;
+template class hdps::PointDataIterator<std::vector<float>::iterator, const unsigned*, unsigned(*)(const unsigned*)>;
+template class hdps::PointDataIterator<std::vector<float>::iterator, std::vector<unsigned>::const_iterator, unsigned(*)(std::vector<unsigned>::const_iterator)>;
+template class hdps::PointDataIterator<std::vector<float>::const_iterator, const unsigned*, unsigned(*)(const unsigned*)>;
+template class hdps::PointDataIterator<std::vector<float>::const_iterator, std::vector<unsigned>::const_iterator, unsigned(*)(std::vector<unsigned>::const_iterator)>;
 
 using hdps::PointDataIterator;
 
@@ -31,11 +31,12 @@ TEST(PointDataIterator, satisfiesRandomAccessIteratorRequirements)
 
     // Note: The 1-letter identifiers (X, a, b, n, r) and the operational semantics
     // are directly from the C++11 Standard.
-    using X = PointDataIterator<float*, const unsigned*>;
-    X a(inputData.data(), indices.data() + indices.size(), numberOfDimensions);
-    X b(inputData.data(), indices.data(), numberOfDimensions);
+    const auto indexFunction = [](const unsigned* ptr) {return *ptr; };
+    using X = PointDataIterator<float*, const unsigned*, unsigned(*)(const unsigned*)>;
+    X a(inputData.data(), indices.data() + indices.size(), numberOfDimensions, indexFunction);
+    X b(inputData.data(), indices.data(), numberOfDimensions, indexFunction);
 
-    const X initialIterator(inputData.data(), indices.data(), numberOfDimensions);
+    const X initialIterator(inputData.data(), indices.data(), numberOfDimensions, indexFunction);
     X       mutableIterator = initialIterator;
     X& r = mutableIterator;
 

--- a/HDPS/src/plugins/PointData/src/PointDataIterator.h
+++ b/HDPS/src/plugins/PointData/src/PointDataIterator.h
@@ -7,29 +7,14 @@
 
 namespace hdps
 {
-    template <typename ValueIteratorType, typename IndexIteratorType>
+    template <typename ValueIteratorType, typename IndexIteratorType, typename IndexFunctionType>
     class PointDataIterator
     {
-        /* For an unsigned index argument, the value of the index is the value of the argument.
-        */
-        static auto valueOfIndex(const unsigned index)
-        {
-            return index;
-        }
-
-        /* For an iterator, the value of the index comes from dereferencing the iterator.
-        */
-        template <typename T>
-        static auto valueOfIndex(T indexIterator)
-        {
-            return *indexIterator;
-        }
-
-
         // Its data members: 
         ValueIteratorType _valueIterator{};
         IndexIteratorType _indexIterator{};
         unsigned _numberOfDimensions{};
+        IndexFunctionType _indexFunction;
 
         using PointViewType = PointView<ValueIteratorType>;
     public:
@@ -49,11 +34,13 @@ namespace hdps
         PointDataIterator(
             const ValueIteratorType valueIterator,
             const IndexIteratorType indexIterator,
-            const unsigned numberOfDimensions)
+            const unsigned numberOfDimensions,
+            const IndexFunctionType indexFunction)
             :
             _valueIterator{ valueIterator },
             _indexIterator{ indexIterator },
-            _numberOfDimensions{ numberOfDimensions }
+            _numberOfDimensions{ numberOfDimensions },
+            _indexFunction{ indexFunction }
         {
         }
 
@@ -62,7 +49,7 @@ namespace hdps
         */
         auto operator*() const
         {
-            const auto index = valueOfIndex(_indexIterator);
+            const auto index = _indexFunction(_indexIterator);
             const auto begin = _valueIterator + (index * _numberOfDimensions);
             const auto end = begin + _numberOfDimensions;
             return PointViewType(begin, end, index);
@@ -223,7 +210,7 @@ namespace hdps
         */
         friend auto index(const PointDataIterator& arg)
         {
-            return valueOfIndex(arg._indexIterator);
+            return arg._indexFunction(arg._indexIterator);
         }
 
     };

--- a/HDPS/src/plugins/PointData/src/PointDataRange.h
+++ b/HDPS/src/plugins/PointData/src/PointDataRange.h
@@ -10,46 +10,48 @@ namespace hdps
 {
     /* A PointDataRange is a random access range between two iterators of type PointDataIterator.
     */
-    template <typename ValueIteratorType, typename IndexIteratorType>
-    using PointDataRange = RandomAccessRange<PointDataIterator<ValueIteratorType, IndexIteratorType>>;
+    template <typename ValueIteratorType, typename IndexIteratorType, typename IndexFunctionType>
+    using PointDataRange = RandomAccessRange<PointDataIterator<ValueIteratorType, IndexIteratorType, IndexFunctionType>>;
 
 
     /* Makes a PointDataRange object for a subset of the values specified by the
     * first parameter. The subset is specified by the indices provided by the
     * second parameter.
     */
-    template <typename ValueIteratorType, typename IndexContainerType>
+    template <typename ValueIteratorType, typename IndexContainerType, typename IndexFunctionType>
     auto makePointDataRangeOfSubset(
         const ValueIteratorType beginOfValueContainer,
         const IndexContainerType& indices,
-        const unsigned numberOfDimensions)
+        const unsigned numberOfDimensions,
+        const IndexFunctionType indexFunction)
     {
         using IndexIteratorType = decltype(begin(indices));
-        using PointDataIteratorType = PointDataIterator<ValueIteratorType, IndexIteratorType>;
+        using PointDataIteratorType = PointDataIterator<ValueIteratorType, IndexIteratorType, IndexFunctionType>;
 
-        return PointDataRange<ValueIteratorType, IndexIteratorType>
+        return PointDataRange<ValueIteratorType, IndexIteratorType, IndexFunctionType>
         {
-            PointDataIteratorType(beginOfValueContainer, begin(indices), numberOfDimensions),
-                PointDataIteratorType(beginOfValueContainer, end(indices), numberOfDimensions)
+            PointDataIteratorType(beginOfValueContainer, begin(indices), numberOfDimensions, indexFunction),
+                PointDataIteratorType(beginOfValueContainer, end(indices), numberOfDimensions, indexFunction)
         };
     }
 
 
     /* Makes a PointDataRange object for a full set of values.
     */
-    template <typename ValueIteratorType>
+    template <typename ValueIteratorType, typename IndexFunctionType>
     auto makePointDataRangeOfFullSet(
         const ValueIteratorType beginOfValueContainer,
         const ValueIteratorType endOfValueContainer,
-        const unsigned numberOfDimensions)
+        const unsigned numberOfDimensions,
+        const IndexFunctionType indexFunction)
     {
-        using PointDataIteratorType = PointDataIterator<ValueIteratorType, unsigned>;
+        using PointDataIteratorType = PointDataIterator<ValueIteratorType, unsigned, IndexFunctionType>;
         const auto numberOfPoints = static_cast<unsigned>( (endOfValueContainer - beginOfValueContainer) / numberOfDimensions);
 
-        return PointDataRange<ValueIteratorType, unsigned>
+        return PointDataRange<ValueIteratorType, unsigned, IndexFunctionType>
         {
-            PointDataIteratorType(beginOfValueContainer, 0U, numberOfDimensions),
-                PointDataIteratorType(beginOfValueContainer, numberOfPoints, numberOfDimensions)
+            PointDataIteratorType(beginOfValueContainer, 0U, numberOfDimensions, indexFunction),
+                PointDataIteratorType(beginOfValueContainer, numberOfPoints, numberOfDimensions, indexFunction)
         };
     }
 


### PR DESCRIPTION
`Points::visitSourceData` allows accessing the source data. When either the source data or the derived data (or both) are a subset, `visitSourceData` specifically allows access to that subset.

Internally it is implemented by specifying a custom index function for the range of `PointDataIterator` iterators. The index function specifies how to get the index into the internal raw data buffer.