### PR TITLE
Limit the number of system view plugins

### DIFF
--- a/HDPS/src/PluginFactory.cpp
+++ b/HDPS/src/PluginFactory.cpp
@@ -103,9 +103,14 @@ std::uint32_t PluginFactory::getNumberOfInstances() const
 
 void PluginFactory::setNumberOfInstances(std::uint32_t numberOfInstances)
 {
+    if (numberOfInstances == _numberOfInstances)
+        return;
+
     _numberOfInstances = numberOfInstances;
 
     _pluginTriggerAction.setEnabled(mayProduce());
+
+    emit numberOfInstancesChanged(_numberOfInstances);
 }
 
 std::uint32_t PluginFactory::getMaximumNumberOfInstances() const

--- a/HDPS/src/PluginFactory.h
+++ b/HDPS/src/PluginFactory.h
@@ -195,6 +195,14 @@ protected:
      */
     static std::uint16_t getNumberOfDatasetsForType(const Datasets& datasets, const DataType& dataType);
 
+signals:
+
+    /**
+     * Signals that the number of instances changed to \p numberOfInstances
+     * @param numberOfInstances Number of plugin instances
+     */
+    void numberOfInstancesChanged(std::uint32_t numberOfInstances);
+
 private:
     QString                     _kind;                          /** Kind of plugin (e.g. scatter plot plugin & TSNE analysis plugin) */
     Type                        _type;                          /** Type of plugin (e.g. analysis, data, loader, writer & view) */

--- a/HDPS/src/private/LoadSystemViewMenu.cpp
+++ b/HDPS/src/private/LoadSystemViewMenu.cpp
@@ -62,7 +62,6 @@ void LoadSystemViewMenu::populate()
         for (auto& action : actions)
             addAction(action);
     }
-
 }
 
 bool LoadSystemViewMenu::mayProducePlugins() const
@@ -96,6 +95,11 @@ QVector<QPointer<TriggerAction>> LoadSystemViewMenu::getLoadSystemViewsActions(m
 
         action->setIcon(pluginTriggerAction->icon());
         action->setEnabled(pluginTriggerAction->isEnabled());
+
+        connect(pluginTriggerAction, &PluginTriggerAction::enabledChanged, this, [action, pluginTriggerAction](bool enabled) -> void {
+            if (enabled != action->isEnabled())
+                action->setEnabled(enabled);
+        });
 
         ViewPlugin* dockToViewPlugin = nullptr;
 

--- a/HDPS/src/private/PluginManager.cpp
+++ b/HDPS/src/private/PluginManager.cpp
@@ -285,6 +285,9 @@ plugin::Plugin* PluginManager::requestPlugin(const QString& kind, Datasets datas
         if (pluginInstance == nullptr)
             throw std::runtime_error(QString("Unable to produce plugin of kind %1").arg(kind).toStdString());
 
+        if (!pluginFactory->mayProduce())
+            throw std::runtime_error("Maximum number of plugin instances reached");
+
         pluginFactory->setNumberOfInstances(pluginFactory->getNumberOfInstances() + 1);
 
         switch (pluginFactory->getType()) {


### PR DESCRIPTION
This PR solves the issue(s) addressed in #458 in two ways:
- The `PluginManager` excepts when a view plugin of `kind` is already alive
- The `LoadSystemViewMenu` now synchronizes the read-only state with the plugin trigger action