### PR TITLE
Feature/save and load analysis

### DIFF
--- a/HDPS/src/AbstractPluginManager.h
+++ b/HDPS/src/AbstractPluginManager.h
@@ -63,7 +63,7 @@ public: // Plugin creation/destruction
      * @param datasets Zero or more datasets upon which the plugin is based (e.g. analysis plugin)
      * @return Pointer to created plugin, nullptr if creation failed
      */
-    virtual plugin::Plugin* requestPlugin(const QString& kind, Datasets datasets = Datasets()) = 0;
+    virtual plugin::Plugin* requestPlugin(const QString& kind, Datasets inputDatasets = Datasets(), Datasets outputDatasets = Datasets()) = 0;
 
     /**
      * Create a plugin of \p kind with \p inputDatasets
@@ -72,8 +72,9 @@ public: // Plugin creation/destruction
      * @return Pointer of \p PluginType to created plugin, nullptr if creation failed
      */
     template<typename PluginType>
-    PluginType* requestPlugin(const QString& kind, const Datasets& datasets) {
-        return dynamic_cast<PluginType*>(requestPlugin(kind, datasets));
+    PluginType* requestPlugin(const QString& kind, Datasets inputDatasets = Datasets(), Datasets outputDatasets = Datasets())
+    {
+        return dynamic_cast<PluginType*>(requestPlugin(kind, inputDatasets, outputDatasets));
     }
 
 private:

--- a/HDPS/src/AnalysisPlugin.cpp
+++ b/HDPS/src/AnalysisPlugin.cpp
@@ -23,31 +23,52 @@ void AnalysisPlugin::setObjectName(const QString& name)
     QObject::setObjectName("Plugins/Analysis/" + name);
 }
 
-void AnalysisPlugin::setInputDataset(Dataset<DatasetImpl> inputDataset)
+void AnalysisPlugin::setInputDataset(const Dataset<DatasetImpl>& inputDataset)
 {
-    _input = inputDataset;
+    setInputDatasets({ inputDataset });
 }
 
-void AnalysisPlugin::setOutputDataset(Dataset<DatasetImpl> outputDataset)
+void AnalysisPlugin::setInputDatasets(const Datasets& inputDatasets)
 {
-    _output = outputDataset;
-    outputDataset->setAnalysis(this);
+    _input = inputDatasets;
+}
+
+void AnalysisPlugin::setOutputDataset(const Dataset<DatasetImpl>& outputDataset)
+{
+    setOutputDatasets({ outputDataset });
+}
+
+void AnalysisPlugin::setOutputDatasets(const Datasets& outputDatasets)
+{
+    _output = outputDatasets;
+
+    for(auto& output : _output)
+        output->setAnalysis(this);
 }
 
 void AnalysisPlugin::fromVariantMap(const QVariantMap& variantMap)
 {
     Plugin::fromVariantMap(variantMap);
 
-    mv::util::variantMapMustContain(variantMap, "inputDatasetGUID");
-    mv::util::variantMapMustContain(variantMap, "outputDatasetGUID");
+    // _input and _output are set before fromVariantMap is called 
+    // in PluginManager::requestPlugin()
+    // since they might be used in the init() function
 }
 
 QVariantMap AnalysisPlugin::toVariantMap() const
 {
     auto variantMap = Plugin::toVariantMap();
 
-    variantMap["inputDatasetGUID"] = _input->getId();
-    variantMap["outputDatasetGUID"] = _output->getId();
+    QVariantList inputDatasetsGUIDs, outputDatasetsGUIDs;
+
+    for (auto& input : _input)
+        inputDatasetsGUIDs << input->getId();
+
+    for (auto& output : _output)
+        outputDatasetsGUIDs << output->getId();
+
+    variantMap["inputDatasetsGUIDs"] = inputDatasetsGUIDs;
+    variantMap["outputDatasetsGUIDs"] = outputDatasetsGUIDs;
 
     return variantMap;
 }

--- a/HDPS/src/AnalysisPlugin.cpp
+++ b/HDPS/src/AnalysisPlugin.cpp
@@ -67,8 +67,8 @@ QVariantMap AnalysisPlugin::toVariantMap() const
     for (auto& output : _output)
         outputDatasetsGUIDs << output->getId();
 
-    variantMap["inputDatasetsGUIDs"] = inputDatasetsGUIDs;
-    variantMap["outputDatasetsGUIDs"] = outputDatasetsGUIDs;
+    variantMap["InputDatasetsGUIDs"] = inputDatasetsGUIDs;
+    variantMap["OutputDatasetsGUIDs"] = outputDatasetsGUIDs;
 
     return variantMap;
 }

--- a/HDPS/src/AnalysisPlugin.cpp
+++ b/HDPS/src/AnalysisPlugin.cpp
@@ -59,16 +59,16 @@ QVariantMap AnalysisPlugin::toVariantMap() const
 {
     auto variantMap = Plugin::toVariantMap();
 
-    QVariantList inputDatasetsGUIDs, outputDatasetsGUIDs;
+    QVariantList inputDatasetsIDs, outputDatasetsIDs;
 
     for (auto& input : _input)
-        inputDatasetsGUIDs << input->getId();
+        inputDatasetsIDs << input->getId();
 
     for (auto& output : _output)
-        outputDatasetsGUIDs << output->getId();
+        outputDatasetsIDs << output->getId();
 
-    variantMap["InputDatasetsGUIDs"] = inputDatasetsGUIDs;
-    variantMap["OutputDatasetsGUIDs"] = outputDatasetsGUIDs;
+    variantMap["InputDatasetsIDs"] = inputDatasetsIDs;
+    variantMap["OutputDatasetsIDs"] = outputDatasetsIDs;
 
     return variantMap;
 }

--- a/HDPS/src/AnalysisPlugin.cpp
+++ b/HDPS/src/AnalysisPlugin.cpp
@@ -31,6 +31,25 @@ void AnalysisPlugin::setInputDataset(Dataset<DatasetImpl> inputDataset)
 void AnalysisPlugin::setOutputDataset(Dataset<DatasetImpl> outputDataset)
 {
     _output = outputDataset;
+    outputDataset->setAnalysis(this);
+}
+
+void AnalysisPlugin::fromVariantMap(const QVariantMap& variantMap)
+{
+    Plugin::fromVariantMap(variantMap);
+
+    mv::util::variantMapMustContain(variantMap, "inputDatasetGUID");
+    mv::util::variantMapMustContain(variantMap, "outputDatasetGUID");
+}
+
+QVariantMap AnalysisPlugin::toVariantMap() const
+{
+    auto variantMap = Plugin::toVariantMap();
+
+    variantMap["inputDatasetGUID"] = _input->getId();
+    variantMap["outputDatasetGUID"] = _output->getId();
+
+    return variantMap;
 }
 
 QIcon AnalysisPluginFactory::getIcon(const QColor& color /*= Qt::black*/) const

--- a/HDPS/src/AnalysisPlugin.h
+++ b/HDPS/src/AnalysisPlugin.h
@@ -55,6 +55,20 @@ public:
         return Dataset<DatasetType>(_output.get<DatasetType>());
     }
 
+public: // Serialization
+
+    /**
+     * Load view plugin from variant
+     * @param Variant representation of the view plugin
+     */
+    void fromVariantMap(const QVariantMap& variantMap) override;
+
+    /**
+     * Save view plugin to variant
+     * @return Variant representation of the view plugin
+     */
+    QVariantMap toVariantMap() const override;
+
 protected:
     Dataset<DatasetImpl>    _input;       /** Input dataset smart pointer */
     Dataset<DatasetImpl>    _output;      /** Output dataset smart pointer */

--- a/HDPS/src/AnalysisPlugin.h
+++ b/HDPS/src/AnalysisPlugin.h
@@ -35,24 +35,53 @@ public:
      * Set input dataset smart pointer
      * @param inputDataset Smart pointer to the input dataset
      */
-    void setInputDataset(Dataset<DatasetImpl> inputDataset);
+    void setInputDataset(const Dataset<DatasetImpl>& inputDataset);
+
+    /**
+     * Set input datasets smart pointers
+     * @param inputDatasets Vector of smart pointers to the input datasets
+     */
+    void setInputDatasets(const Datasets& inputDatasets);
 
     /** Get input dataset smart pointer */
     template<typename DatasetType = DatasetImpl>
     Dataset<DatasetType> getInputDataset() {
-        return Dataset<DatasetType>(_input.get<DatasetType>());
+        if (_input.size() > 0)
+            return Dataset<DatasetType>(_input[0].get<DatasetType>());
+        else
+            return Dataset<DatasetImpl>();
+
+    }
+
+    /** Get input dataset smart pointer vector */
+    Datasets getInputDatasets() {
+        return _input;
     }
 
     /**
      * Set output dataset smart pointer
      * @param outputDataset Smart pointer to output dataset
      */
-    void setOutputDataset(Dataset<DatasetImpl> outputDataset);
+    void setOutputDataset(const Dataset<DatasetImpl>& outputDataset);
+
+    /**
+     * Set output datasets smart pointers
+     * @param outputDatasets Vector of smart pointers to output datasets
+     */
+    void setOutputDatasets(const Datasets& outputDatasets);
 
     /** Get output dataset smart pointer */
     template<typename DatasetType = DatasetImpl>
     Dataset<DatasetType> getOutputDataset() {
-        return Dataset<DatasetType>(_output.get<DatasetType>());
+        if (_output.size() > 0)
+            return Dataset<DatasetType>(_output[0].get<DatasetType>());
+        else
+            return Dataset<DatasetImpl>();
+    }
+
+    /** Get output dataset smart pointers */
+    Datasets getOutputDatasets() {
+        return _output;
     }
 
 public: // Serialization
