### PR TITLE
Fix crash when scatterplot is empty and the user attempts to select something

### DIFF
--- a/Scatterplot/src/ScatterplotPlugin.cpp
+++ b/Scatterplot/src/ScatterplotPlugin.cpp
@@ -355,13 +355,14 @@ void ScatterplotPlugin::onSelecting(hdps::Selection selection)
 {
     const Points* const selectionSet = makeSelection(selection);
 
-    if ((selectionSet != nullptr) && (settings != nullptr) && (settings->IsNotifyingOnSelecting()))
+    if (selectionSet != nullptr)
     {
-        _core->notifySelectionChanged(selectionSet->getDataName());
-    }
-    else
-    {
-        updateSelection();
+        // Only notify other plugins of the selection changes if enabled in the settings
+        // This prevents plugins that take a long time to process selections to deteriorate performance
+        if ((settings != nullptr) && settings->IsNotifyingOnSelecting())
+            _core->notifySelectionChanged(selectionSet->getDataName());
+        else
+            updateSelection();
     }
 }
 


### PR DESCRIPTION
This PR relates to PR #56  where the updateSelection() call was added in the end. However, this doesn't work because when there is no dataset displayed the updateSelection call can't request it.

In addition, the updateSelection() call in the else-statement executes essentially the same code as the notifySelectionChanged call in the if-statement. As far as I can see it just cuts out the notification system of the core which shouldn't cost very much.

So therefore I'm not sure what the notifyOnSelectingCheckBox actually changes. Am I missing something?