### PR TITLE
Replace private `PointData::VectorHolder` class with `std::variant`

### DIFF
--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -54,7 +54,7 @@ mv::Dataset<DatasetImpl> PointData::createDataSet(const QString& guid /*= ""*/) 
 
 unsigned int PointData::getNumPoints() const
 {
-    return static_cast<unsigned int>(_vectorHolder.size() / _numDimensions);
+    return static_cast<unsigned int>(getSizeOfVector() / _numDimensions);
 }
 
 unsigned int PointData::getNumDimensions() const
@@ -69,7 +69,7 @@ const std::vector<QString>& PointData::getDimensionNames() const
 
 void PointData::setData(const std::nullptr_t, const std::size_t numPoints, const std::size_t numDimensions)
 {
-    _vectorHolder.resize(numPoints * numDimensions);
+    resizeVector(numPoints * numDimensions);
     _numDimensions = static_cast<unsigned int>(numDimensions);
 }
 
@@ -86,19 +86,21 @@ void PointData::setDimensionNames(const std::vector<QString>& dimNames)
 
 float PointData::getValueAt(const std::size_t index) const
 {
-    return _vectorHolder.constVisit<float>([index](const auto& vec)
+    return std::visit([index](const auto& vec)
         {
-            return vec[index];
-        });
+            return static_cast<float>(vec[index]);
+        },
+        _variantOfVectors);
 }
 
 void PointData::setValueAt(const std::size_t index, const float newValue)
 {
-    _vectorHolder.visit([index, newValue](auto& vec)
+    std::visit([index, newValue](auto& vec)
         {
             using value_type = typename std::remove_reference_t<decltype(vec)>::value_type;
             vec[index] = static_cast<value_type>(newValue);
-        });
+        },
+        _variantOfVectors);
 }
 
 void PointData::fromVariantMap(const QVariantMap& variantMap)
