### PR TITLE
Fix toggle view plugin crash

### DIFF
--- a/HDPS/src/private/LoadedViewsMenu.cpp
+++ b/HDPS/src/private/LoadedViewsMenu.cpp
@@ -61,7 +61,15 @@ QVector<QPointer<ToggleAction>> LoadedViewsMenu::getLoadedViewsActions(bool syst
                 continue;
         }
 
-        actions << &viewPlugin->getVisibleAction();
+        auto action = new ToggleAction(this, viewPlugin->getKind());
+        action->setIcon(viewPlugin->getVisibleAction().icon());
+        action->setChecked(viewPlugin->getVisibleAction().isChecked());
+
+        connect(action, &QAction::toggled, this, [viewPlugin, action]() -> void {
+            viewPlugin->getVisibleAction().toggle();
+            });
+
+        actions << action;
     }
 
     sortActions(actions);


### PR DESCRIPTION
This should fix #288.

`LoadedViewsMenu::getLoadedViewsActions` now works just like `LoadSystemViewMenu::getLoadSystemViewsActions`

I think the underlying issue is somehow connected to [`QMenu::addMenu`](https://doc.qt.io/qt-6/qmenu.html#addMenu) which according to the docs does not take ownership of the new menu it creates. Then, in `ViewMenu::ViewMenu` this somehow creates a memory issue...