@@ -70,8 +99,12 @@ public: // Serialization
     QVariantMap toVariantMap() const override;
 
 protected:
-    Dataset<DatasetImpl>    _input;       /** Input dataset smart pointer */
-    Dataset<DatasetImpl>    _output;      /** Output dataset smart pointer */
+    /** Returns whether any output dataset is given */
+    bool outputDataInit() const { return _output.size() > 0; }
+
+protected:
+    Datasets    _input;       /** Input datasets smart pointers */
+    Datasets    _output;      /** Output datasets smart pointers */
 };
 
 class AnalysisPluginFactory : public PluginFactory

--- a/HDPS/src/AnalysisPlugin.h
+++ b/HDPS/src/AnalysisPlugin.h
@@ -87,14 +87,14 @@ public:
 public: // Serialization
 
     /**
-     * Load view plugin from variant
-     * @param Variant representation of the view plugin
+     * Load analysis plugin from variant
+     * @param Variant representation of the analysis plugin
      */
     void fromVariantMap(const QVariantMap& variantMap) override;
 
     /**
-     * Save view plugin to variant
-     * @return Variant representation of the view plugin
+     * Save analysis plugin to variant
+     * @param Variant representation of the analysis plugin
      */
     QVariantMap toVariantMap() const override;
 

--- a/HDPS/src/DatasetPrivate.cpp
+++ b/HDPS/src/DatasetPrivate.cpp
@@ -2,11 +2,12 @@
 // A corresponding LICENSE file is located in the root directory of this source tree 
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
-#include "DatasetPrivate.h"
-#include "CoreInterface.h"
-#include "event/Event.h"
 #include "Application.h"
+#include "CoreInterface.h"
+#include "DatasetPrivate.h"
 #include "Set.h"
+
+#include "event/Event.h"
 
 #include <QMetaMethod>
 

--- a/HDPS/src/DatasetPrivate.cpp
+++ b/HDPS/src/DatasetPrivate.cpp
@@ -168,6 +168,8 @@ void DatasetPrivate::registerDatasetEvents()
                     reset();
 
                     emit removed(_datasetId);
+
+                    break;
                 }
 
                 case EventType::DatasetDataChanged:
@@ -224,8 +226,8 @@ void DatasetPrivate::registerDatasetEvents()
                     break;
                 }
 
-                case EventType::DatasetAdded:
-                case EventType::DatasetLocked:
+                case EventType::DatasetAdded:   [[fallthrough]];
+                case EventType::DatasetLocked:  [[fallthrough]];
                 case EventType::DatasetUnlocked:
                     break;
             }

--- a/HDPS/src/LinkedData.h
+++ b/HDPS/src/LinkedData.h
@@ -8,8 +8,6 @@
 
 #include "util/Serializable.h"
 
-#include <QString>
-
 #include <map>
 #include <vector>
 
@@ -115,11 +113,6 @@ private:
     Dataset<DatasetImpl>    _sourceDataSet;
     Dataset<DatasetImpl>    _targetDataSet;
     SelectionMap            _mapping;
-};
-
-class IndexLinkedData
-{
-
 };
 
 }

--- a/HDPS/src/Plugin.cpp
+++ b/HDPS/src/Plugin.cpp
@@ -80,7 +80,7 @@ mv::plugin::Type Plugin::getType() const
 
 QString Plugin::getVersion() const
 {
-    return "No Version";
+    return _factory->getVersion();
 }
 
 bool Plugin::hasHelp()

--- a/HDPS/src/PluginFactory.cpp
+++ b/HDPS/src/PluginFactory.cpp
@@ -3,8 +3,8 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "PluginFactory.h"
+
 #include "Set.h"