@@ -188,35 +190,35 @@ QVariantMap PointData::toVariantMap() const
 {
     QVariantMap rawData;
 
-    const auto typeSpecifier        = _vectorHolder.getElementTypeSpecifier();
-    const auto typeSpecifierName    = _vectorHolder.getElementTypeNames()[static_cast<std::int32_t>(typeSpecifier)];
+    const auto typeSpecifier        = getElementTypeSpecifier();
+    const auto typeSpecifierName    = getElementTypeNames()[static_cast<std::int32_t>(typeSpecifier)];
     const auto typeIndex            = static_cast<std::int32_t>(typeSpecifier);
     const auto numberOfElements     = static_cast<std::uint64_t>(getNumPoints() * getNumDimensions());
 
     switch (typeSpecifier)
     {
         case ElementTypeSpecifier::float32:
-            rawData = rawDataToVariantMap((char*)_vectorHolder.getConstVector<float>().data(), numberOfElements * sizeof(float), true);
+            rawData = rawDataToVariantMap((char*)getConstVector<float>().data(), numberOfElements * sizeof(float), true);
             break;
 
         case ElementTypeSpecifier::bfloat16:
-            rawData = rawDataToVariantMap((char*)_vectorHolder.getConstVector<biovault::bfloat16_t>().data(), numberOfElements * sizeof(biovault::bfloat16_t), true);
+            rawData = rawDataToVariantMap((char*)getConstVector<biovault::bfloat16_t>().data(), numberOfElements * sizeof(biovault::bfloat16_t), true);
             break;
 
         case ElementTypeSpecifier::int16:
-            rawData = rawDataToVariantMap((char*)_vectorHolder.getConstVector<std::int16_t>().data(), numberOfElements * sizeof(std::int16_t), true);
+            rawData = rawDataToVariantMap((char*)getConstVector<std::int16_t>().data(), numberOfElements * sizeof(std::int16_t), true);
             break;
 
         case ElementTypeSpecifier::uint16:
-            rawData = rawDataToVariantMap((char*)_vectorHolder.getConstVector<std::uint16_t>().data(), numberOfElements * sizeof(std::uint16_t), true);
+            rawData = rawDataToVariantMap((char*)getConstVector<std::uint16_t>().data(), numberOfElements * sizeof(std::uint16_t), true);
             break;
 
         case ElementTypeSpecifier::int8:
-            rawData = rawDataToVariantMap((char*)_vectorHolder.getConstVector<std::int8_t>().data(), numberOfElements * sizeof(std::int8_t), true);
+            rawData = rawDataToVariantMap((char*)getConstVector<std::int8_t>().data(), numberOfElements * sizeof(std::int8_t), true);
             break;
 
         case ElementTypeSpecifier::uint8:
-            rawData = rawDataToVariantMap((char*)_vectorHolder.getConstVector<std::uint8_t>().data(), numberOfElements * sizeof(std::uint8_t), true);
+            rawData = rawDataToVariantMap((char*)getConstVector<std::uint8_t>().data(), numberOfElements * sizeof(std::uint8_t), true);
             break;
 
         default:
@@ -237,7 +239,7 @@ void PointData::extractFullDataForDimension(std::vector<float>& result, const in
 
     result.resize(getNumPoints());
 
-    _vectorHolder.constVisit(
+    std::visit(
         [&result, this, dimensionIndex](const auto& vec)
         {
             const auto resultSize = result.size();
@@ -246,7 +248,8 @@ void PointData::extractFullDataForDimension(std::vector<float>& result, const in
             {
                 result[i] = vec[i * _numDimensions + dimensionIndex];
             }
-        });
+        },
+        _variantOfVectors);
 }
 
 
@@ -257,7 +260,7 @@ void PointData::extractFullDataForDimensions(std::vector<mv::Vector2f>& result, 
 
     result.resize(getNumPoints());
 
-    _vectorHolder.constVisit(
+    std::visit(
         [&result, this, dimensionIndex1, dimensionIndex2](const auto& vec)
         {
             const auto resultSize = result.size();
@@ -267,7 +270,8 @@ void PointData::extractFullDataForDimensions(std::vector<mv::Vector2f>& result, 
                 const auto n = i * _numDimensions;
                 result[i].set(vec[n + dimensionIndex1], vec[n + dimensionIndex2]);
             }
-        });
+        },
+        _variantOfVectors);
 }
 
 
@@ -278,7 +282,7 @@ void PointData::extractDataForDimensions(std::vector<mv::Vector2f>& result, cons
 
     result.resize(indices.size());
 
-    _vectorHolder.constVisit(
+    std::visit(
         [&result, this, dimensionIndex1, dimensionIndex2, indices](const auto& vec)
         {
             const auto resultSize = result.size();
@@ -288,7 +292,8 @@ void PointData::extractDataForDimensions(std::vector<mv::Vector2f>& result, cons
                 const auto n = std::size_t{ indices[i] } *_numDimensions;
                 result[i].set(vec[n + dimensionIndex1], vec[n + dimensionIndex2]);
             }
-        });
+        },
+        _variantOfVectors);
 }
 
 Points::Points(mv::CoreInterface* core, QString dataName, const QString& guid /*= ""*/) :

--- a/HDPS/src/plugins/PointData/src/PointData.h
+++ b/HDPS/src/plugins/PointData/src/PointData.h
@@ -22,7 +22,8 @@
 
 #include <array>
 #include <cassert>
-#include <utility> // For tuple.
+#include <utility>
+#include <variant>
 #include <vector>
 
 using namespace mv::plugin;
