### PR TITLE
Save analysis plugins in projects

### DIFF
--- a/HDPS/src/AbstractPluginManager.h
+++ b/HDPS/src/AbstractPluginManager.h
@@ -63,7 +63,7 @@ public: // Plugin creation/destruction
      * @param datasets Zero or more datasets upon which the plugin is based (e.g. analysis plugin)
      * @return Pointer to created plugin (nullptr if creation failed)
      */
-    virtual plugin::Plugin* requestPlugin(const QString& kind, Datasets datasets = Datasets()) = 0;
+    virtual plugin::Plugin* requestPlugin(const QString& kind, Datasets inputDatasets = Datasets(), Datasets outputDatasets = Datasets()) = 0;
 
     /**
      * Create a plugin of \p kind with \p inputDatasets
@@ -72,9 +72,9 @@ public: // Plugin creation/destruction
      * @return Pointer to created plugin of plugin type (nullptr if creation failed)
      */
     template<typename PluginType>
-    PluginType* requestPlugin(const QString& kind, Datasets datasets = Datasets())
+    PluginType* requestPlugin(const QString& kind, Datasets inputDatasets = Datasets(), Datasets outputDatasets = Datasets())
     {
-        return dynamic_cast<PluginType*>(requestPlugin(kind, datasets));
+        return dynamic_cast<PluginType*>(requestPlugin(kind, inputDatasets, outputDatasets));
     }
 
     /**

--- a/HDPS/src/AnalysisPlugin.cpp
+++ b/HDPS/src/AnalysisPlugin.cpp
@@ -23,31 +23,52 @@ void AnalysisPlugin::setObjectName(const QString& name)
     QObject::setObjectName("Plugins/Analysis/" + name);
 }
 
-void AnalysisPlugin::setInputDataset(Dataset<DatasetImpl> inputDataset)
+void AnalysisPlugin::setInputDataset(const Dataset<DatasetImpl>& inputDataset)
 {
-    _input = inputDataset;
+    setInputDatasets({ inputDataset });
 }
 
-void AnalysisPlugin::setOutputDataset(Dataset<DatasetImpl> outputDataset)
+void AnalysisPlugin::setInputDatasets(const Datasets& inputDatasets)
 {
-    _output = outputDataset;
-    outputDataset->setAnalysis(this);
+    _input = inputDatasets;
+}
+
+void AnalysisPlugin::setOutputDataset(const Dataset<DatasetImpl>& outputDataset)
+{
+    setOutputDatasets({ outputDataset });
+}
+
+void AnalysisPlugin::setOutputDatasets(const Datasets& outputDatasets)
+{
+    _output = outputDatasets;
+
+    for(auto& output : _output)
+        output->setAnalysis(this);
 }
 
 void AnalysisPlugin::fromVariantMap(const QVariantMap& variantMap)
 {
     Plugin::fromVariantMap(variantMap);
 
-    mv::util::variantMapMustContain(variantMap, "inputDatasetGUID");
-    mv::util::variantMapMustContain(variantMap, "outputDatasetGUID");
+    // _input and _output are set before fromVariantMap is called 
+    // in PluginManager::requestPlugin()
+    // since they might be used in the init() function
 }
 
 QVariantMap AnalysisPlugin::toVariantMap() const
 {
     auto variantMap = Plugin::toVariantMap();
 
-    variantMap["inputDatasetGUID"] = _input->getId();
-    variantMap["outputDatasetGUID"] = _output->getId();
+    QVariantList inputDatasetsGUIDs, outputDatasetsGUIDs;
+
+    for (auto& input : _input)
+        inputDatasetsGUIDs << input->getId();
+
+    for (auto& output : _output)
+        outputDatasetsGUIDs << output->getId();
+
+    variantMap["inputDatasetsGUIDs"] = inputDatasetsGUIDs;
+    variantMap["outputDatasetsGUIDs"] = outputDatasetsGUIDs;
 
     return variantMap;
 }

--- a/HDPS/src/AnalysisPlugin.cpp
+++ b/HDPS/src/AnalysisPlugin.cpp
@@ -31,6 +31,25 @@ void AnalysisPlugin::setInputDataset(Dataset<DatasetImpl> inputDataset)
 void AnalysisPlugin::setOutputDataset(Dataset<DatasetImpl> outputDataset)
 {
     _output = outputDataset;
+    outputDataset->setAnalysis(this);
+}
+
+void AnalysisPlugin::fromVariantMap(const QVariantMap& variantMap)
+{
+    Plugin::fromVariantMap(variantMap);
+
+    mv::util::variantMapMustContain(variantMap, "inputDatasetGUID");
+    mv::util::variantMapMustContain(variantMap, "outputDatasetGUID");
+}
+
+QVariantMap AnalysisPlugin::toVariantMap() const
+{
+    auto variantMap = Plugin::toVariantMap();
+
+    variantMap["inputDatasetGUID"] = _input->getId();
+    variantMap["outputDatasetGUID"] = _output->getId();
+
+    return variantMap;
 }
 
 QIcon AnalysisPluginFactory::getIcon(const QColor& color /*= Qt::black*/) const

--- a/HDPS/src/AnalysisPlugin.h
+++ b/HDPS/src/AnalysisPlugin.h
@@ -55,6 +55,20 @@ public:
         return Dataset<DatasetType>(_output.get<DatasetType>());
     }
 
