### PR TITLE
Add extra check in action publish to prevent public actions with duplicate names

### DIFF
--- a/HDPS/src/AbstractActionsManager.h
+++ b/HDPS/src/AbstractActionsManager.h
@@ -223,9 +223,10 @@ public: // Linking
      * @param privateAction Pointer to private action to publish
      * @param name Name of the published widget action (if empty, a name choosing dialog will popup)
      * @param recursive Whether to also publish the child actions recursively
+     * @param allowDuplicateName Boolean determining whether publishing will take place when a public with the same name already exists in the public actions database
      * @return Boolean determining whether the action is successfully published or not
      */
-    virtual bool publishPrivateAction(gui::WidgetAction* privateAction, const QString& name = "", bool recursive = true) = 0;
+    virtual bool publishPrivateAction(gui::WidgetAction* privateAction, const QString& name = "", bool recursive = true, bool allowDuplicateName = false) = 0;
 
     /**
      * Connect \p privateAction to \p publicAction

--- a/HDPS/src/actions/WidgetAction.cpp
+++ b/HDPS/src/actions/WidgetAction.cpp
@@ -265,9 +265,9 @@ bool WidgetAction::isConnected() const
     return _publicAction != nullptr;
 }
 
-bool WidgetAction::publish(const QString& name /*= ""*/)
+bool WidgetAction::publish(const QString& name /*= ""*/, bool allowDuplicateName /*= false*/)
 {
-    return hdps::actions().publishPrivateAction(this, name);
+    return hdps::actions().publishPrivateAction(this, name, true, allowDuplicateName);
 }
 
 void WidgetAction::connectToPublicAction(WidgetAction* publicAction, bool recursive)

--- a/HDPS/src/actions/WidgetAction.h
+++ b/HDPS/src/actions/WidgetAction.h
@@ -373,9 +373,10 @@ public: // Connections and publishing
     /**
      * Publish this action so that other actions can connect to it
      * @param name Name of the published widget action (if empty, a configuration dialog will popup)
+     * @param allowDuplicateName Boolean determining whether publishing will take place when a public with the same name already exists in the public actions database
      * @return Boolean determining whether the action is successfully published or not
      */
-    virtual bool publish(const QString& name = "") final;
+    virtual bool publish(const QString& name = "", bool allowDuplicateName = false) final;
 
 protected: 
 

--- a/HDPS/src/private/ActionsManager.h
+++ b/HDPS/src/private/ActionsManager.h
@@ -41,9 +41,10 @@ public:
      * @param privateAction Pointer to private action to publish
      * @param name Name of the published widget action (if empty, a name choosing dialog will popup)
      * @param recursive Whether to also publish the child actions recursively
+     * @param allowDuplicateName Boolean determining whether publishing will take place when a public with the same name already exists in the public actions database
      * @return Boolean determining whether the action is successfully published or not
      */
-    bool publishPrivateAction(gui::WidgetAction* privateAction, const QString& name = "", bool recursive = true) override;
+    bool publishPrivateAction(gui::WidgetAction* privateAction, const QString& name = "", bool recursive = true, bool allowDuplicateName = false) override;
 
 public: // Serialization
 


### PR DESCRIPTION
 I changed the `WidgetAction::publish(...)` API. It now has an argument `allowDuplicateName` which defaults to `false` In this case, an expectation is thrown when a private action is being published with an existing name. When set to true, the publishing process behaves normally but does show a warning in the terminal output.