@@ -53,247 +54,129 @@ class ClusterAction;
 
 class POINTDATA_EXPORT PointData : public mv::plugin::RawData
 {
-private:
-
-    class VectorHolder
+public:
+    enum class ElementTypeSpecifier
     {
-    private:
-        using TupleOfVectors = std::tuple <
-            std::vector<float>,
-            std::vector<biovault::bfloat16_t>,
-            std::vector<std::int16_t>,
-            std::vector<std::uint16_t>,
-            std::vector<std::int8_t>,
-            std::vector<std::uint8_t> >;
-    public:
-        enum class ElementTypeSpecifier
-        {
-            float32,
-            bfloat16,
-            int16,
-            uint16,
-            int8,
-            uint8
-        };
-
-        static constexpr std::array<const char*, std::tuple_size<TupleOfVectors>::value> getElementTypeNames()
-        {
-            return
-            {{
-                "float32",
-                "bfloat16",
-                "int16",
-                "uint16",
-                "int8",
-                "uint8"
-            }};
-        }
-
-    private:
-         // Tuple of vectors. Only the vector whose value_type corresponds to _elementTypeSpecifier
-        // is selected. (The other vector is ignored, and could be cleared.) The vector stores the
-        // point data in dimension-major order
-        // Note: Instead of std::tuple, std::variant (from C++17) might be more appropriate, but at
-        // the moment of writing, C++17 may not yet be enabled system wide.
-        TupleOfVectors _tupleOfVectors;
-
-        // Specifies which vector is selected, based on its value_type.
-        ElementTypeSpecifier _elementTypeSpecifier{};
-
-        // Tries to find the element type specifier that corresponds to ElementType.
-        template <typename ElementType, typename Head, typename... Tail>
-        constexpr static ElementTypeSpecifier recursiveFindElementTypeSpecifier(
-            const std::tuple<Head, Tail...>*,
-            const int temp = 0)
-        {
-            using HeadValueType = typename Head::value_type;
-
-            if (std::is_same<ElementType, HeadValueType>::value)
-            {
-                return static_cast<ElementTypeSpecifier>(temp);
-            }
-            else
-            {
-                constexpr const std::tuple<Tail...>* tailNullptr{ nullptr };
-                return recursiveFindElementTypeSpecifier<ElementType>(tailNullptr, temp + 1);
-            }
-        }
-
-
-        template <typename ElementType>
-        constexpr static ElementTypeSpecifier recursiveFindElementTypeSpecifier(const std::tuple<>*, const int)
-        {
-            return ElementTypeSpecifier{}; // Should not occur!
-        }
-
-        template <typename ReturnType, typename VectorHolderType, typename FunctionObject, typename Head, typename... Tail>
-        static ReturnType recursiveVisit(VectorHolderType& vectorHolder, FunctionObject functionObject, const std::tuple<Head, Tail...>*)
-        {
-            using HeadValueType = typename Head::value_type;
-
-            if (vectorHolder.template isSameElementType<HeadValueType>())
-            {
-                return functionObject(vectorHolder.template getVector<HeadValueType>());
-            }
-            else
-            {
-                constexpr const std::tuple<Tail...>* tailNullptr{nullptr};
-                return recursiveVisit<ReturnType>(vectorHolder, functionObject, tailNullptr);
-            }
-        }
-
-        template <typename ReturnType, typename VectorHolderType, typename FunctionObject>
-        static ReturnType recursiveVisit(VectorHolderType&, FunctionObject&, const std::tuple<>*)
-        {
-            struct VisitException : std::exception
-            {
-                const char* what() const noexcept override
-                {
-                    return "visit error!";
-                }
-            };
-            throw VisitException{};
-        }
-
-    public:
-
-        /// Yields the n-th supported element type.
-        template <std::size_t N>
-        using ElementTypeAt = typename std::tuple_element_t<N, TupleOfVectors>::value_type;
-
-        /// Defaulted default-constructor. Ensures that the element type
-        /// specifier is default-initialized (to "float32").
-        VectorHolder() = default;
-
-        /// Explicit constructor that copies the specified vector into the
-        /// internal data structure. Ensures that the element type specifier
-        /// matches the value type of the vector.
-        template <typename T>
-        explicit VectorHolder(const std::vector<T>& vec)
-            :
-            _elementTypeSpecifier{ getElementTypeSpecifier<T>() }
-        {
-            std::get<std::vector<T>>(_tupleOfVectors) = vec;
-        }
-
-
-        /// Explicit constructor that efficiently "moves" the specified vector
-        /// into the internal data structure. Ensures that the element type
-        /// specifier matches the value type of the vector.
-        template <typename T>
-        explicit VectorHolder(std::vector<T>&& vec)
-            :
-            _elementTypeSpecifier{ getElementTypeSpecifier<T>() }
-        {
-            std::get<std::vector<T>>(_tupleOfVectors) = std::move(vec);
-        }
-
-
-        // Similar to C++17 std::visit.
-        template <typename ReturnType = void, typename FunctionObject>
-        ReturnType constVisit(FunctionObject functionObject) const
-        {
-            constexpr const TupleOfVectors* const tupleNullptr{nullptr};
-            return recursiveVisit<ReturnType>(*this, functionObject, tupleNullptr);
-        }
-
-
-        // Similar to C++17 std::visit.
-        template <typename ReturnType = void, typename FunctionObject>
-        ReturnType visit(FunctionObject functionObject)
-        {
-            constexpr const TupleOfVectors* const tupleNullptr{nullptr};
-            return recursiveVisit<ReturnType>(*this, functionObject, tupleNullptr);
-        }
-
-        template <typename T>
-        static constexpr ElementTypeSpecifier getElementTypeSpecifier()
-        {
-            constexpr const TupleOfVectors* const tupleNullptr{ nullptr };
-            return recursiveFindElementTypeSpecifier<T>(tupleNullptr);
-        }
-
-        template <typename T>
-        bool isSameElementType() const
-        {
-            constexpr auto elementTypeSpecifier = getElementTypeSpecifier<T>();
-            return elementTypeSpecifier == _elementTypeSpecifier;
-        }
-
-        template <typename T>
-        const std::vector<T>& getConstVector() const
-        {
-            // This function should only be used to access the currently selected vector.
-            assert(isSameElementType<T>());
-            return std::get<std::vector<T>>(_tupleOfVectors);
-        }
-
-        template <typename T>
-        const std::vector<T>& getVector() const
-        {
-            return getConstVector<T>();
-        }
-
-        template <typename T>
-        std::vector<T>& getVector()
-        {
-            return const_cast<std::vector<T>&>(getConstVector<T>());
-        }
-
-        /// Just forwarding to the corresponding member function of the currently selected std::vector.
-        std::size_t size() const
-        {
-            return constVisit<std::size_t>([] (const auto& vec){ return vec.size(); });
-        }
-
-        /// Just forwarding to the corresponding member function of the currently selected std::vector.
-        void resize(const std::size_t newSize)
-        {
-            visit([newSize](auto& vec) { vec.resize(newSize); });
-        }
- 
-        /// Just forwarding to the corresponding member function of the currently selected std::vector.
-        void clear()
-        {
-            visit([](auto& vec) { return vec.clear(); });
-        }
-
-        /// Just forwarding to the corresponding member function of the currently selected std::vector.
-        void shrink_to_fit()
-        {
-            visit([](auto& vec) { return vec.shrink_to_fit(); });
-        }
-
-        void setElementTypeSpecifier(const ElementTypeSpecifier elementTypeSpecifier)
-        {
-            _elementTypeSpecifier = elementTypeSpecifier;
-        }
- 
-        ElementTypeSpecifier getElementTypeSpecifier() const
-        {
-            return _elementTypeSpecifier;
-        }
-
-
-        /// Resizes the currently active internal data vector to the specified
-        /// number of elements, and converts the elements of the specified data
-        /// to the internal data element type, by static_cast. 
-        template <typename T>
-        void convertData(const T* const data, const std::size_t numberOfElements)
-        {
-            resize(numberOfElements);
-
-            visit([data](auto& vec)
-            {
-                std::size_t i{};
-                for (auto& elem: vec)
-                {
-                    elem = static_cast<std::remove_reference_t<decltype(elem)>>(data[i]);
-                    ++i;
-                }
-            });
-        }
+        float32,
+        bfloat16,
+        int16,
+        uint16,
+        int8,
+        uint8
     };
+
+private:
+    using VariantOfVectors = std::variant <
+        std::vector<float>,
+        std::vector<biovault::bfloat16_t>,
+        std::vector<std::int16_t>,
+        std::vector<std::uint16_t>,
+        std::vector<std::int8_t>,
+        std::vector<std::uint8_t> >;
+
+    // Sets the index of the specified variant. If the new index is different from the previous one, the value will be reset. 
+    // Inspired by `expand_type` from kmbeutel at
+    // https://www.reddit.com/r/cpp/comments/f8cbzs/creating_stdvariant_based_on_index_at_runtime/?rdt=52905
+    template <typename... Alternatives>
+    static void setIndexOfVariant(std::variant<Alternatives...> var, std::size_t index)
+    {
+        if (index != var.index())
+        {
+            assert(index < sizeof...(Alternatives));
+            const std::variant<Alternatives...> variants[] = { Alternatives{ }... };
+            var = variants[index];
+        }
+    }
+
+
+    // Returns the index of the specified alternative: the position of the alternative type withing the variant.
+    // Inspired by `variant_index` from Bargor at
+    // https://stackoverflow.com/questions/52303316/get-index-by-type-in-stdvariant
+    template<typename Variant, typename Alternative, std::size_t index = 0>
+    static constexpr std::size_t getIndexOfVariantAlternative()
+    {
+        static_assert(index < std::variant_size_v<Variant>);
+
+        if constexpr (std::is_same_v<std::variant_alternative_t<index, Variant>, Alternative>)
+        {
+            return index;
+        }
+        else
+        {
+            return getIndexOfVariantAlternative<Variant, Alternative, index + 1>();
+        }
+    }
+
+
+    template <typename T>
+    static constexpr ElementTypeSpecifier getElementTypeSpecifier()
+    {
+        constexpr auto index = getIndexOfVariantAlternative<VariantOfVectors, std::vector<T>>();
+        return static_cast<ElementTypeSpecifier>(index);
+    }
+
+    template <typename T>
+    const std::vector<T>& getConstVector() const
+    {
+        // This function should only be used to access the currently selected vector.
+        assert(std::holds_alternative<std::vector<T>>(_variantOfVectors));
+        return std::get<std::vector<T>>(_variantOfVectors);
+    }
+
+    template <typename T>
+    const std::vector<T>& getVector() const
+    {
+        return getConstVector<T>();
+    }
+
+    template <typename T>
+    std::vector<T>& getVector()
+    {
+        return const_cast<std::vector<T>&>(getConstVector<T>());
+    }
+
+    /// Returns the size of the std::vector currently held by _variantOfVectors.
+    std::size_t getSizeOfVector() const
+    {
+        return std::visit([](const auto& vec) { return vec.size(); }, _variantOfVectors);
+    }
+
+    /// Resizes the std::vector currently held by _variantOfVectors.
+    void resizeVector(const std::size_t newSize)
+    {
+        std::visit([newSize](auto& vec) { vec.resize(newSize); }, _variantOfVectors);
+    }
+
+    void setElementTypeSpecifier(const ElementTypeSpecifier elementTypeSpecifier)
+    {
+        setIndexOfVariant(_variantOfVectors, static_cast<std::size_t>(elementTypeSpecifier));
+    }
+
+    ElementTypeSpecifier getElementTypeSpecifier() const
+    {
+        return static_cast<ElementTypeSpecifier>(_variantOfVectors.index());
+    }
+
+
+    /// Resizes the currently held data vector to the specified
+    /// number of elements, and converts the elements of the specified data
+    /// to the internal data element type, by static_cast. 
+    template <typename T>
+    void convertData(const T* const data, const std::size_t numberOfElements)
+    {
+        std::visit([data, numberOfElements](auto& vec)
+        {
+            vec.resize(numberOfElements);
+
+            std::size_t i{};
+            for (auto& elem: vec)
+            {
+                elem = static_cast<std::remove_reference_t<decltype(elem)>>(data[i]);
+                ++i;
+            }
+        },
+        _variantOfVectors);
+    }
 
 
     template <typename DimensionIndex>
@@ -313,12 +196,10 @@ private:
     }
 
 public:
-    using ElementTypeSpecifier = VectorHolder::ElementTypeSpecifier;
-
     /// Yields the n-th supported element type. Corresponds to the n-th entry
     /// in the array of type names, returned by getElementTypeNames().
     template <std::size_t N>
-    using ElementTypeAt = VectorHolder::ElementTypeAt<N>;
+    using ElementTypeAt = typename std::variant_alternative_t<N, VariantOfVectors>::value_type;
 
     PointData(PluginFactory* factory) : RawData(factory, PointType) { }
     ~PointData(void) override;
@@ -338,7 +219,7 @@ public:
     std::uint64_t getRawDataSize() const {
         std::uint64_t elementSize = 0u;
 
-        switch (_vectorHolder.getElementTypeSpecifier())
+        switch (getElementTypeSpecifier())
         {
             case ElementTypeSpecifier::float32:
                 elementSize = 4u;
@@ -362,24 +243,39 @@ public:
         return elementSize * getNumPoints() * getNumDimensions();
     }
 
+    static constexpr std::array<const char*, std::variant_size_v<VariantOfVectors>> getElementTypeNames()
+    {
+        return
+        { {
+            "float32",
+            "bfloat16",
+            "int16",
+            "uint16",
+            "int8",
+            "uint8"
+        } };
+    }
+
     // Similar to C++17 std::visit.
     template <typename ReturnType = void, typename FunctionObject>
     ReturnType constVisitFromBeginToEnd(FunctionObject functionObject) const
     {
-        return _vectorHolder.constVisit<ReturnType>([functionObject](const auto& vec)
+        return std::visit([functionObject](const auto& vec) -> ReturnType
             {
                 return functionObject(std::cbegin(vec), std::cend(vec));
-            });
+            },
+            _variantOfVectors);
     }
 
     // Similar to C++17 std::visit.
     template <typename ReturnType = void, typename FunctionObject>
     ReturnType visitFromBeginToEnd(FunctionObject functionObject)
     {
-        return _vectorHolder.visit<ReturnType>([functionObject](auto& vec)
+        return std::visit([functionObject](auto& vec) -> ReturnType
             {
                 return functionObject(std::begin(vec), std::end(vec));
-            });
+            },
+            _variantOfVectors);
     }
 
     void extractFullDataForDimension(std::vector<float>& result, const int dimensionIndex) const;
