### PR TITLE
Fix conversion warning in PointData.h

### DIFF
--- a/HDPS/src/plugins/PointData/src/PointData.h
+++ b/HDPS/src/plugins/PointData/src/PointData.h
@@ -773,7 +773,7 @@ public:
     void populateDataForDimensions(ResultContainer& resultContainer, const DimensionIndices& dimensionIndices) const
     {
         if (isProxy()) {
-            auto offset = 0;
+            std::size_t offset = 0;
 
             for (auto proxyMember : getProxyMembers()) {
                 auto points = hdps::Dataset<Points>(proxyMember);


### PR DESCRIPTION
Fixes a conversion warning that comes up when building every plugin that uses `populateDataForDimensions`, which is a little annoying since the warning comes from a template function and is therefore very verbose...
