### PR TITLE
Open Data Hierarchy and Properties when opening Data Loader Preset 

### DIFF
--- a/HDPS/src/private/StartPageGetStartedWidget.cpp
+++ b/HDPS/src/private/StartPageGetStartedWidget.cpp
@@ -168,7 +168,7 @@ void StartPageGetStartedWidget::updateCreateProjectFromDatasetActions()
         const auto subtitle = QString("Import data into new project with %1").arg(viewPluginFactory->getKind());
 
         StartPageAction fromDataStartPageAction(viewPluginFactory->getIcon(), viewPluginFactory->getKind(), subtitle, subtitle, "", [viewPluginFactory]() -> void {
-            projects().newBlankProject();
+            projects().newProject(Qt::AlignRight);
             plugins().requestPlugin(viewPluginFactory->getKind());
         });
 


### PR DESCRIPTION
Whenever I use one of the "Project From Data" presets e.g. to immediately open an image loader, I afterwards manually add the data hierarchy and property plugins. I think many people who'd use the shortcut would to the same. 

I'd suggest to open those two system plugins be default with the "Project From Data" preset.