@@ -390,7 +286,7 @@ public:
     void populateFullDataForDimensions(ResultContainer& resultContainer, const DimensionIndices& dimensionIndices) const
     {
         CheckDimensionIndices(dimensionIndices);
-        _vectorHolder.constVisit([&resultContainer, this, &dimensionIndices](const auto& vec)
+        std::visit([&resultContainer, this, &dimensionIndices](const auto& vec)
             {
                 const std::ptrdiff_t numPoints{ getNumPoints() };
                 std::ptrdiff_t resultIndex{};
@@ -405,7 +301,8 @@ public:
                         ++resultIndex;
                     }
                 }
-            });
+            },
+            _variantOfVectors);
     }
 
     template <typename ResultContainer, typename DimensionIndices, typename Indices>
@@ -413,7 +310,7 @@ public:
     {
         CheckDimensionIndices(dimensionIndices);
 
-        _vectorHolder.constVisit([&resultContainer, this, &dimensionIndices, &indices](const auto& vec)
+        std::visit([&resultContainer, this, &dimensionIndices, &indices](const auto& vec)
             {
                 const std::ptrdiff_t numPoints{ static_cast<std::uint32_t>(indices.size()) };
                 std::ptrdiff_t resultIndex{};
@@ -428,36 +325,27 @@ public:
                         ++resultIndex;
                     }
                 }
-            });
+            },
+            _variantOfVectors);
     }
 
     const std::vector<QString>& getDimensionNames() const;
 
