### PR TITLE
Add custom actions to view plugin hamburger menu

### DIFF
--- a/HDPS/src/ViewPlugin.cpp
+++ b/HDPS/src/ViewPlugin.cpp
@@ -30,7 +30,8 @@ ViewPlugin::ViewPlugin(const PluginFactory* factory) :
     _visibleAction(this, "Visible", true, true),
     _helpAction(this, "Trigger help"),
     _presetsAction(this, this, QString("%1/Presets").arg(getKind()), getKind(), factory->getIcon()),
-    _triggerShortcut()
+    _triggerShortcut(),
+    _titleBarMenuActions()
 {
     setText(getGuiName());
 
@@ -224,6 +225,25 @@ QVariantMap ViewPlugin::toVariantMap() const
     _visibleAction.insertIntoVariantMap(variantMap);
 
     return variantMap;
+}
+
+void ViewPlugin::addTitleBarMenuAction(hdps::gui::WidgetAction* action)
+{
+    Q_ASSERT(action != nullptr);
+
+    _titleBarMenuActions << action;
+}
+
+void ViewPlugin::removeTitleBarMenuAction(hdps::gui::WidgetAction* action)
+{
+    Q_ASSERT(action != nullptr);
+
+    _titleBarMenuActions.removeOne(action);
+}
+
+hdps::gui::WidgetActions ViewPlugin::getTitleBarMenuActions()
+{
+    return _titleBarMenuActions;
 }
 
 ViewPluginFactory::ViewPluginFactory(bool producesSystemViewPlugins /*= false*/) :

--- a/HDPS/src/ViewPlugin.h
+++ b/HDPS/src/ViewPlugin.h
@@ -78,6 +78,26 @@ public:
      */
     virtual void setTriggerShortcut(const QKeySequence& keySequence) final;
 
+public: // Title bar settings menu
+
+    /**
+     * Add action to the title bar menu
+     * @param action Pointer to widget action
+     */
+    void addTitleBarMenuAction(gui::WidgetAction* action);
+
+    /**
+     * Remove action from the title bar menu
+     * @param action Pointer to widget action
+     */
+    void removeTitleBarMenuAction(gui::WidgetAction* action);
+
+    /**
+     * Get title bar actions
+     * @return List of pointers to title bar actions
+     */
+    gui::WidgetActions getTitleBarMenuActions();
+
 public: // Serialization
 
     /**
@@ -106,18 +126,19 @@ public: // Action getters
     gui::PresetsAction& getPresetsAction() { return _presetsAction; }
 
 private:
-    QWidget                 _widget;                /** Widget representation of the plugin */
-    gui::TriggerAction      _editActionsAction;     /** Trigger action to start editing the view plugin action hierarchy */
-    gui::TriggerAction      _screenshotAction;      /** Trigger action to create a screenshot */
-    gui::ToggleAction       _isolateAction;         /** Toggle action to toggle view isolation (when toggled, all other view plugins are temporarily closed) */
-    gui::ToggleAction       _mayCloseAction;        /** Action for toggling whether the view plugin may be closed */
-    gui::ToggleAction       _mayFloatAction;        /** Action for toggling whether the view plugin may float */
-    gui::ToggleAction       _mayMoveAction;         /** Action for toggling whether the view plugin may be moved */
-    gui::LockingAction      _lockingAction;         /** Action for toggling whether the view plugin is locked */
-    gui::ToggleAction       _visibleAction;         /** Action which determines whether the view plugin is visible or not */
-    gui::TriggerAction      _helpAction;            /** Action which triggers documentation */
-    gui::PresetsAction      _presetsAction;         /** Action for managing presets */
-    QKeySequence            _triggerShortcut;       /** Shortcut for triggering the plugin */
+    QWidget                 _widget;                    /** Widget representation of the plugin */
+    gui::TriggerAction      _editActionsAction;         /** Trigger action to start editing the view plugin action hierarchy */
+    gui::TriggerAction      _screenshotAction;          /** Trigger action to create a screenshot */
+    gui::ToggleAction       _isolateAction;             /** Toggle action to toggle view isolation (when toggled, all other view plugins are temporarily closed) */
+    gui::ToggleAction       _mayCloseAction;            /** Action for toggling whether the view plugin may be closed */
+    gui::ToggleAction       _mayFloatAction;            /** Action for toggling whether the view plugin may float */
+    gui::ToggleAction       _mayMoveAction;             /** Action for toggling whether the view plugin may be moved */
+    gui::LockingAction      _lockingAction;             /** Action for toggling whether the view plugin is locked */
+    gui::ToggleAction       _visibleAction;             /** Action which determines whether the view plugin is visible or not */
+    gui::TriggerAction      _helpAction;                /** Action which triggers documentation */
+    gui::PresetsAction      _presetsAction;             /** Action for managing presets */
+    QKeySequence            _triggerShortcut;           /** Shortcut for triggering the plugin */
+    gui::WidgetActions      _titleBarMenuActions;       /** Additional actions which are added to the end of the settings menu of the view plugin title bar */
 };
 
 class ViewPluginFactory : public PluginFactory

