### PR TITLE
Performance issues with dataset picker action

### DIFF
--- a/HDPS/src/DataHierarchyItem.cpp
+++ b/HDPS/src/DataHierarchyItem.cpp
@@ -18,6 +18,7 @@ DataHierarchyItem::DataHierarchyItem(QObject* parent, Dataset<DatasetImpl> datas
     _dataset(dataset),
     _parent(),
     _children(),
+    _fullPathName(),
     _selected(false),
     _expanded(true),
     _taskDescription(""),
@@ -51,6 +52,7 @@ DataHierarchyItem::DataHierarchyItem(QObject* parent, Dataset<DatasetImpl> datas
     });
 
     setVisible(visible);
+    computeFullPathName();
 }
 
 QString DataHierarchyItem::getGuiName() const
@@ -175,7 +177,7 @@ void DataHierarchyItem::deselect()
     setSelected(false);
 }
 
-QString DataHierarchyItem::getFullPathName() const
+void DataHierarchyItem::computeFullPathName()
 {
     DataHierarchyItems parents;
 
@@ -191,7 +193,12 @@ QString DataHierarchyItem::getFullPathName() const
     // Add name of this data hierarchy item
     dataHierarchyItemNames << _dataset->getGuiName();
 
-    return dataHierarchyItemNames.join("/");
+    _fullPathName = dataHierarchyItemNames.join("/");
+}
+
+QString DataHierarchyItem::getFullPathName() const
+{
+    return _fullPathName;
 }
 
 void DataHierarchyItem::addChild(DataHierarchyItem& child)

--- a/HDPS/src/DataHierarchyItem.h
+++ b/HDPS/src/DataHierarchyItem.h
@@ -122,6 +122,9 @@ public:
     /** De-selects the hierarchy item */
     void deselect();
 
+    /** Compute the full path name of the data hierarchy item (separated by forward slashes) */
+    void computeFullPathName();
+
     /** Get the full path name of the data hierarchy item (separated by forward slashes) */
     QString getFullPathName() const;
 
@@ -366,6 +369,7 @@ protected:
     Dataset<DatasetImpl>        _dataset;               /** Smart pointer to dataset */
     DataHierarchyItem*          _parent;                /** Pointer to parent data hierarchy item */
     DataHierarchyItems          _children;              /** Pointers to child items (if any) */
+    QString                     _fullPathName;          /** The full hierarchy path name of the data hiearchy item */
     bool                        _selected;              /** Whether the hierarchy item is selected */
     bool                        _expanded;              /** Whether the item is expanded or not (when it has children) */
     QString                     _taskDescription;       /** Task description */

--- a/HDPS/src/DataHierarchyManager.cpp
+++ b/HDPS/src/DataHierarchyManager.cpp
@@ -22,7 +22,7 @@ DataHierarchyManager::DataHierarchyManager(QObject* parent /*= nullptr*/) :
 
 void DataHierarchyManager::addItem(Dataset<DatasetImpl> dataset, Dataset<DatasetImpl> parentDataset, const bool& visible /*= true*/)
 {
-    qDebug() << "Adding" << dataset->getGuiName() << "to the data hierarchy";
+    //qDebug() << "Adding" << dataset->getGuiName() << "to the data hierarchy";
 
     try {
 
@@ -124,7 +124,7 @@ DataHierarchyItem& DataHierarchyManager::getItem(const QString& datasetGuid)
         Q_ASSERT(!datasetGuid.isEmpty());
 
         for (auto dataHierarchyItem : _items)
-            if (dataHierarchyItem->getDataset().getDatasetGuid() == datasetGuid)
+            if (dataHierarchyItem->getDatasetReference().getDatasetGuid() == datasetGuid)
                 return *dataHierarchyItem;
 
         QString errorMessage = QString("Failed to find data hierarchy item with guid: %1").arg(datasetGuid);

--- a/HDPS/src/MainWindow.cpp
+++ b/HDPS/src/MainWindow.cpp
@@ -31,7 +31,9 @@
 #include <QTimer>
 #include <QLabel>
 
-#define MAIN_WINDOW_VERBOSE
+#ifdef _DEBUG
+    #define MAIN_WINDOW_VERBOSE
+#endif
 
 using namespace ads;
 


### PR DESCRIPTION
The following fixes solve the performance issues:
- The data hierarchy manager `getItem(...)` used to get a data hierarchy item dataset by calling `getDataset()`. This is costly because it creates a temporary smart pointer object that requires core event registering/unregistering. `getDataset()` has been replaced with `getDatasetReference()` which does not suffer from this problem.
- Data hierarchy full path name is now cached