+public: // Serialization
+
+    /**
+     * Load view plugin from variant
+     * @param Variant representation of the view plugin
+     */
+    void fromVariantMap(const QVariantMap& variantMap) override;
+
+    /**
+     * Save view plugin to variant
+     * @return Variant representation of the view plugin
+     */
+    QVariantMap toVariantMap() const override;
+
 protected:
     Dataset<DatasetImpl>    _input;       /** Input dataset smart pointer */
     Dataset<DatasetImpl>    _output;      /** Output dataset smart pointer */

--- a/HDPS/src/AnalysisPlugin.h
+++ b/HDPS/src/AnalysisPlugin.h
@@ -35,24 +35,53 @@ public:
      * Set input dataset smart pointer
      * @param inputDataset Smart pointer to the input dataset
      */
-    void setInputDataset(Dataset<DatasetImpl> inputDataset);
+    void setInputDataset(const Dataset<DatasetImpl>& inputDataset);
+
+    /**
+     * Set input datasets smart pointers
+     * @param inputDatasets Vector of smart pointers to the input datasets
+     */
+    void setInputDatasets(const Datasets& inputDatasets);
 
     /** Get input dataset smart pointer */
     template<typename DatasetType = DatasetImpl>
     Dataset<DatasetType> getInputDataset() {
-        return Dataset<DatasetType>(_input.get<DatasetType>());
+        if (_input.size() > 0)
+            return Dataset<DatasetType>(_input[0].get<DatasetType>());
+        else
+            return Dataset<DatasetImpl>();
+
+    }
+
+    /** Get input dataset smart pointer vector */
+    Datasets getInputDatasets() {
+        return _input;
     }
 
     /**
      * Set output dataset smart pointer
      * @param outputDataset Smart pointer to output dataset
      */
-    void setOutputDataset(Dataset<DatasetImpl> outputDataset);
+    void setOutputDataset(const Dataset<DatasetImpl>& outputDataset);
+
+    /**
+     * Set output datasets smart pointers
+     * @param outputDatasets Vector of smart pointers to output datasets
+     */
+    void setOutputDatasets(const Datasets& outputDatasets);
 
     /** Get output dataset smart pointer */
     template<typename DatasetType = DatasetImpl>
     Dataset<DatasetType> getOutputDataset() {
-        return Dataset<DatasetType>(_output.get<DatasetType>());
+        if (_output.size() > 0)
+            return Dataset<DatasetType>(_output[0].get<DatasetType>());
+        else
+            return Dataset<DatasetImpl>();
+    }
+
+    /** Get output dataset smart pointers */
+    Datasets getOutputDatasets() {
+        return _output;
     }
 
 public: // Serialization
@@ -70,8 +99,12 @@ public: // Serialization
     QVariantMap toVariantMap() const override;
 
 protected:
-    Dataset<DatasetImpl>    _input;       /** Input dataset smart pointer */
-    Dataset<DatasetImpl>    _output;      /** Output dataset smart pointer */
+    /** Returns whether any output dataset is given */
+    bool outputDataInit() const { return _output.size() > 0; }
+
+protected:
+    Datasets    _input;       /** Input datasets smart pointers */
+    Datasets    _output;      /** Output datasets smart pointers */
 };
 
 class AnalysisPluginFactory : public PluginFactory

--- a/HDPS/src/DatasetPrivate.cpp
+++ b/HDPS/src/DatasetPrivate.cpp
@@ -2,11 +2,12 @@
 // A corresponding LICENSE file is located in the root directory of this source tree 
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
-#include "DatasetPrivate.h"
-#include "CoreInterface.h"
-#include "event/Event.h"
 #include "Application.h"
+#include "CoreInterface.h"
+#include "DatasetPrivate.h"
 #include "Set.h"
+
+#include "event/Event.h"
 
 #include <QMetaMethod>
 

--- a/HDPS/src/LinkedData.h
+++ b/HDPS/src/LinkedData.h
@@ -8,8 +8,6 @@
 
 #include "util/Serializable.h"
 
-#include <QString>
-
 #include <map>
 #include <vector>
 
@@ -115,11 +113,6 @@ private:
     Dataset<DatasetImpl>    _sourceDataSet;
     Dataset<DatasetImpl>    _targetDataSet;
     SelectionMap            _mapping;
-};
-
-class IndexLinkedData
-{
-
 };
 
 }

--- a/HDPS/src/PluginFactory.cpp
+++ b/HDPS/src/PluginFactory.cpp
@@ -3,8 +3,8 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "PluginFactory.h"
+
 #include "Set.h"
