### PR TITLE
Fixes some mean shift issues

### DIFF
--- a/HDPS/res/shaders/GradientCompute.frag
+++ b/HDPS/res/shaders/GradientCompute.frag
@@ -2,7 +2,7 @@
 
 uniform sampler2D densityTexture;
 
-uniform vec2 renderParams;
+uniform vec4 renderParams;
 
 in vec2 pass_texCoord;
 
@@ -15,19 +15,27 @@ void main()
     float density = texture(densityTexture, pass_texCoord.xy).r;
     if(density < renderParams.y)
     {
-        gradient = vec3(0);
+        gradient = vec3(0.0);
     }
     else
     {
+	    vec3 texelSize = vec3( renderParams.zz, 0.0);
+
         vec4 neighborDensities;
-        neighborDensities.x = textureOffset(densityTexture, pass_texCoord, ivec2(1, 0)).r;
-        neighborDensities.y = textureOffset(densityTexture, pass_texCoord, ivec2(-1, 0)).r;
-        neighborDensities.z = textureOffset(densityTexture, pass_texCoord, ivec2(0, 1)).r;
-        neighborDensities.w = textureOffset(densityTexture, pass_texCoord, ivec2(0, -1)).r;
+        neighborDensities.x = texture(densityTexture, pass_texCoord.xy + texelSize.xz).r;
+        neighborDensities.y = texture(densityTexture, pass_texCoord.xy - texelSize.xz).r;
+        neighborDensities.z = texture(densityTexture, pass_texCoord.xy + texelSize.zy).r;
+        neighborDensities.w = texture(densityTexture, pass_texCoord.xy - texelSize.zy).r;
+        // this does not work as desired when density and gradient textures are of different sizes.
+        // I.e., it is a 1 texel step in the input texture when it is desired in the output texture.
+        //neighborDensities.x = textureOffset(densityTexture, pass_texCoord, ivec2(1, 0)).r;
+        //neighborDensities.y = textureOffset(densityTexture, pass_texCoord, ivec2(-1, 0)).r;
+        //neighborDensities.z = textureOffset(densityTexture, pass_texCoord, ivec2(0, 1)).r;
+        //neighborDensities.w = textureOffset(densityTexture, pass_texCoord, ivec2(0, -1)).r;
         neighborDensities *= renderParams.x;
 
         gradient = vec3(neighborDensities.x - neighborDensities.y, neighborDensities.z - neighborDensities.w, density);
     }
     
-    fragColor = vec4(gradient, 1);
+    fragColor = vec4(gradient, 1.0);
 }

--- a/HDPS/res/shaders/MeanshiftCompute.frag
+++ b/HDPS/res/shaders/MeanshiftCompute.frag
@@ -1,7 +1,7 @@
 #version 330 core
 
-#define EPSILON 0.002
-#define MAX_STEPS 1000
+#define EPSILON 0.001
+#define MAX_STEPS 10000
 
 uniform sampler2D gradientTexture;
 
@@ -15,15 +15,11 @@ void main()
 {
     vec2 texelSize = renderParams.zw;
     
-    vec3 t = texture(gradientTexture, pass_texCoord).xyz;
-    vec2 gradient = t.xy;
-    float density = t.z;
-    float threshold = EPSILON * renderParams.y;
-    
-    float len = length(gradient);
-    
-    if (density < threshold) {
-        fragColor = vec4(0, 0, 0, 1);
+    vec2 gradient = texture(gradientTexture, pass_texCoord).xy;
+
+    if( all(equal(gradient, vec2(0.0))) )
+    {
+        fragColor = vec4(0.0);
         return;
     }
     
@@ -32,14 +28,12 @@ void main()
     int count = 0;
     for (int i = 0; i < MAX_STEPS; i++)
     {
-        vec2 ngradient = texture(gradientTexture, pos).xy;
-        if (dot(ngradient, gradient) < 0) break;
-        gradient = ngradient;
+        gradient = texture(gradientTexture, pos).xy;
+
+        if (length(gradient) < EPSILON) break;
         
-        pos = pos + normalize(gradient) * texelSize;
-        
-        count = i;
+        pos = pos + normalize(gradient) * texelSize * renderParams.x;
     }
 
-    fragColor = vec4(pos, count / (MAX_STEPS-1), 1);
+    fragColor = vec4(pos, 1, 1);
 }

--- a/HDPS/src/util/MeanShift.h
+++ b/HDPS/src/util/MeanShift.h
@@ -31,7 +31,7 @@ public:
     Texture2D& getMeanShiftTexture();
 
 private:
-    const unsigned int RESOLUTION = 512;
+    const unsigned int RESOLUTION = 256;
 
     DensityComputation densityComputation;
 


### PR DESCRIPTION
Fixes some issues in mean shift clustering, particularly in large and unevenly distributed data, that occured due to changes from original implementation.
Adds a postprocessing step that merges clusters where the center (detected density peak) is not included in the cluster, with the corresponding cluster containing the center (This can only happen when the mean shift has not nicely converged to a single peak).