### PR TITLE
More explicit point data depedency of image data [skip ci]

### DIFF
--- a/HDPS/src/plugins/ImageData/src/ImageData.json
+++ b/HDPS/src/plugins/ImageData/src/ImageData.json
@@ -1,5 +1,5 @@
 {
     "name" : "Images",
     "version" : "1",
-    "dependencies" : ["Points"]
+    "dependencies" : ["Points", "Cluster"]
 }

--- a/HDPS/src/plugins/ImageData/src/Images.cpp
+++ b/HDPS/src/plugins/ImageData/src/Images.cpp
@@ -6,6 +6,7 @@
 #include <util/Timer.h>
 
 #include <DataHierarchyItem.h>
+#include <Dataset.h>
 
 #include <PointData/PointData.h>
 #include <ClusterData/ClusterData.h>
@@ -25,6 +26,11 @@ Images::Images(hdps::CoreInterface* core, QString dataName, const QString& guid 
     _imageData = &getRawData<ImageData>();
 
     setLinkedDataFlags(0);
+
+    if (!getDataHierarchyItem().getParent().getDataset<DatasetImpl>().isValid() ||
+        getDataHierarchyItem().getParent().getDataType() != PointType ||
+        getDataHierarchyItem().getParent().getDataType() != ClusterType)
+        qWarning() << "Images: warning: image data set must be derived from points or clusters.";
 }
 
 void Images::init()
@@ -34,6 +40,29 @@ void Images::init()
     _infoAction = QSharedPointer<InfoAction>::create(nullptr, *this);
 
     addAction(*_infoAction.get());
+}
+
+std::tuple<hdps::Dataset<hdps::DatasetImpl>, hdps::Dataset<Images>> Images::addImageDataset(QString datasetGuiName, const hdps::Dataset<hdps::DatasetImpl>& parentDataSet /*= Dataset<DatasetImpl>()*/, const QString pluginKind /*= "Points"*/)
+{
+    // default to point type
+    QString pkind = "Points";
+    using ptype = Points;
+
+    if (pluginKind == "Cluster")
+    {
+        pkind = "Cluster";
+        using ptype = Clusters;
+    }
+    else if (pluginKind != "Points")
+        qWarning() << "Images::addImageDataset: warning: pluginKind must be Points or Cluster - defaulting to Points. Given: " << pluginKind;
+
+    auto points = Application::core()->addDataset<ptype>(pkind, datasetGuiName, parentDataSet);
+    events().notifyDatasetAdded(points);
+
+    hdps::Dataset<Images> images = Application::core()->addDataset<Images>("Images", "images", Dataset<DatasetImpl>(*points));
+    events().notifyDatasetAdded(images);
+
+    return { points, images };
 }
 
 Dataset<DatasetImpl> Images::createSubsetFromSelection(const QString& guiName, const Dataset<DatasetImpl>& parentDataSet /*= Dataset<DatasetImpl>()*/, const bool& visible /*= true*/) const

--- a/HDPS/src/plugins/ImageData/src/Images.h
+++ b/HDPS/src/plugins/ImageData/src/Images.h
@@ -13,6 +13,7 @@
 #include <QSize>
 
 #include <vector>
+#include <tuple>
 
 using namespace hdps::plugin;
 
@@ -39,6 +40,20 @@ public: // Construction
 
     /** Initializes the dataset */
     void init() override;
+
+    /**
+     * Creates a dataset and derives an image dataset from it:
+     *
+     *      auto [pointDataset, imageDatset] = Images::addImageDataset("My Image", parent);
+     *      auto [clusterDataset, imageDatset] = Images::addImageDataset("My Image", parent, "Cluster");
+     *
+     * This function sends the core event notifications "notifyDatasetAdded" for both pointDataset and imageDatset
+     *
+     * @param datasetGuiName Name of the added dataset in the GUI
+     * @param parentDataSet Smart pointer to the parent dataset in the data hierarchy (root if smart pointer is not valid)
+     * @param pluginKind Either "Points" (default) or "Cluster" to define the data type of the raw value data set
+     */
+    static std::tuple<hdps::Dataset<hdps::DatasetImpl>, hdps::Dataset<Images>> addImageDataset(QString datasetGuiName, const hdps::Dataset<hdps::DatasetImpl>& parentDataSet = hdps::Dataset<hdps::DatasetImpl>(), QString pluginKind = "Points");
 
 public: // Subsets
 


### PR DESCRIPTION
The Image data type implicitly expects that an image data set is a child of another, e.g. a point data set.

Currently, plugins like the image loader have to create both parent and derived image data sets themselves. 
Now you can specify the parent data set type of Image data. Only "Points" (default) and "Cluster" are possible since these are implemented in the ImageData type:
```c++
auto [pointDataset, imageDatset] = Images::addImageDataset("My Image", parent);
auto [clusterDataset, imageDatset] = Images::addImageDataset("My Image", parent, "Cluster");
```
The new `pointDataset` and respective `clusterDataset` is the parent of the `imageDatset`