-#include "actions/PluginTriggerAction.h"
 
 namespace mv
 {
@@ -122,7 +122,7 @@ QStringList PluginFactory::getDatasetTypesAsStringList(const Datasets& datasets)
 {
     QStringList datasetTypes;
 
-    for (auto dataset : datasets)
+    for (const auto& dataset : datasets)
         datasetTypes << dataset->getDataType().getTypeString();
 
     return datasetTypes;
@@ -130,7 +130,7 @@ QStringList PluginFactory::getDatasetTypesAsStringList(const Datasets& datasets)
 
 bool PluginFactory::areAllDatasetsOfTheSameType(const Datasets& datasets, const DataType& dataType)
 {
-    for (auto dataset : datasets)
+    for (const auto& dataset : datasets)
         if (dataset->getDataType() != dataType)
             return false;
 
@@ -141,7 +141,7 @@ std::uint16_t PluginFactory::getNumberOfDatasetsForType(const Datasets& datasets
 {
     std::uint16_t numberOfDatasetsForType = 0;
 
-    for (auto dataset : datasets)
+    for (const auto& dataset : datasets)
         if (dataset->getDataType() == dataType)
             numberOfDatasetsForType++;
 

--- a/HDPS/src/PluginFactory.h
+++ b/HDPS/src/PluginFactory.h
@@ -4,9 +4,10 @@
 
 #pragma once
 
-#include "PluginType.h"
-#include "DataType.h"
 #include "Dataset.h"
+#include "DataType.h"
+#include "PluginType.h"
+
 #include "actions/PluginTriggerAction.h"
 
 #include <QObject>
@@ -19,8 +20,6 @@ namespace mv
 
     namespace gui
     {
-        class PluginTriggerAction;
-
         using PluginTriggerActions = QVector<QPointer<PluginTriggerAction>>;
     }
 

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -130,7 +130,7 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     variantMapMustContain(variantMap, "StorageType");
     variantMapMustContain(variantMap, "DataType");
     variantMapMustContain(variantMap, "Derived");
-    variantMapMustContain(variantMap, "Full");
+//    variantMapMustContain(variantMap, "Full");
     variantMapMustContain(variantMap, "LinkedData");
 
     setText(variantMap["Name"].toString());
@@ -149,7 +149,7 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
         assert(_sourceDataset.isValid());
     }
 
-    if (!variantMap["Full"].toBool())
+    if (variantMap.contains("Full") && !variantMap["Full"].toBool())
     {        
         if (variantMap.contains("FullDatasetGUID"))
             makeSubsetOf(mv::data().getDataset(variantMap["FullDatasetGUID"].toString()));
@@ -157,7 +157,6 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
             makeSubsetOf(getParent()->getFullDataset<mv::DatasetImpl>());
 
         assert(variantMap["PluginKind"].toString() == _rawData->getKind());
-        assert(variantMap["PluginVersion"].toString() == _rawData->getVersion());
 
         assert(_fullDataset.isValid());
     }

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -141,7 +141,7 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
 
     if (variantMap["Derived"].toBool())
     {
-        if (variantMap.contains("FullDatasetGUID"))
+        if (variantMap.contains("SourceDatasetGUID"))
             setSourceDataSet(mv::data().getDataset(variantMap["SourceDatasetGUID"].toString()));
         else
             setSourceDataSet(getParent());

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -144,6 +144,8 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
         assert(_sourceDataset.isValid());
     }
 
+    _mayUnderive = variantMap["MayUnderive"].toBool();
+
     if (!variantMap["Full"].toBool())
     {
         makeSubsetOf(mv::data().getDataset(variantMap["FullDatasetGUID"].toString()));
@@ -202,6 +204,7 @@ QVariantMap DatasetImpl::toVariantMap() const
         { "PluginKind", QVariant::fromValue(_rawData->getKind()) },
         { "PluginVersion", QVariant::fromValue(_rawData->getVersion()) },
         { "Derived", QVariant::fromValue(isDerivedData()) },
+        { "MayUnderive", QVariant::fromValue(mayUnderive()) },
         { "Full", QVariant::fromValue(isFull()) },
         { "SourceDatasetGUID", isDerivedData() ? QVariant::fromValue(_sourceDataset->getId()) : "" },
         { "FullDatasetGUID", isFull() ? "" : QVariant::fromValue(_fullDataset->getId()) },

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -139,14 +139,14 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
 
     if (variantMap["Derived"].toBool())
     {
-        setSourceDataSet(mv::data().getSet(variantMap["SourceDatasetGUID"].toString()));
+        setSourceDataSet(mv::data().getDataset(variantMap["SourceDatasetGUID"].toString()));
 
         assert(_sourceDataset.isValid());
     }
 
     if (!variantMap["Full"].toBool())
     {
-        makeSubsetOf(mv::data().getSet(variantMap["FullDatasetGUID"].toString()));
+        makeSubsetOf(mv::data().getDataset(variantMap["FullDatasetGUID"].toString()));
 
         assert(variantMap["PluginKind"].toString() == _rawData->getKind());
         assert(variantMap["PluginVersion"].toString() == _rawData->getVersion());

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -70,7 +70,7 @@ QVector<Dataset<DatasetImpl>> DatasetImpl::getChildren(const QVector<DataType>& 
     return children;
 }
 
-QVector<mv::Dataset<mv::DatasetImpl>> DatasetImpl::getChildren(const DataType& filterDataType)
+QVector<mv::Dataset<mv::DatasetImpl>> DatasetImpl::getChildren(const DataType& filterDataType) const
 {
     return getChildren(QVector<DataType>({ filterDataType }));
 }

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -139,7 +139,7 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
 
     if (variantMap["Derived"].toBool())
     {
-        setSourceDataSet(mv::data().getSet(variantMap["SourceDatasetGUID"].toString());
+        setSourceDataSet(mv::data().getSet(variantMap["SourceDatasetGUID"].toString()));
 
         assert(_sourceDataset.isValid());
     }

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -4,17 +4,15 @@
 
 #include "Set.h"
 
+#include "AnalysisPlugin.h"
 #include "CoreInterface.h"
 #include "DataHierarchyItem.h"
-#include "AnalysisPlugin.h"
 
-#include "util/Serialization.h"
-#include "util/Icon.h"
 #include "util/Exception.h"
+#include "util/Icon.h"
+#include "util/Serialization.h"
 
 #include "Application.h"
-
-#include <QPainter>
 
 using namespace mv::gui;
 using namespace mv::util;

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -132,6 +132,7 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     variantMapMustContain(variantMap, "LinkedData");
     variantMapMustContain(variantMap, "SourceDatasetGUID");
     variantMapMustContain(variantMap, "FullDatasetGUID");
+    variantMapMustContain(variantMap, "GroupIndex");
 
     setText(variantMap["Name"].toString());
     setLocked(variantMap["Locked"].toBool());
@@ -142,6 +143,8 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     if (_derived)
         _sourceDataset = Application::core()->requestDataset(variantMap["SourceDatasetGUID"].toString());
 
+    if (variantMap["GroupIndex"].toInt() >= 0)
+        setGroupIndex(variantMap["GroupIndex"].toInt());
     if (!_all)
         _fullDataset = Application::core()->requestDataset(variantMap["FullDatasetGUID"].toString());
 

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -427,7 +427,7 @@ std::vector<mv::LinkedData>& DatasetImpl::getLinkedData()
     return _linkedData;
 }
 
-std::int32_t DatasetImpl::getLinkedDataFlags()
+std::int32_t DatasetImpl::getLinkedDataFlags() const
 {
     return _linkedDataFlags;
 }
@@ -445,7 +445,7 @@ void DatasetImpl::setLinkedDataFlag(std::int32_t linkedDataFlag, bool set /*= tr
         _linkedDataFlags &= ~linkedDataFlag;
 }
 
-bool DatasetImpl::hasLinkedDataFlag(std::int32_t linkedDataFlag)
+bool DatasetImpl::hasLinkedDataFlag(std::int32_t linkedDataFlag) const
 {
     return _linkedDataFlags & linkedDataFlag;
 }

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -149,7 +149,8 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
         assert(_sourceDataset.isValid());
     }
 
-    if (variantMap.contains("Full") && !variantMap["Full"].toBool())
+    // For backwards compatability, check PluginVersion
+    if (!(variantMap["PluginVersion"] == "No Version") && !variantMap["Full"].toBool())
     {        
         if (variantMap.contains("FullDatasetGUID"))
             makeSubsetOf(mv::data().getDataset(variantMap["FullDatasetGUID"].toString()));

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -139,7 +139,12 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
 
     if (variantMap["Derived"].toBool())
     {
-        setSourceDataSet(mv::data().getDataset(variantMap["SourceDatasetGUID"].toString()));
+        auto sourceDatasetGUID = variantMap["SourceDatasetGUID"].toString();
+
+        if(sourceDatasetGUID == "")
+            setSourceDataSet(getParent());
+        else
+            setSourceDataSet(mv::data().getDataset(sourceDatasetGUID));
 
         assert(_sourceDataset.isValid());
     }
@@ -147,8 +152,13 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     _mayUnderive = variantMap["MayUnderive"].toBool();
 
     if (!variantMap["Full"].toBool())
-    {
-        makeSubsetOf(mv::data().getDataset(variantMap["FullDatasetGUID"].toString()));
+    {        
+        auto fullDatasetGUID = variantMap["FullDatasetGUID"].toString();
+
+        if (fullDatasetGUID == "")
+            makeSubsetOf(getParent()->getFullDataset<mv::DatasetImpl>());
+        else
+            makeSubsetOf(mv::data().getDataset(fullDatasetGUID));
 
         assert(variantMap["PluginKind"].toString() == _rawData->getKind());
         assert(variantMap["PluginVersion"].toString() == _rawData->getVersion());

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -137,16 +137,27 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     setText(variantMap["Name"].toString());
     setLocked(variantMap["Locked"].toBool());
 
-    _derived    = variantMap["Derived"].toBool();
-    _all        = variantMap["Full"].toBool();
+    if (variantMap["Derived"].toBool())
+    {
+        setSourceDataSet(mv::data().getSet(variantMap["SourceDatasetGUID"].toString());
 
-    if (_derived)
-        _sourceDataset = Application::core()->requestDataset(variantMap["SourceDatasetGUID"].toString());
+        assert(_sourceDataset.isValid());
+    }
+
+    if (!variantMap["Full"].toBool())
+    {
+        makeSubsetOf(mv::data().getSet(variantMap["FullDatasetGUID"].toString()));
+
+        assert(variantMap["PluginKind"].toString() == _rawData->getKind());
+        assert(variantMap["PluginVersion"].toString() == _rawData->getVersion());
+
+        assert(_fullDataset.isValid());
+    }
+
+    assert(variantMap["DataType"].toString() == getDataType().getTypeString());
 
     if (variantMap["GroupIndex"].toInt() >= 0)
         setGroupIndex(variantMap["GroupIndex"].toInt());
-    if (!_all)
-        _fullDataset = Application::core()->requestDataset(variantMap["FullDatasetGUID"].toString());
 
     setStorageType(static_cast<StorageType>(variantMap["StorageType"].toInt()));
 

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -127,6 +127,7 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
 
     variantMapMustContain(variantMap, "Name");
     variantMapMustContain(variantMap, "Locked");
+    variantMapMustContain(variantMap, "Full");
     variantMapMustContain(variantMap, "Derived");
     variantMapMustContain(variantMap, "LinkedData");
     variantMapMustContain(variantMap, "SourceDatasetGUID");
@@ -136,12 +137,11 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     setLocked(variantMap["Locked"].toBool());
 
     _derived    = variantMap["Derived"].toBool();
-    bool full   = variantMap["Full"].toBool();
+    _all        = variantMap["Full"].toBool();
 
     if (_derived)
         _sourceDataset = Application::core()->requestDataset(variantMap["SourceDatasetGUID"].toString());
 
-    if (!full)
     if (!_all)
         _fullDataset = Application::core()->requestDataset(variantMap["FullDatasetGUID"].toString());
 
@@ -188,6 +188,7 @@ QVariantMap DatasetImpl::toVariantMap() const
         { "PluginKind", QVariant::fromValue(_rawData->getKind()) },
         { "PluginVersion", QVariant::fromValue(_rawData->getVersion()) },
         { "Derived", QVariant::fromValue(isDerivedData()) },
+        { "Full", QVariant::fromValue(isFull()) },
         { "SourceDatasetGUID", isDerivedData() ? QVariant::fromValue(_sourceDataset->getId()) : "" },
         { "FullDatasetGUID", isFull() ? "" : QVariant::fromValue(_fullDataset->getId()) },
         { "GroupIndex", QVariant::fromValue(getGroupIndex()) },
@@ -290,7 +291,7 @@ DatasetImpl::DatasetImpl(const QString& rawDataName, bool mayUnderive /*= true*/
     _storageType(StorageType::Owner),
     _rawData(nullptr),
     _rawDataName(rawDataName),
-    _all(false),
+    _all(true),
     _derived(false),
     _sourceDataset(),
     _properties(),

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -141,8 +141,8 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
 
     if (variantMap["Derived"].toBool())
     {
-        if (variantMap.contains("SourceDatasetGUID"))
-            setSourceDataSet(mv::data().getDataset(variantMap["SourceDatasetGUID"].toString()));
+        if (variantMap.contains("SourceDatasetID"))
+            setSourceDataSet(mv::data().getDataset(variantMap["SourceDatasetID"].toString()));
         else
             setSourceDataSet(getParent());
 
@@ -152,8 +152,8 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     // For backwards compatability, check PluginVersion
     if (!(variantMap["PluginVersion"] == "No Version") && !variantMap["Full"].toBool())
     {        
-        if (variantMap.contains("FullDatasetGUID"))
-            makeSubsetOf(mv::data().getDataset(variantMap["FullDatasetGUID"].toString()));
+        if (variantMap.contains("FullDatasetID"))
+            makeSubsetOf(mv::data().getDataset(variantMap["FullDatasetID"].toString()));
         else
             makeSubsetOf(getParent()->getFullDataset<mv::DatasetImpl>());
 
@@ -214,8 +214,8 @@ QVariantMap DatasetImpl::toVariantMap() const
         { "Derived", QVariant::fromValue(isDerivedData()) },
         { "MayUnderive", QVariant::fromValue(mayUnderive()) },
         { "Full", QVariant::fromValue(isFull()) },
-        { "SourceDatasetGUID", isDerivedData() ? QVariant::fromValue(_sourceDataset->getId()) : "" },
-        { "FullDatasetGUID", isFull() ? "" : QVariant::fromValue(_fullDataset->getId()) },
+        { "SourceDatasetID", isDerivedData() ? QVariant::fromValue(_sourceDataset->getId()) : "" },
+        { "FullDatasetID", isFull() ? "" : QVariant::fromValue(_fullDataset->getId()) },
         { "GroupIndex", QVariant::fromValue(getGroupIndex()) },
         { "LinkedData", linkedDataList },
         { "Properties", QVariant::fromValue(_properties)}

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -130,16 +130,13 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     variantMapMustContain(variantMap, "Name");
     variantMapMustContain(variantMap, "Locked");
     variantMapMustContain(variantMap, "Derived");
-    variantMapMustContain(variantMap, "HasAnalysis");
-    variantMapMustContain(variantMap, "Analysis");
     variantMapMustContain(variantMap, "LinkedData");
 
     setText(variantMap["Name"].toString());
     setLocked(variantMap["Locked"].toBool());
 
-    _derived            = variantMap["Derived"].toBool();
-    bool full           = variantMap["Full"].toBool();
-    bool hasAnalysis    = variantMap["HasAnalysis"].toBool();
+    _derived    = variantMap["Derived"].toBool();
+    bool full   = variantMap["Full"].toBool();
 
     if (_derived)
         _sourceDataset = getParent();
@@ -165,34 +162,15 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
 
         getLinkedData().push_back(linkedData);
     }
-
-    if (hasAnalysis)
-    {
-        auto analysisPluginMap = variantMap["Analysis"].toMap();
-
-        variantMapMustContain(analysisPluginMap, "Kind");
-        variantMapMustContain(analysisPluginMap, "inputDatasetGUID");
-        variantMapMustContain(analysisPluginMap, "outputDatasetGUID");
-
-        auto analysisPluginKind = analysisPluginMap["Kind"].toString();
-
-        _analysis = dynamic_cast<plugin::AnalysisPlugin*>(plugins().requestPlugin(analysisPluginKind, { mv::data().getSet(analysisPluginMap["inputDatasetGUID"].toString()) }, { mv::data().getSet(analysisPluginMap["outputDatasetGUID"].toString()) }));
-        _analysis->fromVariantMap(analysisPluginMap);
-    }
 }
 
 QVariantMap DatasetImpl::toVariantMap() const
 {
     auto variantMap = WidgetAction::toVariantMap();
 
-    QVariantMap analysisMap;
-
-    if (_analysis)
-        analysisMap = _analysis->toVariantMap();
-
     QStringList proxyMemberGuids;
 
-    for (auto proxyMember : _proxyMembers)
+    for (const auto& proxyMember : _proxyMembers)
         proxyMemberGuids << proxyMember->getId();
 
     QVariantList linkedData;
@@ -210,8 +188,6 @@ QVariantMap DatasetImpl::toVariantMap() const
         { "PluginVersion", QVariant::fromValue(_rawData->getVersion()) },
         { "Derived", QVariant::fromValue(isDerivedData()) },
         { "GroupIndex", QVariant::fromValue(getGroupIndex()) },
-        { "HasAnalysis", QVariant::fromValue(_analysis != nullptr) },
-        { "Analysis", analysisMap },
         { "LinkedData", linkedData }
     });
 
@@ -244,7 +220,7 @@ void DatasetImpl::setProxyMembers(const Datasets& proxyDatasets)
             throw std::runtime_error("Proxy dataset requires at least one input dataset");
         }
 
-        for (auto proxyDataset : proxyDatasets)
+        for (const auto& proxyDataset : proxyDatasets)
             if (proxyDataset->getDataType() != getDataType())
                 throw std::runtime_error("All datasets should be of the same data type");
 
@@ -266,7 +242,7 @@ void DatasetImpl::setProxyMembers(const Datasets& proxyDatasets)
 
 bool DatasetImpl::mayProxy(const Datasets& proxyDatasets) const
 {
-    for (auto proxyDataset : proxyDatasets)
+    for (const auto& proxyDataset : proxyDatasets)
         if (proxyDataset->getDataType() != getDataType())
             return false;
 

--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -168,6 +168,9 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
     if (variantMap.contains("MayUnderive"))
         _mayUnderive = variantMap["MayUnderive"].toBool();
 
+    if (variantMap.contains("Properties"))
+        _properties = variantMap["Properties"].toMap();
+
     if (getStorageType() == StorageType::Proxy && variantMap.contains("ProxyMembers")) {
         Datasets proxyMembers;
 
@@ -214,7 +217,8 @@ QVariantMap DatasetImpl::toVariantMap() const
         { "SourceDatasetGUID", isDerivedData() ? QVariant::fromValue(_sourceDataset->getId()) : "" },
         { "FullDatasetGUID", isFull() ? "" : QVariant::fromValue(_fullDataset->getId()) },
         { "GroupIndex", QVariant::fromValue(getGroupIndex()) },
-        { "LinkedData", linkedDataList }
+        { "LinkedData", linkedDataList },
+        { "Properties", QVariant::fromValue(_properties)}
     });
 
     return variantMap;

--- a/HDPS/src/Set.h
+++ b/HDPS/src/Set.h
@@ -5,10 +5,10 @@
 #ifndef HDPS_DATASET_H
 #define HDPS_DATASET_H
 
-#include "RawData.h"
+#include "CoreInterface.h"
 #include "Dataset.h"
 #include "LinkedData.h"
-#include "CoreInterface.h"
+#include "RawData.h"
 
 #include "DatasetTask.h"
 #include "ForegroundTask.h"
@@ -18,8 +18,8 @@
 #include "util/Miscellaneous.h"
 
 #include <QString>
-#include <QVector>
 #include <QUuid>
+#include <QVector>
 
 #include <memory>
 

--- a/HDPS/src/Set.h
+++ b/HDPS/src/Set.h
@@ -279,7 +279,7 @@ public: // Hierarchy
      * @param filterDataType Type of data to filter
      * @return Child datasets of the dataset type
      */
-    QVector<Dataset<DatasetImpl>> getChildren(const DataType& filterDataType);
+    QVector<Dataset<DatasetImpl>> getChildren(const DataType& filterDataType) const;
 
 public: // Selection
 

--- a/HDPS/src/Set.h
+++ b/HDPS/src/Set.h
@@ -463,7 +463,7 @@ public: // Linked data
      * Get flags for linked data
      * @return Flags for linked data
      */
-    std::int32_t getLinkedDataFlags();
+    std::int32_t getLinkedDataFlags() const;
 
     /**
      * Set flags for linked data
@@ -482,7 +482,7 @@ public: // Linked data
      * @param linkedDataFlag Linked data
      * @return Boolean determining  linkedDataFlag Linked data
      */
-    bool hasLinkedDataFlag(std::int32_t linkedDataFlag);
+    bool hasLinkedDataFlag(std::int32_t linkedDataFlag) const;
 
     /**
      * Resolves linked data for the dataset

--- a/HDPS/src/TransformationPlugin.cpp
+++ b/HDPS/src/TransformationPlugin.cpp
@@ -28,6 +28,11 @@ void TransformationPlugin::setInputDatasets(const Datasets& inputDatasets)
     _inputDatasets = inputDatasets;
 }
 
+void TransformationPlugin::setInputDataset(const Dataset<DatasetImpl>& inputDataset)
+{
+    setInputDatasets({ inputDataset });
+}
+
 TransformationPluginFactory::TransformationPluginFactory() :
     PluginFactory(Type::TRANSFORMATION)
 {

--- a/HDPS/src/TransformationPlugin.h
+++ b/HDPS/src/TransformationPlugin.h
@@ -40,10 +40,28 @@ public:
     Datasets getInputDatasets() const;
     
     /**
+     * Get first input dataset
+     * @return First input dataset
+     */
+    template<typename DatasetType = DatasetImpl>
+    Dataset<DatasetType> getInputDataset() {
+        if (_inputDatasets.size() > 0)
+            return Dataset<DatasetType>(_inputDatasets[0].get<DatasetType>());
+        else
+            return Dataset<DatasetImpl>();
+    }
+
+    /**
      * Set input datasets
      * @inputDatasets Input datasets
      */
     void setInputDatasets(const Datasets& inputDatasets);
+
+    /**
+     * Set a single input dataset
+     * @param inputDataset Smart pointer to the input dataset
+     */
+    void setInputDataset(const Dataset<DatasetImpl>& inputDataset);
 
 private:
     Datasets    _inputDatasets;        /** One, or more, input dataset */

--- a/HDPS/src/WriterPlugin.cpp
+++ b/HDPS/src/WriterPlugin.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "WriterPlugin.h"
+
 #include "Application.h"
 
 namespace mv
@@ -17,9 +18,14 @@ WriterPlugin::WriterPlugin(const PluginFactory* factory) :
 
 }
 
-void WriterPlugin::setInputDataset(Dataset<DatasetImpl> inputDataset)
+void WriterPlugin::setInputDataset(const Dataset<DatasetImpl>& inputDataset)
 {
-    _input = inputDataset;
+    setInputDatasets({ inputDataset });
+}
+
+void WriterPlugin::setInputDatasets(const Datasets& inputDatasets)
+{
+    _input = inputDatasets;
 }
 
 WriterPluginFactory::WriterPluginFactory() :

--- a/HDPS/src/WriterPlugin.h
+++ b/HDPS/src/WriterPlugin.h
@@ -37,16 +37,30 @@ public:
      * Set input dataset smart pointer
      * @param inputDataset Smart pointer to input dataset
      */
-    void setInputDataset(Dataset<DatasetImpl> inputDataset);
+    void setInputDataset(const Dataset<DatasetImpl>& inputDataset);
+
+    /**
+     * Set input datasets smart pointers
+     * @param inputDatasets Vector of smart pointers to the input datasets
+     */
+    void setInputDatasets(const Datasets& inputDatasets);
 
     /** Get input dataset smart pointer */
     template<typename DatasetType = DatasetImpl>
     Dataset<DatasetType> getInputDataset() {
-        return Dataset<DatasetType>(_input.get<DatasetType>());
+        if (_input.size() > 0)
+            return Dataset<DatasetType>(_input[0].get<DatasetType>());
+        else
+            return Dataset<DatasetImpl>();
+    }
+
+    /** Get input dataset smart pointer vector */
+    Datasets getInputDatasets() {
+        return _input;
     }
 
 protected:
-    Dataset<DatasetImpl>    _input;     /** Input dataset smart pointer */
+    Datasets    _input;     /** Input datasets smart pointers */
 };
 
 

--- a/HDPS/src/event/EventListener.cpp
+++ b/HDPS/src/event/EventListener.cpp
@@ -74,7 +74,7 @@ void EventListener::onDataEvent(DatasetEvent* dataEvent)
         if (_dataEventHandlersByType.find(dataRemovedEvent->getDataType()) != _dataEventHandlersByType.end())
             _dataEventHandlersByType[dataRemovedEvent->getDataType()](dataEvent);
 
-        for (auto dataEventHandler : _dataEventHandlers)
+        for (const auto& dataEventHandler : _dataEventHandlers)
             dataEventHandler(dataEvent);
     }
 
@@ -87,7 +87,7 @@ void EventListener::onDataEvent(DatasetEvent* dataEvent)
     if (_dataEventHandlersByType.find(dataEvent->getDataset()->getDataType()) != _dataEventHandlersByType.end())
         _dataEventHandlersByType[dataEvent->getDataset()->getDataType()](dataEvent);
 
-    for (auto dataEventHandler : _dataEventHandlers)
+    for (const auto& dataEventHandler : _dataEventHandlers)
         dataEventHandler(dataEvent);
 }
 

--- a/HDPS/src/plugins/ClusterData/src/ClustersAction.h
+++ b/HDPS/src/plugins/ClusterData/src/ClustersAction.h
@@ -12,8 +12,6 @@
 #include "ColorizeClustersAction.h"
 #include "PrefixClustersAction.h"
 
-#include <actions/Actions.h>
-
 #include <QItemSelectionModel>
 
 class Cluster;

--- a/HDPS/src/plugins/ClusterData/src/ClustersAction.h
+++ b/HDPS/src/plugins/ClusterData/src/ClustersAction.h
@@ -6,6 +6,8 @@
 
 #include "clusterdata_export.h"
 
+#include <Dataset.h>
+
 #include "ClustersModel.h"
 #include "ClustersFilterModel.h"
 #include "ClustersActionWidget.h"

--- a/HDPS/src/plugins/ClusterData/src/ClustersModel.h
+++ b/HDPS/src/plugins/ClusterData/src/ClustersModel.h
@@ -8,9 +8,7 @@
 
 #include "Cluster.h"
 
-#include <actions/Actions.h>
-
-using namespace mv;
+#include <QAbstractListModel>
 
 /**
  * Clusters model class

--- a/HDPS/src/plugins/ClusterData/src/SelectClustersAction.h
+++ b/HDPS/src/plugins/ClusterData/src/SelectClustersAction.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
-#include <actions/Actions.h>
+#include <actions/TriggerAction.h>
+#include <actions/WidgetAction.h>
+#include <actions/WidgetActionWidget.h>
 
 using namespace mv;
 using namespace mv::gui;

--- a/HDPS/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.h
+++ b/HDPS/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.h
@@ -14,9 +14,13 @@
 #include <DataHierarchyItem.h>
 #include <Dataset.h>
 
-#include <QWidget>
+#include <actions/ToggleAction.h>
+#include <actions/TriggerAction.h>
+#include <models/DataHierarchyFilterModel.h>
+#include <models/DataHierarchyModel.h>
+#include <widgets/HierarchyWidget.h>
 
-class DataHierarchyPlugin;
+#include <QWidget>
 
 /**
  * Widget for displaying the data hierarchy

--- a/HDPS/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/HDPS/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -80,7 +80,7 @@ void DataHierarchyWidgetContextMenu::addMenusForPluginType(plugin::Type pluginTy
 
         QString menuPath, previousMenuPath = titleSegments.first();
 
-        for (auto titleSegment : titleSegments) {
+        for (const auto& titleSegment : titleSegments) {
             if (titleSegment != titleSegments.first() && titleSegment != titleSegments.last())
                 menuPath += "/";
 

--- a/HDPS/src/plugins/ImageData/src/ImageData.cpp
+++ b/HDPS/src/plugins/ImageData/src/ImageData.cpp
@@ -6,8 +6,8 @@
 #include "Images.h"
 #include "Application.h"
 
-#include "PointData/PointData.h"
 #include "DataHierarchyItem.h"
+#include "PointData/PointData.h"
 
 #include "util/Exception.h"
 

--- a/HDPS/src/plugins/ImageData/src/ImageData.h
+++ b/HDPS/src/plugins/ImageData/src/ImageData.h
@@ -10,9 +10,9 @@
 #include <RawData.h>
 #include <Set.h>
 
-#include <QString>
-#include <QSize>
 #include <QDebug>
+#include <QSize>
+#include <QString>
 
 #include <vector>
 

--- a/HDPS/src/plugins/ImageData/src/ImageData.h
+++ b/HDPS/src/plugins/ImageData/src/ImageData.h
@@ -85,9 +85,6 @@ public:
      */
     void setImageSize(const QSize& imageSize);
 
-    /** Get the target rectangle */
-    QRect getTargetRectangle() const;
-
     /** Gets the number of components per pixel */
     std::uint32_t getNumberOfComponentsPerPixel() const;
 

--- a/HDPS/src/plugins/ImageData/src/Images.cpp
+++ b/HDPS/src/plugins/ImageData/src/Images.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "Images.h"
+
 #include "ImageData.h"
 #include "InfoAction.h"
 
@@ -12,8 +13,8 @@
 #include <DataHierarchyItem.h>
 #include <Dataset.h>
 
-#include <PointData/PointData.h>
 #include <ClusterData/ClusterData.h>
+#include <PointData/PointData.h>
 
 #include <QDebug>
 

--- a/HDPS/src/plugins/ImageData/src/Images.h
+++ b/HDPS/src/plugins/ImageData/src/Images.h
@@ -10,14 +10,13 @@
 
 #include <Set.h>
 
-#include <QString>
-#include <QImage>
 #include <QColor>
 #include <QRect>
 #include <QSize>
+#include <QString>
 
-#include <vector>
 #include <tuple>
+#include <vector>
 
 using namespace mv::plugin;
 

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -978,7 +978,7 @@ void Points::fromVariantMap(const QVariantMap& variantMap)
     variantMapMustContain(variantMap, "DimensionNames");
     variantMapMustContain(variantMap, "Selection");
 
-    // For backwards compatability
+    // For backwards compatability, check PluginVersion
     if (variantMap["PluginVersion"] == "No Version" && !variantMap["Full"].toBool())
     {
         makeSubsetOf(getParent()->getFullDataset<mv::DatasetImpl>());

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -103,7 +103,6 @@ void PointData::setValueAt(const std::size_t index, const float newValue)
 
 void PointData::fromVariantMap(const QVariantMap& variantMap)
 {
-
     variantMapMustContain(variantMap, "Data");
     variantMapMustContain(variantMap, "NumberOfPoints");
     variantMapMustContain(variantMap, "NumberOfDimensions");

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -101,12 +101,6 @@ void PointData::setValueAt(const std::size_t index, const float newValue)
         });
 }
 
