### PR TITLE
Feature/fix memory leaks

### DIFF
--- a/HDPS/src/private/StartPageActionsWidget.cpp
+++ b/HDPS/src/private/StartPageActionsWidget.cpp
@@ -19,8 +19,7 @@ StartPageActionsWidget::StartPageActionsWidget(QWidget* parent /*= nullptr*/, co
     _layout(),
     _model(this),
     _filterModel(this),
-    _hierarchyWidget(this, "Item", _model, &_filterModel, true, true),
-    _startPageActionDelegate(new StartPageActionDelegate())
+    _hierarchyWidget(this, "Item", _model, &_filterModel, true, true)
 {
     if (!title.isEmpty())
         _layout.addWidget(StartPageContentWidget::createHeaderLabel(title, title));
@@ -47,7 +46,7 @@ StartPageActionsWidget::StartPageActionsWidget(QWidget* parent /*= nullptr*/, co
     auto& treeView = _hierarchyWidget.getTreeView();
 
     treeView.setRootIsDecorated(false);
-    treeView.setItemDelegateForColumn(static_cast<int>(StartPageActionsModel::Column::SummaryDelegate), _startPageActionDelegate.get());
+    treeView.setItemDelegateForColumn(static_cast<int>(StartPageActionsModel::Column::SummaryDelegate), new StartPageActionDelegate(this));
     treeView.setSelectionBehavior(QAbstractItemView::SelectRows);
     treeView.setSelectionMode(QAbstractItemView::SingleSelection);
     treeView.setIconSize(QSize(24, 24));

--- a/HDPS/src/private/StartPageActionsWidget.cpp
+++ b/HDPS/src/private/StartPageActionsWidget.cpp
@@ -19,7 +19,8 @@ StartPageActionsWidget::StartPageActionsWidget(QWidget* parent /*= nullptr*/, co
     _layout(),
     _model(this),
     _filterModel(this),
-    _hierarchyWidget(this, "Item", _model, &_filterModel, true, true)
+    _hierarchyWidget(this, "Item", _model, &_filterModel, true, true),
+    _startPageActionDelegate(new StartPageActionDelegate())
 {
     if (!title.isEmpty())
         _layout.addWidget(StartPageContentWidget::createHeaderLabel(title, title));
@@ -46,7 +47,7 @@ StartPageActionsWidget::StartPageActionsWidget(QWidget* parent /*= nullptr*/, co
     auto& treeView = _hierarchyWidget.getTreeView();
 
     treeView.setRootIsDecorated(false);
-    treeView.setItemDelegateForColumn(static_cast<int>(StartPageActionsModel::Column::SummaryDelegate), new StartPageActionDelegate());
+    treeView.setItemDelegateForColumn(static_cast<int>(StartPageActionsModel::Column::SummaryDelegate), _startPageActionDelegate.get());
     treeView.setSelectionBehavior(QAbstractItemView::SelectRows);
     treeView.setSelectionMode(QAbstractItemView::SingleSelection);
     treeView.setIconSize(QSize(24, 24));

--- a/HDPS/src/private/StartPageActionsWidget.h
+++ b/HDPS/src/private/StartPageActionsWidget.h
@@ -6,6 +6,9 @@
 #include <widgets/HierarchyWidget.h>
 
 #include <QWidget>
+#include <QSharedPointer>
+
+class StartPageActionDelegate;
 
 /**
  * Start page actions widget class
@@ -69,4 +72,5 @@ private:
     StartPageActionsModel           _model;             /** Model which contains start page actions */
     StartPageActionsFilterModel     _filterModel;       /** Model for filtering and sorting start page actions */
     hdps::gui::HierarchyWidget      _hierarchyWidget;   /** Widget for displaying the actions */
+    QSharedPointer<StartPageActionDelegate> _startPageActionDelegate; /** Custom start page action display in _hierarchyWidget */
 };

--- a/HDPS/src/private/StartPageActionsWidget.h
+++ b/HDPS/src/private/StartPageActionsWidget.h
@@ -6,7 +6,6 @@
 #include <widgets/HierarchyWidget.h>
 
 #include <QWidget>
-#include <QSharedPointer>
 
 class StartPageActionDelegate;
 
@@ -72,5 +71,4 @@ private:
     StartPageActionsModel           _model;             /** Model which contains start page actions */
     StartPageActionsFilterModel     _filterModel;       /** Model for filtering and sorting start page actions */
     hdps::gui::HierarchyWidget      _hierarchyWidget;   /** Widget for displaying the actions */
-    QSharedPointer<StartPageActionDelegate> _startPageActionDelegate; /** Custom start page action display in _hierarchyWidget */
 };

--- a/HDPS/src/private/StartPageActionsWidget.h
+++ b/HDPS/src/private/StartPageActionsWidget.h
@@ -7,8 +7,6 @@
 
 #include <QWidget>
 
-class StartPageActionDelegate;
-
 /**
  * Start page actions widget class
  *


### PR DESCRIPTION
I used [valgrind](https://en.wikipedia.org/wiki/Valgrind) with WSL to check for memory leaks. There are a bunch upon closing the application, which are reported somewhat like this
```
==2937== 640 (16 direct, 624 indirect) bytes in 1 blocks are definitely lost in loss record 2,800 of 2,880
==2937==    at 0x4845013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2937==    by 0x4A967C8: StartPageActionsWidget::StartPageActionsWidget(QWidget*, QString const&, bool) (StartPageActionsWidget.cpp:49)
==2937==    by 0x4A8846A: StartPageOpenProjectWidget::StartPageOpenProjectWidget(StartPageContentWidget*) (StartPageOpenProjectWidget.cpp:20)
==2937==    by 0x4A86FB8: StartPageContentWidget::StartPageContentWidget(QWidget*) (StartPageContentWidget.cpp:24)
==2937==    by 0x4A84CA8: StartPageWidget::StartPageWidget(QWidget*) (StartPageWidget.cpp:22)
==2937==    by 0x4A709FC: MainWindow::showEvent(QShowEvent*) (MainWindow.cpp:69)
==2937==    by 0x5B78D27: QWidget::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6.3.1)
==2937==    by 0x5B20A54: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6.3.1)
==2937==    by 0x69980C7: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.3.1)
==2937==    by 0x5B75856: QWidgetPrivate::show_helper() (in /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6.3.1)
==2937==    by 0x5B7886A: QWidgetPrivate::setVisible(bool) (in /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6.3.1)
==2937==    by 0x127621: main (Main.cpp:87)
```

These reports are very detailed, and give you a pretty precise location for where the memory error was caused.

For now I just fixed a single issue which is caused by [QAbstractItemView::setItemDelegateForColumn](https://doc.qt.io/qt-6/qabstractitemview.html#setItemDelegateForColumn), which takes a pointer but does not take ownership of it like many Qt object do (see doc link).

I'll look through some of these issues and push to this PR; for now it'll remain as a draft.