### PR TITLE
Set the full dataset of a subset loaded from project

### DIFF
--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -132,9 +132,13 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
 
     _guid       = variantMap["GUID"].toString();
     _derived    = variantMap["Derived"].toBool();
+    bool full   = variantMap["Full"].toBool();
 
     if (_derived)
         _sourceDataset = getParent();
+
+    if (!full)
+        _fullDataset = getParent()->getFullDataset<hdps::DatasetImpl>();
 
     setStorageType(static_cast<StorageType>(variantMap["StorageType"].toInt()));
 


### PR DESCRIPTION
When loading a subset from a project it doesn't set the _fullDataset variable to anything, so it will refer to itself.
This results in the dataset being unable to determine how many dimensions it has etc.

See lines 938 in PointData.cpp:
`    if (!isFull()) {
        makeSubsetOf(getFullDataset<Points>());`