-    static constexpr auto getElementTypeNames()
-    {
-        return VectorHolder::getElementTypeNames();
-    }
-
     /// Returns the number of types, supported as element type of the internal data storage. 
     static constexpr auto getNumberOfSupportedElementTypes()
     {
-        return VectorHolder::getElementTypeNames().size();
+        return getElementTypeNames().size();
     }
 
     void setElementType(const ElementTypeSpecifier elementTypSpecifier)
     {
-        if (_vectorHolder.getElementTypeSpecifier() != elementTypSpecifier)
-        {
-            _vectorHolder.clear();
-            _vectorHolder.shrink_to_fit();
-            _vectorHolder.setElementTypeSpecifier(elementTypSpecifier);
-        }
+        setElementTypeSpecifier(elementTypSpecifier);
     }
 
     template <typename T>
     void setElementType()
     {
-        constexpr auto elementTypSpecifier = VectorHolder::getElementTypeSpecifier<T>();
+        constexpr auto elementTypSpecifier = getElementTypeSpecifier<T>();
         setElementType(elementTypSpecifier);
     }
 
@@ -469,7 +357,7 @@ public:
     template <typename T>
     void convertData(const T* const data, const std::size_t numPoints, const std::size_t numDimensions)
     {
-        _vectorHolder.convertData(data, numPoints * numDimensions);
+        convertData(data, numPoints * numDimensions);
         _numDimensions = static_cast<std::uint32_t>(numDimensions);
     }
 
