### PR TITLE
Fix runtime crash in group action

### DIFF
--- a/HDPS/src/actions/GroupAction.cpp
+++ b/HDPS/src/actions/GroupAction.cpp
@@ -125,13 +125,16 @@ void GroupAction::addAction(WidgetAction* action, std::int32_t widgetFlags /*= -
 
     sortActions();
 
-    connect(action, &WidgetAction::configurationFlagToggled, this, [&](const WidgetAction::ConfigurationFlag& configurationFlag, bool set) -> void {
-        // only some configuration flags require an update
-        switch (configurationFlag) {
-        case WidgetAction::ConfigurationFlag::NoLabelInGroup:        [[fallthrough]];
-        case WidgetAction::ConfigurationFlag::ForceCollapsedInGroup:
-            emit actionsChanged(getActions());
-        }
+    QList<std::int32_t> configurationFlagsRequireUpdate{
+        static_cast<std::int32_t>(WidgetAction::ConfigurationFlag::NoLabelInGroup),
+        static_cast<std::int32_t>(WidgetAction::ConfigurationFlag::ForceCollapsedInGroup)
+    };
+
+    connect(action, &WidgetAction::configurationFlagToggled, this, [&, configurationFlagsRequireUpdate](const WidgetAction::ConfigurationFlag& configurationFlag, bool set) -> void {
+        if (!configurationFlagsRequireUpdate.contains(static_cast<std::int32_t>(configurationFlag)))
+            return;
+
+        emit actionsChanged(getActions());
     });
 
     connect(action, &WidgetAction::sortIndexChanged, this, [&](std::int32_t sortIndex) -> void {


### PR DESCRIPTION
In a newer Qt (6.6.0) version and with MSVC 2022 in release mode, the Image Viewer causes a crash in the constructor `ScalarChannelAction::ScalarChannelAction(...)` during
```
_windowLevelAction.setConfigurationFlag(WidgetAction::ConfigurationFlag::ForceCollapsedInGroup);
```
which in turn emits ``configurationFlagToggled``.

This ultimately leads to a nullpointer reference in `GroupAction`. Specifically, I think `QList<std::int32_t> configurationFlagsRequireUpdate` seems to be optimized away since the specific crash occurs in the .contains() call.