-#include "actions/PluginTriggerAction.h"
 
 namespace mv
 {
@@ -122,7 +122,7 @@ QStringList PluginFactory::getDatasetTypesAsStringList(const Datasets& datasets)
 {
     QStringList datasetTypes;
 
-    for (auto dataset : datasets)
+    for (const auto& dataset : datasets)
         datasetTypes << dataset->getDataType().getTypeString();
 
     return datasetTypes;
@@ -130,7 +130,7 @@ QStringList PluginFactory::getDatasetTypesAsStringList(const Datasets& datasets)
 
 bool PluginFactory::areAllDatasetsOfTheSameType(const Datasets& datasets, const DataType& dataType)
 {
-    for (auto dataset : datasets)
+    for (const auto& dataset : datasets)
         if (dataset->getDataType() != dataType)
             return false;
 
@@ -141,7 +141,7 @@ std::uint16_t PluginFactory::getNumberOfDatasetsForType(const Datasets& datasets
 {
     std::uint16_t numberOfDatasetsForType = 0;
 
-    for (auto dataset : datasets)
+    for (const auto& dataset : datasets)
         if (dataset->getDataType() == dataType)
             numberOfDatasetsForType++;
 

--- a/HDPS/src/PluginFactory.h
+++ b/HDPS/src/PluginFactory.h
@@ -5,16 +5,17 @@
 #ifndef HDPS_PLUGINFACTORY_H
 #define HDPS_PLUGINFACTORY_H
 
-#include "PluginType.h"
-#include "DataType.h"
 #include "Dataset.h"
+#include "DataType.h"
+#include "PluginType.h"
+
 #include "actions/PluginTriggerAction.h"
 
-#include <QObject>
-#include <QIcon>
-#include <QVariant>
 #include <QAction>
+#include <QIcon>
+#include <QObject>
 #include <QPointer>
+#include <QVariant>
 
 namespace mv
 {
@@ -22,8 +23,6 @@ namespace mv
 
     namespace gui
     {
-        class PluginTriggerAction;
-
         using PluginTriggerActions = QVector<QPointer<PluginTriggerAction>>;
     }
 

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -137,7 +137,7 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
 
     if (variantMap["Derived"].toBool())
     {
-        setSourceDataSet(mv::data().getSet(variantMap["SourceDatasetGUID"].toString());
+        setSourceDataSet(mv::data().getSet(variantMap["SourceDatasetGUID"].toString()));
 
         assert(_sourceDataset.isValid());
     }

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -4,17 +4,15 @@
 
 #include "Set.h"
 
+#include "AnalysisPlugin.h"
 #include "CoreInterface.h"
 #include "DataHierarchyItem.h"
-#include "AnalysisPlugin.h"
 
-#include "util/Serialization.h"
-#include "util/Icon.h"
 #include "util/Exception.h"
+#include "util/Icon.h"
+#include "util/Serialization.h"
 
 #include "Application.h"
-
-#include <QPainter>
 
 using namespace mv::gui;
 using namespace mv::util;

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -135,8 +135,9 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     setText(variantMap["Name"].toString());
     setLocked(variantMap["Locked"].toBool());
 
-    _derived    = variantMap["Derived"].toBool();
-    bool full   = variantMap["Full"].toBool();
+    _derived            = variantMap["Derived"].toBool();
+    bool full           = variantMap["Full"].toBool();
+    bool hasAnalysis    = variantMap["HasAnalysis"].toBool();
 
     if (_derived)
         _sourceDataset = getParent();
@@ -155,12 +156,26 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
         setProxyMembers(proxyMembers);
     }
 
-    for (auto linkedDataVariant : variantMap["LinkedData"].toList()) {
+    for (const auto& linkedDataVariant : variantMap["LinkedData"].toList()) {
         LinkedData linkedData;
 
         linkedData.fromVariantMap(linkedDataVariant.toMap());
 
         getLinkedData().push_back(linkedData);
+    }
+
+    if (hasAnalysis)
+    {
+        auto analysisPluginMap = variantMap["Analysis"].toMap();
+
+        variantMapMustContain(analysisPluginMap, "Kind");
+        variantMapMustContain(analysisPluginMap, "inputDatasetGUID");
+        variantMapMustContain(analysisPluginMap, "outputDatasetGUID");
+
+        auto analysisPluginKind = analysisPluginMap["Kind"].toString();
+
+        _analysis = dynamic_cast<plugin::AnalysisPlugin*>(plugins().requestPlugin(analysisPluginKind, { mv::data().getSet(analysisPluginMap["inputDatasetGUID"].toString()) }, { mv::data().getSet(analysisPluginMap["outputDatasetGUID"].toString()) }));
+        _analysis->fromVariantMap(analysisPluginMap);
     }
 }
 

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -130,6 +130,7 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     variantMapMustContain(variantMap, "LinkedData");
     variantMapMustContain(variantMap, "SourceDatasetGUID");
     variantMapMustContain(variantMap, "FullDatasetGUID");
+    variantMapMustContain(variantMap, "GroupIndex");
 
     setText(variantMap["Name"].toString());
     setLocked(variantMap["Locked"].toBool());
@@ -140,6 +141,8 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     if (_derived)
         _sourceDataset = Application::core()->requestDataset(variantMap["SourceDatasetGUID"].toString());
 
+    if (variantMap["GroupIndex"].toInt() >= 0)
+        setGroupIndex(variantMap["GroupIndex"].toInt());
     if (!_all)
         _fullDataset = Application::core()->requestDataset(variantMap["FullDatasetGUID"].toString());
 

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -135,16 +135,27 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     setText(variantMap["Name"].toString());
     setLocked(variantMap["Locked"].toBool());
 
-    _derived    = variantMap["Derived"].toBool();
-    _all        = variantMap["Full"].toBool();
+    if (variantMap["Derived"].toBool())
+    {
+        setSourceDataSet(mv::data().getSet(variantMap["SourceDatasetGUID"].toString());
 
-    if (_derived)
-        _sourceDataset = Application::core()->requestDataset(variantMap["SourceDatasetGUID"].toString());
+        assert(_sourceDataset.isValid());
+    }
+
+    if (!variantMap["Full"].toBool())
+    {
+        makeSubsetOf(mv::data().getSet(variantMap["FullDatasetGUID"].toString()));
+
+        assert(variantMap["PluginKind"].toString() == _rawData->getKind());
+        assert(variantMap["PluginVersion"].toString() == _rawData->getVersion());
+
+        assert(_fullDataset.isValid());
+    }
+
+    assert(variantMap["DataType"].toString() == getDataType().getTypeString());
 
     if (variantMap["GroupIndex"].toInt() >= 0)
         setGroupIndex(variantMap["GroupIndex"].toInt());
-    if (!_all)
-        _fullDataset = Application::core()->requestDataset(variantMap["FullDatasetGUID"].toString());
 
     setStorageType(static_cast<StorageType>(variantMap["StorageType"].toInt()));
 

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -125,6 +125,7 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
 
     variantMapMustContain(variantMap, "Name");
     variantMapMustContain(variantMap, "Locked");
+    variantMapMustContain(variantMap, "Full");
     variantMapMustContain(variantMap, "Derived");
     variantMapMustContain(variantMap, "LinkedData");
     variantMapMustContain(variantMap, "SourceDatasetGUID");
@@ -134,12 +135,11 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     setLocked(variantMap["Locked"].toBool());
 
     _derived    = variantMap["Derived"].toBool();
-    bool full   = variantMap["Full"].toBool();
+    _all        = variantMap["Full"].toBool();
 
     if (_derived)
         _sourceDataset = Application::core()->requestDataset(variantMap["SourceDatasetGUID"].toString());
 
-    if (!full)
     if (!_all)
         _fullDataset = Application::core()->requestDataset(variantMap["FullDatasetGUID"].toString());
 
@@ -186,6 +186,7 @@ QVariantMap DatasetImpl::toVariantMap() const
         { "PluginKind", QVariant::fromValue(_rawData->getKind()) },
         { "PluginVersion", QVariant::fromValue(_rawData->getVersion()) },
         { "Derived", QVariant::fromValue(isDerivedData()) },
+        { "Full", QVariant::fromValue(isFull()) },
         { "SourceDatasetGUID", isDerivedData() ? QVariant::fromValue(_sourceDataset->getId()) : "" },
         { "FullDatasetGUID", isFull() ? "" : QVariant::fromValue(_fullDataset->getId()) },
         { "GroupIndex", QVariant::fromValue(getGroupIndex()) },
@@ -289,7 +290,7 @@ DatasetImpl::DatasetImpl(CoreInterface* core, const QString& rawDataName, const 
     _storageType(StorageType::Owner),
     _rawData(nullptr),
     _rawDataName(rawDataName),
-    _all(false),
+    _all(true),
     _derived(false),
     _sourceDataset(),
     _properties(),

--- a/HDPS/src/Set.h
+++ b/HDPS/src/Set.h
@@ -5,10 +5,10 @@
 #ifndef HDPS_DATASET_H
 #define HDPS_DATASET_H
 
-#include "RawData.h"
+#include "CoreInterface.h"
 #include "Dataset.h"
 #include "LinkedData.h"
-#include "CoreInterface.h"
+#include "RawData.h"
 
 #include "DatasetTask.h"
 #include "ForegroundTask.h"
@@ -18,8 +18,8 @@
 #include "util/Miscellaneous.h"
 
 #include <QString>
-#include <QVector>
 #include <QUuid>
+#include <QVector>
 
 #include <memory>
 

--- a/HDPS/src/TransformationPlugin.cpp
+++ b/HDPS/src/TransformationPlugin.cpp
@@ -28,6 +28,11 @@ void TransformationPlugin::setInputDatasets(const Datasets& inputDatasets)
     _inputDatasets = inputDatasets;
 }
 
+void TransformationPlugin::setInputDataset(const Dataset<DatasetImpl>& inputDataset)
+{
+    setInputDatasets({ inputDataset });
+}
+
 TransformationPluginFactory::TransformationPluginFactory() :
     PluginFactory(Type::TRANSFORMATION)
 {

--- a/HDPS/src/TransformationPlugin.h
+++ b/HDPS/src/TransformationPlugin.h
@@ -40,10 +40,28 @@ public:
     Datasets getInputDatasets() const;
     
     /**
+     * Get first input dataset
+     * @return First input dataset
+     */
+    template<typename DatasetType = DatasetImpl>
+    Dataset<DatasetType> getInputDataset() {
+        if (_inputDatasets.size() > 0)
+            return Dataset<DatasetType>(_inputDatasets[0].get<DatasetType>());
+        else
+            return Dataset<DatasetImpl>();
+    }
+
+    /**
      * Set input datasets
      * @inputDatasets Input datasets
      */
     void setInputDatasets(const Datasets& inputDatasets);
+
+    /**
+     * Set a single input dataset
+     * @param inputDataset Smart pointer to the input dataset
+     */
+    void setInputDataset(const Dataset<DatasetImpl>& inputDataset);
 
 private:
     Datasets    _inputDatasets;        /** One, or more, input dataset */

--- a/HDPS/src/WriterPlugin.cpp
+++ b/HDPS/src/WriterPlugin.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "WriterPlugin.h"
+
 #include "Application.h"
 
 namespace mv
@@ -17,9 +18,14 @@ WriterPlugin::WriterPlugin(const PluginFactory* factory) :
 
 }
 
-void WriterPlugin::setInputDataset(Dataset<DatasetImpl> inputDataset)
+void WriterPlugin::setInputDataset(const Dataset<DatasetImpl>& inputDataset)
 {
-    _input = inputDataset;
+    setInputDatasets({ inputDataset });
+}
+
+void WriterPlugin::setInputDatasets(const Datasets& inputDatasets)
+{
+    _input = inputDatasets;
 }
 
 WriterPluginFactory::WriterPluginFactory() :

--- a/HDPS/src/WriterPlugin.h
+++ b/HDPS/src/WriterPlugin.h
@@ -37,16 +37,30 @@ public:
      * Set input dataset smart pointer
      * @param inputDataset Smart pointer to input dataset
      */
-    void setInputDataset(Dataset<DatasetImpl> inputDataset);
+    void setInputDataset(const Dataset<DatasetImpl>& inputDataset);
+
+    /**
+     * Set input datasets smart pointers
+     * @param inputDatasets Vector of smart pointers to the input datasets
+     */
+    void setInputDatasets(const Datasets& inputDatasets);
 
     /** Get input dataset smart pointer */
     template<typename DatasetType = DatasetImpl>
     Dataset<DatasetType> getInputDataset() {
-        return Dataset<DatasetType>(_input.get<DatasetType>());
+        if (_input.size() > 0)
+            return Dataset<DatasetType>(_input[0].get<DatasetType>());
+        else
+            return Dataset<DatasetImpl>();
+    }
+
+    /** Get input dataset smart pointer vector */
+    Datasets getInputDatasets() {
+        return _input;
     }
 
 protected:
-    Dataset<DatasetImpl>    _input;     /** Input dataset smart pointer */
+    Datasets    _input;     /** Input datasets smart pointers */
 };
 
 

--- a/HDPS/src/event/EventListener.cpp
+++ b/HDPS/src/event/EventListener.cpp
@@ -74,7 +74,7 @@ void EventListener::onDataEvent(DatasetEvent* dataEvent)
         if (_dataEventHandlersByType.find(dataRemovedEvent->getDataType()) != _dataEventHandlersByType.end())
             _dataEventHandlersByType[dataRemovedEvent->getDataType()](dataEvent);
 
-        for (auto dataEventHandler : _dataEventHandlers)
+        for (const auto& dataEventHandler : _dataEventHandlers)
             dataEventHandler(dataEvent);
     }
 
@@ -87,7 +87,7 @@ void EventListener::onDataEvent(DatasetEvent* dataEvent)
     if (_dataEventHandlersByType.find(dataEvent->getDataset()->getDataType()) != _dataEventHandlersByType.end())
         _dataEventHandlersByType[dataEvent->getDataset()->getDataType()](dataEvent);
 
-    for (auto dataEventHandler : _dataEventHandlers)
+    for (const auto& dataEventHandler : _dataEventHandlers)
         dataEventHandler(dataEvent);
 }
 

--- a/HDPS/src/plugins/ClusterData/src/ClustersAction.h
+++ b/HDPS/src/plugins/ClusterData/src/ClustersAction.h
@@ -12,8 +12,6 @@
 #include "ColorizeClustersAction.h"
 #include "PrefixClustersAction.h"
 
-#include <actions/Actions.h>
-
 #include <QItemSelectionModel>
 
 class Cluster;

--- a/HDPS/src/plugins/ClusterData/src/ClustersModel.h
+++ b/HDPS/src/plugins/ClusterData/src/ClustersModel.h
@@ -8,9 +8,7 @@
 
 #include "Cluster.h"
 
-#include <actions/Actions.h>
-
-using namespace mv;
+#include <QAbstractListModel>
 
 /**
  * Clusters model class

--- a/HDPS/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.cpp
+++ b/HDPS/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.cpp
@@ -5,24 +5,22 @@
 #include "DataHierarchyWidget.h"
 #include "DataHierarchyWidgetContextMenu.h"
 
-#include <models/DataHierarchyModel.h>
-#include <models/DataHierarchyModelItem.h>
+#include <AbstractDataHierarchyManager.h>
 #include <Application.h>
-#include <Set.h>
 #include <Dataset.h>
 #include <PluginFactory.h>
-#include <AbstractDataHierarchyManager.h>
+#include <Set.h>
+
+#include <models/DataHierarchyModel.h>
+#include <models/DataHierarchyModelItem.h>
 #include <widgets/Divider.h>
-#include <actions/PluginTriggerAction.h>
 
 #include <QDebug>
 #include <QHeaderView>
-#include <QVBoxLayout>
-#include <QMenu>
-#include <QLabel>
+#include <QScopedPointer>
 #include <QStyledItemDelegate>
 #include <QStyleOptionViewItem>
-#include <QScopedPointer>
+#include <QVBoxLayout>
 
 #include <stdexcept>
 

--- a/HDPS/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.h
+++ b/HDPS/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.h
@@ -4,17 +4,16 @@
 
 #pragma once
 
-#include <models/DataHierarchyModel.h>
-#include <models/DataHierarchyFilterModel.h>
-#include <actions/TriggerAction.h>
-#include <actions/ToggleAction.h>
-#include <widgets/HierarchyWidget.h>
 #include <DataHierarchyItem.h>
 #include <Dataset.h>
 
-#include <QWidget>
+#include <actions/ToggleAction.h>
+#include <actions/TriggerAction.h>
+#include <models/DataHierarchyFilterModel.h>
+#include <models/DataHierarchyModel.h>
+#include <widgets/HierarchyWidget.h>
 
-class DataHierarchyPlugin;
+#include <QWidget>
 
 /**
  * Widget for displaying the data hierarchy

--- a/HDPS/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/HDPS/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -51,12 +51,12 @@ void DataHierarchyWidgetContextMenu::addMenusForPluginType(plugin::Type pluginTy
 {
     QMap<QString, QMenu*> menus;
 
-    for (auto pluginTriggerAction : Application::core()->getPluginManager().getPluginTriggerActions(pluginType, _datasets)) {
+    for (auto& pluginTriggerAction : Application::core()->getPluginManager().getPluginTriggerActions(pluginType, _datasets)) {
         const auto titleSegments = pluginTriggerAction->getMenuLocation().split("/");
 
         QString menuPath, previousMenuPath = titleSegments.first();
 
-        for (auto titleSegment : titleSegments) {
+        for (const auto& titleSegment : titleSegments) {
             if (titleSegment != titleSegments.first() && titleSegment != titleSegments.last())
                 menuPath += "/";
 
@@ -118,7 +118,7 @@ QMenu* DataHierarchyWidgetContextMenu::getLockMenu()
     auto lockAllAction = new QAction("All");
 
     connect(lockAllAction, &QAction::triggered, this, [this]() -> void {
-        for (auto dataset : Application::core()->requestAllDataSets())
+        for (auto& dataset : Application::core()->requestAllDataSets())
             dataset->lock();
     });
 
@@ -126,7 +126,7 @@ QMenu* DataHierarchyWidgetContextMenu::getLockMenu()
 
     QVector<bool> locked;
 
-    for (auto dataset : Application::core()->requestAllDataSets())
+    for (const auto& dataset : Application::core()->requestAllDataSets())
         locked << dataset->isLocked();
 
     const auto numberOfLockedDatasets = std::accumulate(locked.begin(), locked.end(), 0);
@@ -139,7 +139,7 @@ QMenu* DataHierarchyWidgetContextMenu::getLockMenu()
     lockSelectedAction->setEnabled(!_datasets.isEmpty());
 
     connect(lockSelectedAction, &QAction::triggered, this, [this]() -> void {
-        for (auto dataset : _datasets)
+        for (auto& dataset : _datasets)
             dataset->lock();
     });
 
@@ -158,7 +158,7 @@ QMenu* DataHierarchyWidgetContextMenu::getUnlockMenu()
 
     QVector<bool> locked;
 
-    for (auto dataset : Application::core()->requestAllDataSets())
+    for (const auto& dataset : Application::core()->requestAllDataSets())
         locked << dataset->isLocked();
 
     const auto numberOfLockedDatasets = std::accumulate(locked.begin(), locked.end(), 0);
@@ -168,7 +168,7 @@ QMenu* DataHierarchyWidgetContextMenu::getUnlockMenu()
     auto unlockAllAction = new QAction("All");
 
     connect(unlockAllAction, &QAction::triggered, this, [this]() -> void {
-        for (auto dataset : Application::core()->requestAllDataSets())
+        for (auto& dataset : Application::core()->requestAllDataSets())
             dataset->unlock();
     });
 
@@ -178,7 +178,7 @@ QMenu* DataHierarchyWidgetContextMenu::getUnlockMenu()
     unlockSelectedAction->setEnabled(!_datasets.isEmpty());
 
     connect(unlockSelectedAction, &QAction::triggered, this, [this]() -> void {
-        for (auto dataset : _datasets)
+        for (auto& dataset : _datasets)
             dataset->unlock();
         });
 

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -867,7 +867,7 @@ void resolveLinkedPointData(LinkedData& linkedData, const std::vector<std::uint3
     *ignoreDatasets << targetDataset;
 
     // Recursively resolve linked point data
-    for (auto targetLd : targetDataset->getLinkedData())
+    for (const mv::LinkedData& targetLd : targetDataset->getLinkedData())
         resolveLinkedPointData(targetLd, targetSelection->indices, ignoreDatasets);
 }
 
@@ -877,7 +877,7 @@ void Points::resolveLinkedData(bool force /*= false*/)
         return;
 
     // Check for linked data in this dataset and resolve them
-    for (mv::LinkedData& linkedData : getLinkedData())
+    for (const mv::LinkedData& linkedData : getLinkedData())
         resolveLinkedPointData(linkedData, getSelection<Points>()->indices, nullptr);
 }
 

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -8,26 +8,26 @@
 #endif
 
 #include "PointData.h"
-#include "InfoAction.h"
+
 #include "DimensionsPickerAction.h"
-#include "event/Event.h"
+#include "InfoAction.h"
 
-#include <QtCore>
-#include <QtDebug>
-#include <QPainter>
-
-#include <cstring>
-#include <type_traits>
-#include <queue>
-#include <set>
-
-#include "graphics/Vector2f.h"
-#include "Application.h"
+#include <Application.h>
+#include <DataHierarchyItem.h>
 
 #include <actions/GroupAction.h>
+#include <event/Event.h>
+#include <graphics/Vector2f.h>
 #include <util/Serialization.h>
 #include <util/Timer.h>
-#include <DataHierarchyItem.h>
+
+#include <QPainter>
+#include <QtCore>
+#include <QtDebug>
+
+#include <cstring>
+#include <set>
+#include <type_traits>
 
 Q_PLUGIN_METADATA(IID "nl.tudelft.PointData")
 

--- a/HDPS/src/plugins/PointData/src/PointData.h
+++ b/HDPS/src/plugins/PointData/src/PointData.h
@@ -8,16 +8,16 @@
 
 #include "RawData.h"
 
-#include "Set.h"
-#include "PointDataRange.h"
 #include "LinkedData.h"
+#include "PointDataRange.h"
+#include "Set.h"
 
 #include "event/EventListener.h"
 
 #include <biovault_bfloat16/biovault_bfloat16.h>
 
-#include <QString>
 #include <QMap>
+#include <QString>
 #include <QVariant>
 
 #include <array>

--- a/HDPS/src/private/DockManager.cpp
+++ b/HDPS/src/private/DockManager.cpp
@@ -155,10 +155,10 @@ void DockManager::fromVariantMap(const QVariantMap& variantMap)
 
         const auto viewPluginDockWidgetsList = variantMap["ViewPluginDockWidgets"].toList();
 
-        for (auto viewPluginDockWidgetVariant : viewPluginDockWidgetsList)
+        for (const auto& viewPluginDockWidgetVariant : viewPluginDockWidgetsList)
             ViewPluginDockWidget::preRegisterSerializationTask(this, viewPluginDockWidgetVariant.toMap()["ID"].toString(), this);
 
-        for (auto viewPluginDockWidgetVariant : viewPluginDockWidgetsList) {
+        for (const auto& viewPluginDockWidgetVariant : viewPluginDockWidgetsList) {
             const auto viewPluginMap    = viewPluginDockWidgetVariant.toMap()["ViewPlugin"].toMap();
             const auto pluginKind       = viewPluginMap["Kind"].toString();
             const auto pluginMap        = viewPluginMap["Plugin"].toMap();
@@ -202,14 +202,14 @@ QVariantMap DockManager::toVariantMap() const
 
     _serializationTask->setEnabled(true);
 
-    for (auto viewPluginDockWidget : getViewPluginDockWidgets())
+    for (const auto& viewPluginDockWidget : getViewPluginDockWidgets())
         ViewPluginDockWidget::preRegisterSerializationTask(const_cast<DockManager*>(this), viewPluginDockWidget->getId(), const_cast<DockManager*>(this));
 
     auto variantMap = Serializable::toVariantMap();
 
     QVariantList viewPluginDockWidgetsList;
 
-    for (auto viewPluginDockWidget : getViewPluginDockWidgets())
+    for (const auto& viewPluginDockWidget : getViewPluginDockWidgets())
         viewPluginDockWidgetsList << viewPluginDockWidget->toVariantMap();
 
     const_cast<DockManager*>(this)->_layoutTask.setRunning();

--- a/HDPS/src/private/DockManager.cpp
+++ b/HDPS/src/private/DockManager.cpp
@@ -5,10 +5,9 @@
 #include "DockManager.h"
 #include "ViewPluginDockWidget.h"
 
-#include <ViewPlugin.h>
-
-#include <CoreInterface.h>
 #include <AbstractPluginManager.h>
+#include <CoreInterface.h>
+#include <ViewPlugin.h>
 
 #include <util/Serialization.h>
 #include <widgets/InfoWidget.h>

--- a/HDPS/src/private/PluginManager.cpp
+++ b/HDPS/src/private/PluginManager.cpp
@@ -296,7 +296,7 @@ plugin::Plugin* PluginManager::requestPlugin(const QString& kind, Datasets input
                 auto writerPlugin = dynamic_cast<WriterPlugin*>(pluginInstance);
 
                 if (!inputDatasets.isEmpty())
-                    writerPlugin->setInputDataset(inputDatasets.first());
+                    writerPlugin->setInputDatasets(inputDatasets);
 
                 break;
             }

--- a/HDPS/src/private/PluginManager.cpp
+++ b/HDPS/src/private/PluginManager.cpp
@@ -265,7 +265,7 @@ QStringList PluginManager::resolveDependencies(QDir pluginDir) const
     return resolvedOrderedPluginNames;
 }
 
-plugin::Plugin* PluginManager::requestPlugin(const QString& kind, Datasets datasets /*= Datasets()*/)
+plugin::Plugin* PluginManager::requestPlugin(const QString& kind, Datasets inputDatasets /*= Datasets()*/, Datasets outputDatasets /*= Datasets()*/)
 {
     try
     {
@@ -284,19 +284,19 @@ plugin::Plugin* PluginManager::requestPlugin(const QString& kind, Datasets datas
             case plugin::Type::ANALYSIS: {
                 auto analysisPlugin = dynamic_cast<AnalysisPlugin*>(pluginInstance);
 
-                for (auto dataset : datasets)
-                    dataset->setAnalysis(analysisPlugin);
+                if (!inputDatasets.isEmpty())
+                    analysisPlugin->setInputDataset(inputDatasets.first());
 
-                if (!datasets.isEmpty())
-                    analysisPlugin->setInputDataset(datasets.first());
+                if (!outputDatasets.isEmpty())
+                    analysisPlugin->setOutputDataset(outputDatasets.first());
 
                 break;
             }
             case plugin::Type::WRITER: {
                 auto writerPlugin = dynamic_cast<WriterPlugin*>(pluginInstance);
 
-                if (!datasets.isEmpty())
-                    writerPlugin->setInputDataset(datasets.first());
+                if (!inputDatasets.isEmpty())
+                    writerPlugin->setInputDataset(inputDatasets.first());
 
                 break;
             }

--- a/HDPS/src/private/PluginManager.cpp
+++ b/HDPS/src/private/PluginManager.cpp
@@ -285,10 +285,10 @@ plugin::Plugin* PluginManager::requestPlugin(const QString& kind, Datasets input
                 auto analysisPlugin = dynamic_cast<AnalysisPlugin*>(pluginInstance);
 
                 if (!inputDatasets.isEmpty())
-                    analysisPlugin->setInputDataset(inputDatasets.first());
+                    analysisPlugin->setInputDatasets(inputDatasets);
 
                 if (!outputDatasets.isEmpty())
-                    analysisPlugin->setOutputDataset(outputDatasets.first());
+                    analysisPlugin->setOutputDatasets(outputDatasets);
 
                 break;
             }
@@ -523,6 +523,7 @@ void PluginManager::fromVariantMap(const QVariantMap& variantMap)
     Serializable::fromVariantMap(variantMap);
 
     variantMapMustContain(variantMap, "UsedPlugins");
+    variantMapMustContain(variantMap, "LoadedAnalyses");
 
     QStringList missingPluginKinds;
 
@@ -532,20 +533,55 @@ void PluginManager::fromVariantMap(const QVariantMap& variantMap)
 
     if (!missingPluginKinds.isEmpty())
         throw std::runtime_error(QString("One or more plugins are not available: %1").arg(missingPluginKinds.join(", ")).toLocal8Bit());
+
+    for (const auto& loadedAnalysis : variantMap["LoadedAnalyses"].toList())
+    {
+        auto analysisPluginMap = loadedAnalysis.toMap();
+
+        variantMapMustContain(analysisPluginMap, "Kind");
+        variantMapMustContain(analysisPluginMap, "inputDatasetsGUIDs");
+        variantMapMustContain(analysisPluginMap, "outputDatasetsGUIDs");
+
+        auto analysisPluginKind = analysisPluginMap["Kind"].toString();
+        if (_pluginFactories.contains(analysisPluginKind))
+        {
+            auto inputDatasetsGUIDs = analysisPluginMap["inputDatasetsGUIDs"].toStringList();
+            auto outputDatasetsGUIDs = analysisPluginMap["outputDatasetsGUIDs"].toStringList();
+
+            Datasets inputDatasets;
+            for (const auto& inputDatasetGUID : inputDatasetsGUIDs)
+                inputDatasets << mv::data().getSet(inputDatasetGUID);
+
+            Datasets outputDatasets;
+            for (const auto& outputDatasetGUID : outputDatasetsGUIDs)
+                outputDatasets << mv::data().getSet(outputDatasetGUID);
+
+            auto analysisPlugin = dynamic_cast<plugin::AnalysisPlugin*>(plugins().requestPlugin(analysisPluginKind, inputDatasets, outputDatasets));
+            if (analysisPlugin)
+                analysisPlugin->fromVariantMap(analysisPluginMap);
+        }
+    }
+
 }
 
 QVariantMap PluginManager::toVariantMap() const
 {
     auto variantMap = Serializable::toVariantMap();
 
-    QVariantList usedPluginsList;
+    QVariantList usedPluginsList;     // kinds of used plugins
+    QVariantList loadedAnalysesList;  // openend analysis plugin instances
 
-    for (auto pluginFactory : _pluginFactories.values())
+    for (const auto pluginFactory : _pluginFactories.values())
         if ((pluginFactory->getType() == Type::DATA || pluginFactory->getType() == Type::ANALYSIS || pluginFactory->getType() == Type::VIEW) && pluginFactory->getNumberOfInstances() > 0)
             usedPluginsList << pluginFactory->getKind();
 
+    for(const auto loadedPlugin : _plugins)
+        if(loadedPlugin->getType() == Type::ANALYSIS )
+            loadedAnalysesList << dynamic_cast<plugin::AnalysisPlugin*>(loadedPlugin)->toVariantMap();
+
     variantMap.insert({
-        { "UsedPlugins", usedPluginsList }
+        { "UsedPlugins", usedPluginsList },
+        { "LoadedAnalyses", loadedAnalysesList }
     });
 
     return variantMap;

--- a/HDPS/src/private/PluginManager.h
+++ b/HDPS/src/private/PluginManager.h
@@ -45,7 +45,7 @@ public: // Plugin creation/destruction
      * @param datasets Zero or more datasets upon which the plugin is based (e.g. analysis plugin)
      * @return Pointer to created plugin (nullptr if creation failed)
      */
-    plugin::Plugin* requestPlugin(const QString& kind, Datasets datasets = Datasets()) override;
+    plugin::Plugin* requestPlugin(const QString& kind, Datasets inputDatasets = Datasets(), Datasets outputDatasets = Datasets()) override;
     
     /**
      * Create a plugin of \p kind with \p inputDatasets


### PR DESCRIPTION
All existing plugins should still just work fine with this PR.

Analysis plugins now can have multiple Input and Output datasets:
```cpp
// Analysis & Transformation and Writer Plugins
void setInputDataset(const Dataset<DatasetImpl>& inputDataset);
void setInputDatasets(const Datasets& inputDatasets);               // NEW

Dataset<DatasetType> getInputDataset();
Datasets getInputDatasets();                                        // NEW

// Only Analysis Plugins
void setOutputDataset(const Dataset<DatasetImpl>& outputDataset);
void setOutputDatasets(const Datasets& outputDatasets);             // NEW

Dataset<DatasetType> getOutputDataset();
Datasets getOutputDatasets();                                       // NEW

bool outputDataInit()                                               // NEW
```

Example setup when implementing save-able analysis plugins:
```cpp
// if not loaded from project, init new data
if (!outputDataInit())
{
    qDebug() << "PCAPlugin::create new derived data";

    auto newOutput = Dataset<Points>(_core->createDerivedDataset("PCA", inputDataset, inputDataset));
    setOutputDataset(newOutput);

    // Set initial data (default 2 dimensions, all points at (0,0) )
    std::vector<float> initialData;
    const size_t numInitialDataDimensions = 2;
    const auto numPoints = inputDataset->getNumPoints();
    initialData.resize(numInitialDataDimensions * numPoints);
    newOutput->setData(initialData.data(), numPoints, numInitialDataDimensions);
    events().notifyDatasetDataChanged(newOutput);
}

// Same as always
auto outputDataset = getOutputDataset<Points>();
```