@@ -479,7 +367,7 @@ public:
     template <typename T>
     void convertData(const T& inputDataContainer, const std::size_t numDimensions)
     {
-        _vectorHolder.convertData(inputDataContainer.data(), inputDataContainer.size());
+        convertData(inputDataContainer.data(), inputDataContainer.size());
         _numDimensions = static_cast<std::uint32_t>(numDimensions);
     }
 
@@ -489,7 +377,7 @@ public:
     template <typename T>
     void setData(const T* const data, const std::size_t numPoints, const std::size_t numDimensions)
     {
-         _vectorHolder = VectorHolder( std::vector<T>(data, data + numPoints * numDimensions) );
+         _variantOfVectors = VariantOfVectors( std::vector<T>(data, data + numPoints * numDimensions) );
          _numDimensions = static_cast<std::uint32_t>(numDimensions);
     }
 
@@ -504,7 +392,7 @@ public:
     template <typename T>
     void setData(const std::vector<T>& data, const std::size_t numDimensions)
     {
-        _vectorHolder = VectorHolder(data);
+        _variantOfVectors = VariantOfVectors(data);
         _numDimensions = static_cast<unsigned int>(numDimensions);
     }
 
@@ -514,7 +402,7 @@ public:
     template <typename T>
     void setData(std::vector<T>&& data, const std::size_t numDimensions)
     {
-        _vectorHolder = VectorHolder(std::move(data));
+        _variantOfVectors = VariantOfVectors(std::move(data));
         _numDimensions = static_cast<unsigned int>(numDimensions);
     }
 
@@ -545,7 +433,7 @@ public:
     virtual QVariantMap toVariantMap() const final;
 
 private:
-    VectorHolder _vectorHolder;
+    VariantOfVectors _variantOfVectors;
 
     /** Number of features of each data point */
     unsigned int _numDimensions = 1;


### PR DESCRIPTION
`PointData::VectorHolder` "mimicked" a C++17 `std::variant` of `std::vector` types. Now that the ManiVault core is upgraded to C++17, it is preferred to use `std::variant` instead, to ease further maintenance.

Note that this commit does not change the interface (the API) of `PointData`. It is basically just a code clean-up!

----
Supersedes pull request https://github.com/ManiVaultStudio/core/pull/439 (without any code changes)