### PR TITLE
Change the QEventLoop to a while processEvents

### DIFF
--- a/HDPS/src/widgets/SplashScreenWidget.cpp
+++ b/HDPS/src/widgets/SplashScreenWidget.cpp
@@ -181,8 +181,10 @@ void SplashScreenWidget::showAnimated()
     connect(animationGroup, &QParallelAnimationGroup::finished, &eventLoop, &QEventLoop::quit);
 
     animationGroup->start();
-
-    eventLoop.exec();
+    
+    while(animationGroup->state() == QAbstractAnimation::Running) {
+      QApplication::processEvents();
+    }
 }
 
 void SplashScreenWidget::closeAnimated()


### PR DESCRIPTION
In the SplashScreen phase when the app is not yet running this is more reliable on macOS