### PR TITLE
Dimensions are not de-serialized properly

### DIFF
--- a/HDPS/src/plugins/PointData/src/DimensionsPickerAction.cpp
+++ b/HDPS/src/plugins/PointData/src/DimensionsPickerAction.cpp
@@ -593,8 +593,8 @@ DimensionsPickerAction::Widget::Widget(QWidget* parent, DimensionsPickerAction* 
     horizontalHeader->setDefaultAlignment(Qt::AlignLeft);
     horizontalHeader->setSortIndicator(2, Qt::DescendingOrder);
 
-    horizontalHeader->resizeSection(1, 85);
-    horizontalHeader->resizeSection(2, 85);
+    //horizontalHeader->resizeSection(1, 85);
+    //horizontalHeader->resizeSection(2, 85);
 
     _tableView.verticalHeader()->hide();
     _tableView.verticalHeader()->setDefaultSectionSize(5);
@@ -614,6 +614,10 @@ DimensionsPickerAction::Widget::Widget(QWidget* parent, DimensionsPickerAction* 
     setLayout(layout);
 
     updateTableViewModel(&dimensionsPickerAction->getProxyModel());
+
+    connect(dimensionsPickerAction, &DimensionsPickerAction::selectedDimensionsChanged, this, [this]() -> void {
+        _tableView.horizontalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
+        });
 }
 
 void DimensionsPickerAction::Widget::updateTableViewModel(QAbstractItemModel* model)
@@ -623,9 +627,7 @@ void DimensionsPickerAction::Widget::updateTableViewModel(QAbstractItemModel* mo
     if (model->rowCount() == 0 || model->columnCount() == 0)
         return;
 
-    auto horizontalHeader = _tableView.horizontalHeader();
-
-    horizontalHeader->setSectionResizeMode(0, QHeaderView::Stretch);
-    horizontalHeader->setSectionResizeMode(1, QHeaderView::Interactive);
-    horizontalHeader->setSectionResizeMode(2, QHeaderView::Interactive);
+    _tableView.horizontalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
+    _tableView.horizontalHeader()->resizeSection(1, 60);
+    _tableView.horizontalHeader()->resizeSection(2, 60);
 }

--- a/HDPS/src/plugins/PointData/src/DimensionsPickerItemModel.cpp
+++ b/HDPS/src/plugins/PointData/src/DimensionsPickerItemModel.cpp
@@ -146,8 +146,8 @@ namespace hdps
                 switch (static_cast<ColumnEnum>(section))
                 {
                 case ColumnEnum::Name: return tr("Name");
-                case ColumnEnum::Mean: return tr("Mean");
-                case ColumnEnum::StandardDeviation: return tr("Standard dev.");
+                case ColumnEnum::Mean: return tr("M");
+                case ColumnEnum::StandardDeviation: return tr("SD");
                 }
             }
         }

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -76,6 +76,7 @@ void PointData::setData(const std::nullptr_t, const std::size_t numPoints, const
 void PointData::setDimensionNames(const std::vector<QString>& dimNames)
 {
     _dimNames = dimNames;
+    _numDimensions = _dimNames.size();
 }
 
 float PointData::getValueAt(const std::size_t index) const
@@ -378,6 +379,8 @@ void Points::init()
 void Points::setData(std::nullptr_t, const std::size_t numPoints, const std::size_t numDimensions)
 {
     getRawData<PointData>().setData(nullptr, numPoints, numDimensions);
+
+    hdps::events().notifyDatasetDataDimensionsChanged(this);
 }
 
 void Points::extractDataForDimension(std::vector<float>& result, const int dimensionIndex) const
@@ -978,12 +981,18 @@ void Points::fromVariantMap(const QVariantMap& variantMap)
         return dimensionNames;
     };
 
+    
+
     std::vector<QString> dimensionNames;
 
     for (const auto dimensionName : fetchDimensionNames())
         dimensionNames.push_back(dimensionName);
 
     setDimensionNames(dimensionNames);
+
+    if (variantMap.contains("Dimensions")) {
+        _dimensionsPickerAction->fromParentVariantMap(variantMap);
+    }
 
     events().notifyDatasetDataChanged(this);
 
@@ -1045,7 +1054,8 @@ QVariantMap Points::toVariantMap() const
     variantMap["Selection"]             = selection;
     variantMap["DimensionNames"]        = rawDataToVariantMap((char*)dimensionsByteArray.data(), dimensionsByteArray.size(), true);
     variantMap["NumberOfDimensions"]    = getNumDimensions();
-
+    variantMap["Dimensions"]            = _dimensionsPickerAction->toVariantMap();
+    
     return variantMap;
 }
 


### PR DESCRIPTION
This PR solves the problem of point dimensions not being de-serialized properly. As it turns out, it is a core problem (with the dimensions picker action and points dataset) and not a problem with the HDF5 loader. As a bonus, selected dimensions are now also serialized properly.