-QString PointData::getVersion() const
-{
-    const auto version = mv::Application::current()->getVersion();
-    return QStringLiteral("%1.%2").arg(version.getMajor()).arg(version.getMinor());
-}
-
 void PointData::fromVariantMap(const QVariantMap& variantMap)
 {
     variantMapMustContain(variantMap, "Data");

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -104,7 +104,7 @@ void PointData::setValueAt(const std::size_t index, const float newValue)
 QString PointData::getVersion() const
 {
     const auto version = mv::Application::current()->getVersion();
-    return QStringLiteral("%1.%2").arg(version.getMajor(), version.getMinor());
+    return QStringLiteral("%1.%2").arg(version.getMajor()).arg(version.getMinor());
 }
 
 void PointData::fromVariantMap(const QVariantMap& variantMap)

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -973,7 +973,7 @@ void Points::fromVariantMap(const QVariantMap& variantMap)
     variantMapMustContain(variantMap, "Selection");
 
     if (isFull())
-        getRawData<PointData>().fromVariantMap(variantMap);
+        getRawData<PointData>()->fromVariantMap(variantMap);
     else
     {
         makeSubsetOf(getFullDataset<Points>());

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -1041,7 +1041,7 @@ QVariantMap Points::toVariantMap() const
 
     QStringList dimensionNames;
 
-    if (getDimensionNames().size() != getNumPoints()) {
+    if (getDimensionNames().size() == getNumDimensions()) {
         for (const auto& dimensionName : getDimensionNames())
             dimensionNames << dimensionName;
     }

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -867,7 +867,7 @@ void resolveLinkedPointData(LinkedData& linkedData, const std::vector<std::uint3
     *ignoreDatasets << targetDataset;
 
     // Recursively resolve linked point data
-    for (auto targetLd : targetDataset->getLinkedData())
+    for (const mv::LinkedData& targetLd : targetDataset->getLinkedData())
         resolveLinkedPointData(targetLd, targetSelection->indices, ignoreDatasets);
 }
 
@@ -877,7 +877,7 @@ void Points::resolveLinkedData(bool force /*= false*/)
         return;
 
     // Check for linked data in this dataset and resolve them
-    for (mv::LinkedData& linkedData : getLinkedData())
+    for (const mv::LinkedData& linkedData : getLinkedData())
         resolveLinkedPointData(linkedData, getSelection<Points>()->indices, nullptr);
 }
 

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -976,8 +976,6 @@ void Points::fromVariantMap(const QVariantMap& variantMap)
         getRawData<PointData>()->fromVariantMap(variantMap);
     else
     {
-        makeSubsetOf(getFullDataset<Points>());
-
         variantMapMustContain(variantMap, "Indices");
 
         const auto& indicesMap = variantMap["Indices"].toMap();

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -103,6 +103,11 @@ void PointData::setValueAt(const std::size_t index, const float newValue)
 
 void PointData::fromVariantMap(const QVariantMap& variantMap)
 {
+
+    variantMapMustContain(variantMap, "Data");
+    variantMapMustContain(variantMap, "NumberOfPoints");
+    variantMapMustContain(variantMap, "NumberOfDimensions");
+
     const auto data                 = variantMap["Data"].toMap();
     const auto numberOfPoints       = static_cast<size_t>(variantMap["NumberOfPoints"].toInt());
     const auto numberOfDimensions   = static_cast<size_t>(variantMap["NumberOfDimensions"].toInt());
@@ -804,7 +809,7 @@ void Points::setValueAt(const std::size_t index, const float newValue)
     getRawData<PointData>()->setValueAt(index, newValue);
 }
 
-void resolveLinkedPointData(LinkedData& linkedData, const std::vector<std::uint32_t>& indices, Datasets* ignoreDatasets = nullptr)
+static void resolveLinkedPointData(const LinkedData& linkedData, const std::vector<std::uint32_t>& indices, Datasets* ignoreDatasets = nullptr)
 {
     Dataset<Points> sourceDataset   = linkedData.getSourceDataSet();
     Dataset<Points> targetDataset   = linkedData.getTargetDataset();
@@ -965,15 +970,13 @@ void Points::fromVariantMap(const QVariantMap& variantMap)
 {
     DatasetImpl::fromVariantMap(variantMap);
 
-    variantMapMustContain(variantMap, "Full");
-    variantMapMustContain(variantMap, "NumberOfDimensions");
-
-    setAll(variantMap["Full"].toBool());
+    variantMapMustContain(variantMap, "DimensionNames");
+    variantMapMustContain(variantMap, "Selection");
 
     if (isFull())
-        getRawData<PointData>()->fromVariantMap(variantMap);
-
-    if (!isFull()) {
+        getRawData<PointData>().fromVariantMap(variantMap);
+    else
+    {
         makeSubsetOf(getFullDataset<Points>());
 
         variantMapMustContain(variantMap, "Indices");
@@ -1005,11 +1008,8 @@ void Points::fromVariantMap(const QVariantMap& variantMap)
         return dimensionNames;
     };
 
-    
-
     std::vector<QString> dimensionNames;
-
-    for (const auto dimensionName : fetchDimensionNames())
+    for (const auto& dimensionName : fetchDimensionNames())
         dimensionNames.push_back(dimensionName);
 
     setDimensionNames(dimensionNames);
@@ -1044,7 +1044,7 @@ QVariantMap Points::toVariantMap() const
     QStringList dimensionNames;
 
     if (getDimensionNames().size() != getNumPoints()) {
-        for (const auto dimensionName : getDimensionNames())
+        for (const auto& dimensionName : getDimensionNames())
             dimensionNames << dimensionName;
     }
     else {
@@ -1073,7 +1073,6 @@ QVariantMap Points::toVariantMap() const
 
     variantMap["Data"]                  = isFull() ? getRawData<PointData>()->toVariantMap() : QVariantMap();
     variantMap["NumberOfPoints"]        = getNumPoints();
-    variantMap["Full"]                  = isFull();
     variantMap["Indices"]               = indices;
     variantMap["Selection"]             = selection;
     variantMap["DimensionNames"]        = rawDataToVariantMap((char*)dimensionsByteArray.data(), dimensionsByteArray.size(), true);

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -1019,6 +1019,7 @@ void Points::fromVariantMap(const QVariantMap& variantMap)
 
     events().notifyDatasetDataChanged(this);
 
+    // Handle saved selection after loading data
     if (isFull()) {
         const auto& selectionMap = variantMap["Selection"].toMap();
 

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -8,26 +8,26 @@
 #endif
 
 #include "PointData.h"
-#include "InfoAction.h"
+
 #include "DimensionsPickerAction.h"
-#include "event/Event.h"
+#include "InfoAction.h"
 
-#include <QtCore>
-#include <QtDebug>
-#include <QPainter>
-
-#include <cstring>
-#include <type_traits>
-#include <queue>
-#include <set>
-
-#include "graphics/Vector2f.h"
-#include "Application.h"
+#include <Application.h>
+#include <DataHierarchyItem.h>
 
 #include <actions/GroupAction.h>
+#include <event/Event.h>
+#include <graphics/Vector2f.h>
 #include <util/Serialization.h>
 #include <util/Timer.h>
-#include <DataHierarchyItem.h>
+
+#include <QPainter>
+#include <QtCore>
+#include <QtDebug>
+
+#include <cstring>
+#include <set>
+#include <type_traits>
 
 Q_PLUGIN_METADATA(IID "nl.tudelft.PointData")
 

--- a/HDPS/src/plugins/PointData/src/PointData.h
+++ b/HDPS/src/plugins/PointData/src/PointData.h
@@ -533,6 +533,12 @@ public:
     void setValueAt(std::size_t index, float newValue);
 
     /**
+     * Returns the version number, currently mirros the ManiVault version
+     * @return Version string "Major.Minor"
+     */
+    QString getVersion() const final;
+
+    /**
      * Load point data from variant map
      * @param Variant map representation of the point data
      */

--- a/HDPS/src/plugins/PointData/src/PointData.h
+++ b/HDPS/src/plugins/PointData/src/PointData.h
@@ -8,16 +8,16 @@
 
 #include "RawData.h"
 
-#include "Set.h"
-#include "PointDataRange.h"
 #include "LinkedData.h"
+#include "PointDataRange.h"
+#include "Set.h"
 
 #include "event/EventListener.h"
 
 #include <biovault_bfloat16/biovault_bfloat16.h>
 
-#include <QString>
 #include <QMap>
+#include <QString>
 #include <QVariant>
 
 #include <array>

--- a/HDPS/src/plugins/PointData/src/PointData.h
+++ b/HDPS/src/plugins/PointData/src/PointData.h
@@ -533,12 +533,6 @@ public:
     void setValueAt(std::size_t index, float newValue);
 
     /**
-     * Returns the version number, currently mirros the ManiVault version
-     * @return Version string "Major.Minor"
-     */
-    QString getVersion() const final;
-
-    /**
      * Load point data from variant map
      * @param Variant map representation of the point data
      */

--- a/HDPS/src/private/DataHierarchyManager.cpp
+++ b/HDPS/src/private/DataHierarchyManager.cpp
@@ -9,6 +9,7 @@
 
 #include <QMessageBox>
 
+#include <algorithm>
 #include <stdexcept>
 
 using namespace mv::util;
@@ -237,8 +238,9 @@ void DataHierarchyManager::fromVariantMap(const QVariantMap& variantMap)
     auto& projectDataSerializationTask = projects().getProjectSerializationTask().getDataTask();
 
     QStringList subtasks;
+    std::vector<std::pair<QVariantMap, bool>> datasetList;
 
-    const std::function<void(const QVariantMap&)> enumerateDatasetNames = [&enumerateDatasetNames, &subtasks](const QVariantMap& variantMap) -> void {
+    const std::function<void(const QVariantMap&)> enumerateDatasetNames = [&enumerateDatasetNames, &subtasks, &datasetList](const QVariantMap& variantMap) -> void {
         for (const auto& variant : variantMap.values()) {
             enumerateDatasetNames(variant.toMap()["Children"].toMap());
 
@@ -246,6 +248,7 @@ void DataHierarchyManager::fromVariantMap(const QVariantMap& variantMap)
             const auto datasetId    = dataset["ID"].toString();
 
             subtasks << datasetId;
+            datasetList.emplace_back(dataset, dataset["Derived"].toBool() || dataset["MayUnderive"].toBool());
         }
     };
 
@@ -254,27 +257,27 @@ void DataHierarchyManager::fromVariantMap(const QVariantMap& variantMap)
     projectDataSerializationTask.setSubtasks(subtasks);
     projectDataSerializationTask.setRunning();
 
-    const auto loadDataset = [&projectDataSerializationTask](const QVariantMap& dataHierarchyItemMap, const QString& guiName, Dataset<DatasetImpl> parent) -> Dataset<DatasetImpl> {
+    const auto loadDataHierarchyItem = [&projectDataSerializationTask](const QVariantMap& dataHierarchyItemMap, const QString& guiName, Dataset<DatasetImpl> parent) -> Dataset<DatasetImpl> {
         const auto dataset      = dataHierarchyItemMap["Dataset"].toMap();
         const auto datasetId    = dataset["ID"].toString();
         const auto datasetName  = dataset["Name"].toString();
         const auto pluginKind   = dataset["PluginKind"].toString();
 
-        projectDataSerializationTask.setSubtaskStarted(datasetId, QString("Loading dataset: %1").arg(datasetName));
+        auto subtaskName = QString("Loading dataset hierarchy item: %1").arg(datasetName);
+        projectDataSerializationTask.setSubtaskStarted(datasetId, subtaskName);
         
         auto loadedDataset = mv::data().createDataset(pluginKind, guiName, parent, dataset["ID"].toString());
         
         loadedDataset->getDataHierarchyItem().fromVariantMap(dataHierarchyItemMap);
-        loadedDataset->fromVariantMap(dataset);
 
-        projectDataSerializationTask.setSubtaskFinished(datasetId, QString("Loading dataset: %1").arg(datasetName));
+        projectDataSerializationTask.setSubtaskFinished(datasetId, subtaskName);
 
         QCoreApplication::processEvents();
 
         return loadedDataset;
     };
 
-    const std::function<void(const QVariantMap&, Dataset<DatasetImpl>)> loadDataHierarchyItem = [&loadDataHierarchyItem, loadDataset](const QVariantMap& variantMap, Dataset<DatasetImpl> parent) -> void {
+    const std::function<void(const QVariantMap&, Dataset<DatasetImpl>)> populateDataHierarchy = [&populateDataHierarchy, loadDataHierarchyItem](const QVariantMap& variantMap, Dataset<DatasetImpl> parent) -> void {
 
         if (Application::isSerializationAborted())
             return;
@@ -287,10 +290,42 @@ void DataHierarchyManager::fromVariantMap(const QVariantMap& variantMap)
             sortedItems[variant.toMap()["SortIndex"].toInt()] = variant.toMap();
 
         for (const auto& item : sortedItems)
-            loadDataHierarchyItem(item["Children"].toMap(), loadDataset(item, item["Name"].toString(), parent));
+            populateDataHierarchy(item["Children"].toMap(), loadDataHierarchyItem(item, item["Name"].toString(), parent));
     };
 
-    loadDataHierarchyItem(variantMap, Dataset<DatasetImpl>());
+    auto populateDatasets = [&projectDataSerializationTask, &datasetList](const QVariantMap& variantMap) -> void {
+
+        if (Application::isSerializationAborted())
+            return;
+
+        // Maintain data hierarchy item order within partitions
+        std::reverse(datasetList.begin(), datasetList.end());
+
+        // First load non-derived datasets
+        std::stable_partition(datasetList.begin(), datasetList.end(),
+            [](const std::pair<QVariantMap, bool>& element) {
+                return !element.second; 
+            });
+
+        for (const auto& [dataVariantMap, isDerived] : datasetList)
+        {
+            const auto datasetId = dataVariantMap["ID"].toString();
+            const auto datasetName = dataVariantMap["Name"].toString();
+
+            auto subtaskName = QString("Loading dataset: %1").arg(datasetName);
+            projectDataSerializationTask.setSubtaskStarted(datasetId, subtaskName);
+
+            mv::data().getDataset(datasetId)->fromVariantMap(dataVariantMap);
+
+            projectDataSerializationTask.setSubtaskFinished(datasetId, subtaskName);
+
+            QCoreApplication::processEvents();
+        }
+    };
+
+    populateDataHierarchy(variantMap, Dataset<DatasetImpl>());
+
+    populateDatasets(variantMap);
 
     projectDataSerializationTask.setFinished();
 }

--- a/HDPS/src/private/DataHierarchyManager.cpp
+++ b/HDPS/src/private/DataHierarchyManager.cpp
@@ -248,7 +248,7 @@ void DataHierarchyManager::fromVariantMap(const QVariantMap& variantMap)
             const auto datasetId    = dataset["ID"].toString();
 
             subtasks << datasetId;
-            datasetList.emplace_back(dataset, dataset["Derived"].toBool() || dataset["MayUnderive"].toBool());
+            datasetList.emplace_back(dataset, dataset["Derived"].toBool());
         }
     };
 

--- a/HDPS/src/private/DataManager.cpp
+++ b/HDPS/src/private/DataManager.cpp
@@ -407,15 +407,14 @@ Dataset<DatasetImpl> DataManager::createSubsetFromSelection(const Dataset<Datase
         // Assign source dataset to subset
         *subset = *const_cast<Dataset<DatasetImpl>&>(sourceDataset);
 
-        subset->setAll(false);
         subset->setText(guiName);
-        subset->getDataHierarchyItem().setVisible(visible);
 
         // Set a pointer to the original full dataset, if the source is another subset, we take their pointer
-        subset->_fullDataset = sourceDataset->isFull() ? sourceDataset : sourceDataset->_fullDataset;
+        subset->makeSubsetOf(sourceDataset->isFull() ? sourceDataset : sourceDataset->_fullDataset);
 
         addDataset(subset, parentDataset, notify);
 
+        subset->getDataHierarchyItem().setVisible(visible);
         subset->init();
 
         return subset;

--- a/HDPS/src/private/DockManager.cpp
+++ b/HDPS/src/private/DockManager.cpp
@@ -5,10 +5,9 @@
 #include "DockManager.h"
 #include "ViewPluginDockWidget.h"
 
-#include <ViewPlugin.h>
-
-#include <CoreInterface.h>
 #include <AbstractPluginManager.h>
+#include <CoreInterface.h>
+#include <ViewPlugin.h>
 
 #include <util/Serialization.h>
 #include <widgets/InfoWidget.h>

--- a/HDPS/src/private/DockManager.cpp
+++ b/HDPS/src/private/DockManager.cpp
@@ -158,10 +158,10 @@ void DockManager::fromVariantMap(const QVariantMap& variantMap)
 
         const auto viewPluginDockWidgetsList = variantMap["ViewPluginDockWidgets"].toList();
 
-        for (auto viewPluginDockWidgetVariant : viewPluginDockWidgetsList)
+        for (const auto& viewPluginDockWidgetVariant : viewPluginDockWidgetsList)
             ViewPluginDockWidget::preRegisterSerializationTask(this, viewPluginDockWidgetVariant.toMap()["ID"].toString(), this);
 
-        for (auto viewPluginDockWidgetVariant : viewPluginDockWidgetsList) {
+        for (const auto& viewPluginDockWidgetVariant : viewPluginDockWidgetsList) {
             const auto viewPluginMap    = viewPluginDockWidgetVariant.toMap()["ViewPlugin"].toMap();
             const auto pluginKind       = viewPluginMap["Kind"].toString();
             const auto pluginMap        = viewPluginMap["Plugin"].toMap();
@@ -207,14 +207,14 @@ QVariantMap DockManager::toVariantMap() const
 
     _serializationTask->setEnabled(true);
 
-    for (auto viewPluginDockWidget : getViewPluginDockWidgets())
+    for (const auto& viewPluginDockWidget : getViewPluginDockWidgets())
         ViewPluginDockWidget::preRegisterSerializationTask(const_cast<DockManager*>(this), viewPluginDockWidget->getId(), const_cast<DockManager*>(this));
 
     auto variantMap = Serializable::toVariantMap();
 
     QVariantList viewPluginDockWidgetsList;
 
-    for (auto viewPluginDockWidget : getViewPluginDockWidgets())
+    for (const auto& viewPluginDockWidget : getViewPluginDockWidgets())
         viewPluginDockWidgetsList << viewPluginDockWidget->toVariantMap();
 
     const_cast<DockManager*>(this)->_layoutTask.setRunning();

--- a/HDPS/src/private/PluginManager.cpp
+++ b/HDPS/src/private/PluginManager.cpp
@@ -272,7 +272,7 @@ QStringList PluginManager::resolveDependencies(QDir pluginDir) const
     return resolvedOrderedPluginNames;
 }
 
-plugin::Plugin* PluginManager::requestPlugin(const QString& kind, Datasets datasets /*= Datasets()*/)
+plugin::Plugin* PluginManager::requestPlugin(const QString& kind, Datasets inputDatasets /*= Datasets()*/, Datasets outputDatasets /*= Datasets()*/)
 {
     try
     {
@@ -291,19 +291,19 @@ plugin::Plugin* PluginManager::requestPlugin(const QString& kind, Datasets datas
             case plugin::Type::ANALYSIS: {
                 auto analysisPlugin = dynamic_cast<AnalysisPlugin*>(pluginInstance);
 
-                for (auto dataset : datasets)
-                    dataset->setAnalysis(analysisPlugin);
+                if (!inputDatasets.isEmpty())
+                    analysisPlugin->setInputDataset(inputDatasets.first());
 
-                if (!datasets.isEmpty())
-                    analysisPlugin->setInputDataset(datasets.first());
+                if (!outputDatasets.isEmpty())
+                    analysisPlugin->setOutputDataset(outputDatasets.first());
 
                 break;
             }
             case plugin::Type::WRITER: {
                 auto writerPlugin = dynamic_cast<WriterPlugin*>(pluginInstance);
 
-                if (!datasets.isEmpty())
-                    writerPlugin->setInputDataset(datasets.first());
+                if (!inputDatasets.isEmpty())
+                    writerPlugin->setInputDataset(inputDatasets.first());
 
                 break;
             }

--- a/HDPS/src/private/PluginManager.cpp
+++ b/HDPS/src/private/PluginManager.cpp
@@ -620,14 +620,14 @@ void PluginManager::fromVariantMap(const QVariantMap& variantMap)
             auto analysisPluginMap = loadedAnalysis.toMap();
 
             variantMapMustContain(analysisPluginMap, "Kind");
-            variantMapMustContain(analysisPluginMap, "InputDatasetsGUIDs");
-            variantMapMustContain(analysisPluginMap, "OutputDatasetsGUIDs");
+            variantMapMustContain(analysisPluginMap, "InputDatasetsIDs");
+            variantMapMustContain(analysisPluginMap, "OutputDatasetsIDs");
 
             auto analysisPluginKind = analysisPluginMap["Kind"].toString();
             if (_pluginFactories.contains(analysisPluginKind))
             {
-                auto inputDatasetsGUIDs = analysisPluginMap["InputDatasetsGUIDs"].toStringList();
-                auto outputDatasetsGUIDs = analysisPluginMap["OutputDatasetsGUIDs"].toStringList();
+                auto inputDatasetsGUIDs = analysisPluginMap["InputDatasetsIDs"].toStringList();
+                auto outputDatasetsGUIDs = analysisPluginMap["OutputDatasetsIDs"].toStringList();
 
                 Datasets inputDatasets;
                 for (const auto& inputDatasetGUID : inputDatasetsGUIDs)

--- a/HDPS/src/private/PluginManager.cpp
+++ b/HDPS/src/private/PluginManager.cpp
@@ -626,11 +626,11 @@ void PluginManager::fromVariantMap(const QVariantMap& variantMap)
 
             Datasets inputDatasets;
             for (const auto& inputDatasetGUID : inputDatasetsGUIDs)
-                inputDatasets << mv::data().getSet(inputDatasetGUID);
+                inputDatasets << mv::data().getDataset(inputDatasetGUID);
 
             Datasets outputDatasets;
             for (const auto& outputDatasetGUID : outputDatasetsGUIDs)
-                outputDatasets << mv::data().getSet(outputDatasetGUID);
+                outputDatasets << mv::data().getDataset(outputDatasetGUID);
 
             auto analysisPlugin = dynamic_cast<plugin::AnalysisPlugin*>(plugins().requestPlugin(analysisPluginKind, inputDatasets, outputDatasets));
             if (analysisPlugin)
@@ -647,13 +647,13 @@ QVariantMap PluginManager::toVariantMap() const
     QVariantList usedPluginsList;     // kinds of used plugins
     QVariantList loadedAnalysesList;  // openend analysis plugin instances
 
-    for (const auto pluginFactory : _pluginFactories.values())
+    for (const auto& pluginFactory : _pluginFactories.values())
         if ((pluginFactory->getType() == Type::DATA || pluginFactory->getType() == Type::ANALYSIS || pluginFactory->getType() == Type::VIEW) && pluginFactory->getNumberOfInstances() > 0)
             usedPluginsList << pluginFactory->getKind();
 
-    for(const auto loadedPlugin : _plugins)
+    for(const auto& loadedPlugin : _plugins)
         if(loadedPlugin->getType() == Type::ANALYSIS )
-            loadedAnalysesList << dynamic_cast<plugin::AnalysisPlugin*>(loadedPlugin)->toVariantMap();
+            loadedAnalysesList << dynamic_cast<plugin::AnalysisPlugin*>(loadedPlugin.get())->toVariantMap();
 
     variantMap.insert({
         { "UsedPlugins", usedPluginsList },

--- a/HDPS/src/private/PluginManager.cpp
+++ b/HDPS/src/private/PluginManager.cpp
@@ -615,14 +615,14 @@ void PluginManager::fromVariantMap(const QVariantMap& variantMap)
         auto analysisPluginMap = loadedAnalysis.toMap();
 
         variantMapMustContain(analysisPluginMap, "Kind");
-        variantMapMustContain(analysisPluginMap, "inputDatasetsGUIDs");
-        variantMapMustContain(analysisPluginMap, "outputDatasetsGUIDs");
+        variantMapMustContain(analysisPluginMap, "InputDatasetsGUIDs");
+        variantMapMustContain(analysisPluginMap, "OutputDatasetsGUIDs");
 
         auto analysisPluginKind = analysisPluginMap["Kind"].toString();
         if (_pluginFactories.contains(analysisPluginKind))
         {
-            auto inputDatasetsGUIDs = analysisPluginMap["inputDatasetsGUIDs"].toStringList();
-            auto outputDatasetsGUIDs = analysisPluginMap["outputDatasetsGUIDs"].toStringList();
+            auto inputDatasetsGUIDs = analysisPluginMap["InputDatasetsGUIDs"].toStringList();
+            auto outputDatasetsGUIDs = analysisPluginMap["OutputDatasetsGUIDs"].toStringList();
 
             Datasets inputDatasets;
             for (const auto& inputDatasetGUID : inputDatasetsGUIDs)

--- a/HDPS/src/private/PluginManager.cpp
+++ b/HDPS/src/private/PluginManager.cpp
@@ -303,7 +303,7 @@ plugin::Plugin* PluginManager::requestPlugin(const QString& kind, Datasets input
                 auto writerPlugin = dynamic_cast<WriterPlugin*>(pluginInstance);
 
                 if (!inputDatasets.isEmpty())
-                    writerPlugin->setInputDataset(inputDatasets.first());
+                    writerPlugin->setInputDatasets(inputDatasets);
 
                 break;
             }

--- a/HDPS/src/private/PluginManager.h
+++ b/HDPS/src/private/PluginManager.h
@@ -45,8 +45,8 @@ public: // Plugin creation/destruction
      * @param datasets Zero or more datasets upon which the plugin is based (e.g. analysis plugin)
      * @return Pointer to created plugin, nullptr if creation failed
      */
-    plugin::Plugin* requestPlugin(const QString& kind, Datasets datasets = Datasets()) override;
-
+    plugin::Plugin* requestPlugin(const QString& kind, Datasets inputDatasets = Datasets(), Datasets outputDatasets = Datasets()) override;
+    
     /**
      * Create a view plugin plugin of \p kind and dock it to \p dockToViewPlugin at \p dockArea
      * @param kind Kind of plugin (name of the plugin)


### PR DESCRIPTION
This PR supersedes #455.
All existing plugins should still just compile and run fine with after PR.

ManiVault can now save and load analysis plugins to/from projects files.

Analysis plugins now can have multiple Input and Output datasets:
```cpp
// Analysis & Transformation and Writer Plugins
void setInputDataset(const Dataset<DatasetImpl>& inputDataset);
void setInputDatasets(const Datasets& inputDatasets);               // NEW

Dataset<DatasetType> getInputDataset();
Datasets getInputDatasets();                                        // NEW

// Only Analysis Plugins
void setOutputDataset(const Dataset<DatasetImpl>& outputDataset);
void setOutputDatasets(const Datasets& outputDatasets);             // NEW

Dataset<DatasetType> getOutputDataset();
Datasets getOutputDatasets();                                       // NEW

bool outputDataInit()                                               // NEW
```

Your Analysis plugin must of course overload the `fromVariantMap` and `toVariantMap` functions. Additionally, the `init()` function needs to take into account that the out dataset of the plugin will already be loaded and does not need to be created anymore.
Here is an example setup when implementing save-able analysis plugins:
```cpp
// if not loaded from project, init new data
if (!outputDataInit())
{
    qDebug() << "PCAPlugin::create new derived data";

    auto newOutput = Dataset<Points>(mv::data().createDerivedDataset("PCA", inputDataset, inputDataset));
    setOutputDataset(newOutput);

    // Set initial data (default 2 dimensions, all points at (0,0) )
    std::vector<float> initialData;
    const size_t numInitialDataDimensions = 2;
    const auto numPoints = inputDataset->getNumPoints();
    initialData.resize(numInitialDataDimensions * numPoints);
    newOutput->setData(initialData.data(), numPoints, numInitialDataDimensions);
    events().notifyDatasetDataChanged(newOutput);
}

// Same as always
auto outputDataset = getOutputDataset<Points>();
```

Other changes:
- Serialization of `DatasetImpl::_properties`
- Serialization of `DatasetImpl::_groupIndex`
- Serialization of `DatasetImpl::_mayUnderive`
- Added `PointData::getVersion` which returns the current ManiVault version. This helps with adjusting behavior for loading projects which saved point data whose version was "No Version"
- Fix serialization of `PointData::_dimNames`: They only correctly saved when `getDimensionNames().size() != getNumPoints()`
- Marked more functions as const