--- a/HDPS/src/private/ViewPluginDockWidget.cpp
+++ b/HDPS/src/private/ViewPluginDockWidget.cpp
@@ -28,7 +28,8 @@ ViewPluginDockWidget::ViewPluginDockWidget(const QString& title /*= ""*/, QWidge
     _viewPluginKind(),
     _viewPluginMap(),
     _settingsMenu(),
-    _helpAction(this, "Help")
+    _helpAction(this, "Help"),
+    _cachedVisibility(false)
 {
     active << this;
 
@@ -41,7 +42,9 @@ ViewPluginDockWidget::ViewPluginDockWidget(const QString& title, ViewPlugin* vie
     _viewPlugin(nullptr),
     _viewPluginKind(),
     _viewPluginMap(),
-    _helpAction(this, "Help")
+    _settingsMenu(),
+    _helpAction(this, "Help"),
+    _cachedVisibility(false)
 {
     active << this;
 
@@ -131,6 +134,13 @@ void ViewPluginDockWidget::initialize()
 
         if (!projectIsReadOnly)
             _settingsMenu.addAction(&_viewPlugin->getLockingAction().getLockedAction());
+
+        if (!_viewPlugin->getTitleBarMenuActions().isEmpty()) {
+            _settingsMenu.addSeparator();
+
+            for (auto titleBarMenuAction : _viewPlugin->getTitleBarMenuActions())
+                _settingsMenu.addAction(titleBarMenuAction);
+        }
     });
 }
 
@@ -154,14 +164,9 @@ ViewPlugin* ViewPluginDockWidget::getViewPlugin()
     return _viewPlugin;
 }
 
-QMenu* ViewPluginDockWidget::getSettingsMenu()
-{
-    return &_settingsMenu;
-}
-
 void ViewPluginDockWidget::restoreViewPluginState()
 {
-    if(!_viewPlugin)
+    if (!_viewPlugin)
         return;
 
     _viewPlugin->fromVariantMap(_viewPluginMap);
@@ -170,6 +175,11 @@ void ViewPluginDockWidget::restoreViewPluginStates()
 {
     for (auto viewPluginDockWidget : ViewPluginDockWidget::active)
         viewPluginDockWidget->restoreViewPluginState();
+}
+
+QMenu* ViewPluginDockWidget::getSettingsMenu()
+{
+    return &_settingsMenu;
 }
 
 void ViewPluginDockWidget::fromVariantMap(const QVariantMap& variantMap)

--- a/HDPS/src/private/ViewPluginDockWidget.h
+++ b/HDPS/src/private/ViewPluginDockWidget.h
@@ -13,7 +13,7 @@
  *
  * @author Thomas Kroes
  */
-class ViewPluginDockWidget : public DockWidget
+class ViewPluginDockWidget final : public DockWidget
 {
     Q_OBJECT
 
@@ -61,17 +61,19 @@ public:
      */
     hdps::plugin::ViewPlugin* getViewPlugin();
 
-    /**
-     * Get settings menu for view plugin dock widget (edit view, create screenshot etc.)
-     * @return Pointer to settings menu
-     */
-    QMenu* getSettingsMenu() override;
-
     /** Restores the view plugin state */
     void restoreViewPluginState();
 
     /** Restores the view plugin states of all active view plugins */
     static void restoreViewPluginStates();
+
+public: // Title bar settings menu
+
+    /**
+     * Get settings menu for view plugin dock widget (edit view, create screenshot etc.)
+     * @return Pointer to settings menu
+     */
+    QMenu* getSettingsMenu() override;
 
 public: // Serialization
 


### PR DESCRIPTION
Added an API to add/remove custom actions to the view plugin title bar hamburger menu:

- Use `viewPlugin->addTitleBarMenuAction()` to add a custom action
- Use `viewPlugin->removeTitleBarMenuAction()` to remove a custom action