### PR TITLE
Comment out loose friend class definition

### DIFF
--- a/HDPS/src/actions/StatusAction.h
+++ b/HDPS/src/actions/StatusAction.h
@@ -132,7 +132,7 @@ protected:
 
     static constexpr std::int32_t MESSAGE_DISAPPEAR_INTERVAL = 1500;   /** Delay after which a message is reset */
 
-    friend class Widget;
+    //friend class Widget;
 };
 
 }


### PR DESCRIPTION
StatusAction defines Widget as a friend class, but StatusAction itself has no widget class. With it commented out the PointData project builds again.