### PR TITLE
Add settings API for global plugin settings

### DIFF
--- a/HDPS/cmake/CMakeMvSourcesPublic.cmake
+++ b/HDPS/cmake/CMakeMvSourcesPublic.cmake
@@ -372,8 +372,8 @@ set(PUBLIC_WIDGET_SOURCES
     src/widgets/ActionsWidget.cpp
     src/widgets/SplashScreenWidget.cpp
     src/widgets/ElidedLabel.cpp
-    src/widgets/FlowLayout.h
-	
+    src/widgets/FlowLayout.cpp
+
     ${ACTION_HIERARCHY_SOURCES}
 )
 
@@ -666,6 +666,7 @@ set(PUBLIC_GLOBAL_SETTINGS_HEADERS
     src/TasksSettingsAction.h
     src/ApplicationSettingsAction.h
     src/TemporaryDirectoriesSettingsAction.h
+    src/PluginGlobalSettingsGroupAction.h
 )
 
 set(PUBLIC_GLOBAL_SETTINGS_SOURCES
@@ -675,6 +676,7 @@ set(PUBLIC_GLOBAL_SETTINGS_SOURCES
     src/TasksSettingsAction.cpp
     src/ApplicationSettingsAction.cpp
     src/TemporaryDirectoriesSettingsAction.cpp
+    src/PluginGlobalSettingsGroupAction.cpp
 )
 
 set(PUBLIC_GLOBAL_SETTINGS_FILES

--- a/HDPS/src/AbstractPluginManager.h
+++ b/HDPS/src/AbstractPluginManager.h
@@ -45,8 +45,8 @@ public:
     {
     }
     
-    /** Loads all plugin factories from the plugin directory and adds them as menu items */
-    virtual void loadPlugins() = 0;
+    /** Loads all plugin factories from the plugin directory */
+    virtual void loadPluginFactories() = 0;
 
     /**
      * Determine whether a plugin of \p kind is loaded
@@ -239,6 +239,9 @@ signals:
      * @param id Globally unique ID of the destroyed plugin
      */
     void pluginDestroyed(const QString& id);
+
+    /** Signals that all plugin factories have been loaded */
+    void pluginFactoriesLoaded();
 
     friend class gui::PluginTriggerAction;
 };

--- a/HDPS/src/AbstractSettingsManager.h
+++ b/HDPS/src/AbstractSettingsManager.h
@@ -49,18 +49,18 @@ public: // Action getters
 
 public: // Global settings actions
 
-    virtual ParametersSettingsAction& getParametersSettings() = 0;
-    virtual MiscellaneousSettingsAction& getMiscellaneousSettings() = 0;
-    virtual TasksSettingsAction& getTasksSettingsAction() = 0;
-    virtual ApplicationSettingsAction& getApplicationSettings() = 0;
-    virtual TemporaryDirectoriesSettingsAction& getTemporaryDirectoriesSettingsAction() = 0;
+    virtual gui::ParametersSettingsAction& getParametersSettings() = 0;
+    virtual gui::MiscellaneousSettingsAction& getMiscellaneousSettings() = 0;
+    virtual gui::TasksSettingsAction& getTasksSettingsAction() = 0;
+    virtual gui::ApplicationSettingsAction& getApplicationSettings() = 0;
+    virtual gui::TemporaryDirectoriesSettingsAction& getTemporaryDirectoriesSettingsAction() = 0;
 
     /**
      * Get plugin global settings for plugin \p kind
      * @param kind Plugin kind
      * @return Pointer to plugin global settings (if available, otherwise returns a nullptr)
      */
-    virtual PluginGlobalSettingsGroupAction* getPluginGlobalSettingsGroupAction(const QString& kind) = 0;
+    virtual gui::PluginGlobalSettingsGroupAction* getPluginGlobalSettingsGroupAction(const QString& kind) = 0;
 };
 
 }

--- a/HDPS/src/AbstractSettingsManager.h
+++ b/HDPS/src/AbstractSettingsManager.h
@@ -15,6 +15,12 @@
 #include "TemporaryDirectoriesSettingsAction.h"
 #include "PluginGlobalSettingsGroupAction.h"
 
+namespace mv {
+    namespace plugin {
+        class Plugin;
+    }
+}
+
 namespace mv
 {
 
@@ -61,6 +67,33 @@ public: // Global settings actions
      * @return Pointer to plugin global settings (if available, otherwise returns a nullptr)
      */
     virtual gui::PluginGlobalSettingsGroupAction* getPluginGlobalSettingsGroupAction(const QString& kind) = 0;
+
+    /**
+     * Get plugin global settings \p ActionType for plugin \p kind
+     * @param kind Plugin kind
+     * @return Pointer to plugin global settings of \p ActionType (if available, otherwise returns a nullptr)
+     */
+    template<typename ActionType>
+    ActionType* getPluginGlobalSettingsGroupAction(const QString& kind) {
+        return dynamic_cast<ActionType*>(getPluginGlobalSettingsGroupAction(kind));
+    }
+
+    /**
+    * Get plugin global settings for \p plugin
+    * @param plugin Pointer to plugin
+    * @return Pointer to plugin global settings (if available, otherwise returns a nullptr)
+    */
+    virtual gui::PluginGlobalSettingsGroupAction* getPluginGlobalSettingsGroupAction(const plugin::Plugin* plugin) = 0;
+
+    /**
+    * Get plugin global settings of \p ActionType for \p plugin
+    * @param plugin Pointer to plugin
+    * @return Pointer to plugin global settings of \p ActionType (if available, otherwise returns a nullptr)
+    */
+    template<typename ActionType>
+    ActionType* getPluginGlobalSettingsGroupAction(const plugin::Plugin* plugin) {
+        return dynamic_cast<ActionType*>(getPluginGlobalSettingsGroupAction(plugin));
+    }
 };
 
 }

--- a/HDPS/src/AbstractSettingsManager.h
+++ b/HDPS/src/AbstractSettingsManager.h
@@ -13,6 +13,7 @@
 #include "TasksSettingsAction.h"
 #include "ApplicationSettingsAction.h"
 #include "TemporaryDirectoriesSettingsAction.h"
+#include "PluginGlobalSettingsGroupAction.h"
 
 namespace mv
 {
@@ -53,6 +54,13 @@ public: // Global settings actions
     virtual TasksSettingsAction& getTasksSettingsAction() = 0;
     virtual ApplicationSettingsAction& getApplicationSettings() = 0;
     virtual TemporaryDirectoriesSettingsAction& getTemporaryDirectoriesSettingsAction() = 0;
+
+    /**
+     * Get plugin global settings for plugin \p kind
+     * @param kind Plugin kind
+     * @return Pointer to plugin global settings (if available, otherwise returns a nullptr)
+     */
+    virtual PluginGlobalSettingsGroupAction* getPluginGlobalSettingsGroupAction(const QString& kind) = 0;
 };
 
 }

--- a/HDPS/src/ApplicationSettingsAction.cpp
+++ b/HDPS/src/ApplicationSettingsAction.cpp
@@ -9,7 +9,7 @@
 #include "util/MacThemeHelper.h"
 #endif // Q_OS_MACX
 
-namespace mv
+namespace mv::gui
 {
 
 ApplicationSettingsAction::ApplicationSettingsAction(QObject* parent) :

--- a/HDPS/src/ApplicationSettingsAction.cpp
+++ b/HDPS/src/ApplicationSettingsAction.cpp
@@ -33,7 +33,6 @@ ApplicationSettingsAction::ApplicationSettingsAction(QObject* parent) :
     if (themesAvailable)
     {
         _appearanceOptionAction.setDefaultWidgetFlags(gui::OptionAction::HorizontalButtons);
-        _appearanceOptionAction.setSettingsPrefix(getSettingsPrefix() + "AppearanceOption");
             
         addAction(&_appearanceOptionAction);
         

--- a/HDPS/src/ApplicationSettingsAction.h
+++ b/HDPS/src/ApplicationSettingsAction.h
@@ -9,7 +9,7 @@
 #include "actions/StringAction.h"
 #include "actions/OptionAction.h"
 
-namespace mv
+namespace mv::gui
 {
 
 /**
@@ -32,12 +32,12 @@ public:
 
 public: // Action getters
 
-    gui::StringAction& getApplicationSessionIdAction() { return _applicationSessionIdAction; }
-    gui::OptionAction& getAppearanceOptionAction() { return _appearanceOptionAction; }
+    StringAction& getApplicationSessionIdAction() { return _applicationSessionIdAction; }
+    OptionAction& getAppearanceOptionAction() { return _appearanceOptionAction; }
 
 private:
-    gui::StringAction   _applicationSessionIdAction;    /** String action for the application session ID */
-    gui::OptionAction   _appearanceOptionAction;        /** Options action for dark, light, or system appearance */
+    StringAction   _applicationSessionIdAction;    /** String action for the application session ID */
+    OptionAction   _appearanceOptionAction;        /** Options action for dark, light, or system appearance */
 };
 
 }

--- a/HDPS/src/CoreInterface.h
+++ b/HDPS/src/CoreInterface.h
@@ -45,7 +45,6 @@ namespace mv
     namespace gui
     {
         class PluginTriggerAction;
-        class GlobalSettingsAction;
 
         using PluginTriggerActions = QVector<QPointer<PluginTriggerAction>>;
     }

--- a/HDPS/src/GlobalSettingsGroupAction.cpp
+++ b/HDPS/src/GlobalSettingsGroupAction.cpp
@@ -16,7 +16,7 @@ GlobalSettingsGroupAction::GlobalSettingsGroupAction(QObject* parent, const QStr
 
 QString GlobalSettingsGroupAction::getSettingsPrefix() const
 {
-    return QString("GlobalSettings/%1/").arg(text());
+    return QString("GlobalSettings/%1/").arg(getSerializationName());
 }
 
 

--- a/HDPS/src/GlobalSettingsGroupAction.cpp
+++ b/HDPS/src/GlobalSettingsGroupAction.cpp
@@ -4,6 +4,8 @@
 
 #include "GlobalSettingsGroupAction.h"
 
+#include <QString>
+
 namespace mv
 {
 
@@ -17,6 +19,26 @@ GlobalSettingsGroupAction::GlobalSettingsGroupAction(QObject* parent, const QStr
 QString GlobalSettingsGroupAction::getSettingsPrefix() const
 {
     return QString("GlobalSettings/%1/").arg(text());
+}
+
+
+void GlobalSettingsGroupAction::addAction(WidgetAction* action, std::int32_t widgetFlags /*= -1*/, WidgetConfigurationFunction widgetConfigurationFunction /*= WidgetConfigurationFunction()*/)
+{
+    Q_ASSERT(action != nullptr);
+
+    if (!action)
+        return;
+
+    const auto actionName = getSettingsPrefix() + action->getSerializationName();
+
+    auto parts = actionName.split(" ");
+
+    for (int i = 0; i < parts.size(); ++i)
+        parts[i].replace(0, 1, parts[i][0].toUpper());
+
+    action->setSettingsPrefix(parts.join(""));
+
+    GroupAction::addAction(action, widgetFlags, widgetConfigurationFunction);
 }
 
 }

--- a/HDPS/src/GlobalSettingsGroupAction.cpp
+++ b/HDPS/src/GlobalSettingsGroupAction.cpp
@@ -6,10 +6,8 @@
 
 #include <QString>
 
-namespace mv
+namespace mv::gui
 {
-
-using namespace gui;
 
 GlobalSettingsGroupAction::GlobalSettingsGroupAction(QObject* parent, const QString& title, bool expanded /*= true*/) :
     GroupAction(parent, title, expanded)

--- a/HDPS/src/GlobalSettingsGroupAction.h
+++ b/HDPS/src/GlobalSettingsGroupAction.h
@@ -40,6 +40,10 @@ namespace mv::gui
  * b. If a plugin already has global settings:
  *     - Add actions to the particular settings action (derived from PluginGlobalSettingsGroupAction) 
  *
+ * Procedure for retrieving global settings:
+ * Common global setting example: mv::settings().getMiscellaneousSettings().getAskConfirmationBeforeRemovingDatasetsAction()
+ * Plugin global setting example: mv::settings().getPluginGlobalSettingsGroupAction<GlobalSettingsAction>(_exampleViewGLPlugin)->getDefaultPointSizeAction().getValue()
+ * 
  * @author Thomas Kroes
  */
 class GlobalSettingsGroupAction : public GroupAction

--- a/HDPS/src/GlobalSettingsGroupAction.h
+++ b/HDPS/src/GlobalSettingsGroupAction.h
@@ -12,7 +12,33 @@ namespace mv::gui
 /**
  * Global settings group action class
  *
- * Base action class which groups related settings
+ * Base action class which groups settings for
+ * - Common global settings (e.g. tasks & parameters)
+ * - Plugin global settings
+ * 
+ * This class ensures that settings are store in the correct place because it overrides the GroupAction::addAction(...)
+ * and adjusts the settings prefix of the added actions.
+ * 
+ * Settings can be found in: ManiVault/GlobalSettings/<global_settings_name>/<action_name>
+ * 
+ * Procedure(s) for adding a common global setting:
+ * a. Add an action to an existing global settings group:
+ *     - ApplicationSettingsAction::addAction(...)
+ *     - MiscellaneousSettingsAction::addAction(...)
+ *     - ParametersSettingsAction::addAction(...)
+ *     - TasksSettingsAction::addAction(...)
+ *     - TemporaryDirectoriesSettingsAction::addAction(...)
+ * b. Create a new settings action derived from GlobalSettingsGroupAction, add it to the SettingsManager
+ *    class and add actions to it: MySettingsAction::addAction(...)
+ * 
+ * Procedure for adding a plugin global setting:
+ * a. If a plugin does not have global settings yet:
+ *     1. Create a settings action (e.g. MyPluginGlobalSettingsAction) derived from PluginGlobalSettingsGroupAction
+ *     2. Add actions to MyPluginGlobalSettingsAction in its constructor (MyPluginGlobalSettingsAction::addAction(...))
+ *     3. Create an instance of MyPluginGlobalSettingsAction, and assign it to the plugin factory in the initialize()
+ *        member function of the plugin factory: setGlobalSettingsGroupAction(new MyPluginGlobalSettingsAction(this, this));
+ * b. If a plugin already has global settings:
+ *     - Add actions to the particular settings action (derived from PluginGlobalSettingsGroupAction) 
  *
  * @author Thomas Kroes
  */

--- a/HDPS/src/GlobalSettingsGroupAction.h
+++ b/HDPS/src/GlobalSettingsGroupAction.h
@@ -29,7 +29,17 @@ public:
     GlobalSettingsGroupAction(QObject* parent, const QString& title, bool expanded = true);
 
     /** Get settings prefix for child actions */
-    QString getSettingsPrefix() const;
+    QString getSettingsPrefix() const override;
+
+public: // Actions management
+
+    /**
+     * Add \p action to the group (facade for GroupAction that automatically sets the WidgetAction settings prefix)
+     * @param action Pointer to action to add
+     * @param widgetFlags Action widget flags (default flags if -1)
+     * @param widgetConfigurationFunction When set, overrides the standard widget configuration function in the widget action
+     */
+    void addAction(WidgetAction* action, std::int32_t widgetFlags = -1, mv::gui::WidgetConfigurationFunction widgetConfigurationFunction = mv::gui::WidgetConfigurationFunction()) override final;
 };
 
 }

--- a/HDPS/src/GlobalSettingsGroupAction.h
+++ b/HDPS/src/GlobalSettingsGroupAction.h
@@ -6,7 +6,7 @@
 
 #include "actions/GroupAction.h"
 
-namespace mv
+namespace mv::gui
 {
 
 /**
@@ -16,7 +16,7 @@ namespace mv
  *
  * @author Thomas Kroes
  */
-class GlobalSettingsGroupAction : public mv::gui::GroupAction
+class GlobalSettingsGroupAction : public GroupAction
 {
 public:
 

--- a/HDPS/src/MiscellaneousSettingsAction.cpp
+++ b/HDPS/src/MiscellaneousSettingsAction.cpp
@@ -5,7 +5,7 @@
 #include "MiscellaneousSettingsAction.h"
 #include "Application.h"
 
-namespace mv
+namespace mv::gui
 {
 
 MiscellaneousSettingsAction::MiscellaneousSettingsAction(QObject* parent) :

--- a/HDPS/src/MiscellaneousSettingsAction.cpp
+++ b/HDPS/src/MiscellaneousSettingsAction.cpp
@@ -22,9 +22,6 @@ MiscellaneousSettingsAction::MiscellaneousSettingsAction(QObject* parent) :
 
     _askConfirmationBeforeRemovingDatasetsAction.setToolTip("Ask confirmation prior to removal of datasets");
     _keepDescendantsAfterRemovalAction.setToolTip("If checked, descendants will not be removed and become orphans (placed at the root of the hierarchy)");
-
-    _ignoreLoadingErrorsAction.setSettingsPrefix(getSettingsPrefix() + "IgnoreLoadingErrors");
-    _askConfirmationBeforeRemovingDatasetsAction.setSettingsPrefix(getSettingsPrefix() + "AskConfirmationBeforeRemovingDatasets");
 }
 
 }

--- a/HDPS/src/MiscellaneousSettingsAction.h
+++ b/HDPS/src/MiscellaneousSettingsAction.h
@@ -9,7 +9,7 @@
 #include "actions/ToggleAction.h"
 #include "actions/OptionAction.h"
 
-namespace mv
+namespace mv::gui
 {
 
 /**
@@ -31,14 +31,14 @@ public:
 
 public: // Action getters
 
-    gui::ToggleAction& getIgnoreLoadingErrorsAction() { return _ignoreLoadingErrorsAction; }
-    gui::ToggleAction& getAskConfirmationBeforeRemovingDatasetsAction() { return _askConfirmationBeforeRemovingDatasetsAction; }
-    gui::ToggleAction& getKeepDescendantsAfterRemovalAction() { return _keepDescendantsAfterRemovalAction; }
+    ToggleAction& getIgnoreLoadingErrorsAction() { return _ignoreLoadingErrorsAction; }
+    ToggleAction& getAskConfirmationBeforeRemovingDatasetsAction() { return _askConfirmationBeforeRemovingDatasetsAction; }
+    ToggleAction& getKeepDescendantsAfterRemovalAction() { return _keepDescendantsAfterRemovalAction; }
 
 private:
-    gui::ToggleAction   _ignoreLoadingErrorsAction;                     /** Toggle between asking for ignoring loading errors or not */
-    gui::ToggleAction   _askConfirmationBeforeRemovingDatasetsAction;   /** Toggle between asking permission before removing datasets or not */
-    gui::ToggleAction   _keepDescendantsAfterRemovalAction;             /** Toggle between asking permission before removing datasets or not */
+    ToggleAction   _ignoreLoadingErrorsAction;                     /** Toggle between asking for ignoring loading errors or not */
+    ToggleAction   _askConfirmationBeforeRemovingDatasetsAction;   /** Toggle between asking permission before removing datasets or not */
+    ToggleAction   _keepDescendantsAfterRemovalAction;             /** Toggle between asking permission before removing datasets or not */
 };
 
 }

--- a/HDPS/src/ParametersSettingsAction.cpp
+++ b/HDPS/src/ParametersSettingsAction.cpp
@@ -7,7 +7,7 @@
 
 using namespace mv::gui;
 
-namespace mv
+namespace mv::gui
 {
 
 ParametersSettingsAction::ParametersSettingsAction(QObject* parent) :

--- a/HDPS/src/ParametersSettingsAction.cpp
+++ b/HDPS/src/ParametersSettingsAction.cpp
@@ -22,10 +22,6 @@ ParametersSettingsAction::ParametersSettingsAction(QObject* parent) :
     addAction(&_confirmRemoveSharedParameterAction);
     addAction(&_expertModeAction);
 
-    _askForSharedParameterNameAction.setSettingsPrefix(getSettingsPrefix() + "AskForSharedParameterName");
-    _confirmRemoveSharedParameterAction.setSettingsPrefix(getSettingsPrefix() + "ConfirmRemoveSharedParameter");
-    _expertModeAction.setSettingsPrefix(getSettingsPrefix() + "ExpertMode");
-
     const auto updateExpertModeActionTooltip = [this]() -> void {
         if (_expertModeAction.isChecked())
             _expertModeAction.setToolTip("Display all parameter connections (expert mode)");

--- a/HDPS/src/ParametersSettingsAction.h
+++ b/HDPS/src/ParametersSettingsAction.h
@@ -8,7 +8,7 @@
 
 #include "actions/ToggleAction.h"
 
-namespace mv
+namespace mv::gui
 {
 
 /**
@@ -30,14 +30,14 @@ public:
 
 public: // Action getters
 
-    gui::ToggleAction& getAskForSharedParameterNameAction() { return _askForSharedParameterNameAction; }
-    gui::ToggleAction& getConfirmRemoveSharedParameterAction() { return _confirmRemoveSharedParameterAction; }
-    gui::ToggleAction& getExpertModeAction() { return _expertModeAction; }
+    ToggleAction& getAskForSharedParameterNameAction() { return _askForSharedParameterNameAction; }
+    ToggleAction& getConfirmRemoveSharedParameterAction() { return _confirmRemoveSharedParameterAction; }
+    ToggleAction& getExpertModeAction() { return _expertModeAction; }
 
 private:
-    gui::ToggleAction   _askForSharedParameterNameAction;       /** Toggle between asking for a name when publishing an action or not */
-    gui::ToggleAction   _confirmRemoveSharedParameterAction;    /** Toggle asking for confirmation prior to removal of public action */
-    gui::ToggleAction   _expertModeAction;                      /** In expert mode, all descendants of a root public action are displayed, otherwise they are hidden */
+    ToggleAction   _askForSharedParameterNameAction;       /** Toggle between asking for a name when publishing an action or not */
+    ToggleAction   _confirmRemoveSharedParameterAction;    /** Toggle asking for confirmation prior to removal of public action */
+    ToggleAction   _expertModeAction;                      /** In expert mode, all descendants of a root public action are displayed, otherwise they are hidden */
 };
 
 }

--- a/HDPS/src/Plugin.cpp
+++ b/HDPS/src/Plugin.cpp
@@ -117,12 +117,22 @@ QStringList Plugin::propertyNames() const
 
 QVariant Plugin::getSetting(const QString& path, const QVariant& defaultValue /*= QVariant()*/) const
 {
-    return Application::current()->getSetting(QString("%1/%2").arg(getKind(), path), defaultValue);
+    return Application::current()->getSetting(QString("%1%2").arg(getGlobalSettingsPrefix(), path), defaultValue);
 }
 
 void Plugin::setSetting(const QString& path, const QVariant& value)
 {
-    Application::current()->setSetting(QString("%1/%2").arg(getKind(), path), value);
+    Application::current()->setSetting(QString("%1%2").arg(getGlobalSettingsPrefix(), path), value);
+}
+
+QString Plugin::getGlobalSettingsPrefix() const
+{
+    return _factory->getGlobalSettingsPrefix();
+}
+
+PluginGlobalSettingsGroupAction* Plugin::getGlobalSettingsAction() const
+{
+    return _factory->getGlobalSettingsGroupAction();
 }
 
 void Plugin::fromVariantMap(const QVariantMap& variantMap)

--- a/HDPS/src/Plugin.h
+++ b/HDPS/src/Plugin.h
@@ -131,6 +131,18 @@ public: // Settings
      */
     void setSetting(const QString& path, const QVariant& value);
 
+    /**
+     * Get global settings prefix (facade for the PluginFactory class)
+     * @return Plugin global settings prefix
+     */
+    QString getGlobalSettingsPrefix() const;
+
+    /**
+     * Get global settings action (facade for the PluginFactory class)
+     * @return Pointer to plugin global settings action (maybe nullptr if plugin does not have global settings)
+     */
+    PluginGlobalSettingsGroupAction* getGlobalSettingsAction() const;
+
 public: // Serialization
 
     /**

--- a/HDPS/src/Plugin.h
+++ b/HDPS/src/Plugin.h
@@ -141,7 +141,7 @@ public: // Settings
      * Get global settings action (facade for the PluginFactory class)
      * @return Pointer to plugin global settings action (maybe nullptr if plugin does not have global settings)
      */
-    PluginGlobalSettingsGroupAction* getGlobalSettingsAction() const;
+    gui::PluginGlobalSettingsGroupAction* getGlobalSettingsAction() const;
 
 public: // Serialization
 

--- a/HDPS/src/PluginFactory.cpp
+++ b/HDPS/src/PluginFactory.cpp
@@ -7,12 +7,9 @@
 
 #include "actions/PluginTriggerAction.h"
 
-namespace mv
-{
+using namespace mv::gui;
 
-using namespace gui;
-
-namespace plugin
+namespace mv::plugin
 {
 
 PluginFactory::PluginFactory(Type type) :
@@ -58,7 +55,7 @@ QString PluginFactory::getGlobalSettingsPrefix() const
     return QString("%1/").arg(getKind());
 }
 
-mv::PluginGlobalSettingsGroupAction* PluginFactory::getGlobalSettingsGroupAction() const
+PluginGlobalSettingsGroupAction* PluginFactory::getGlobalSettingsGroupAction() const
 {
     return _pluginGlobalSettingsGroupAction;
 }
@@ -173,8 +170,6 @@ std::uint16_t PluginFactory::getNumberOfDatasetsForType(const Datasets& datasets
             numberOfDatasetsForType++;
 
     return numberOfDatasetsForType;
-}
-
 }
 
 }

--- a/HDPS/src/PluginFactory.cpp
+++ b/HDPS/src/PluginFactory.cpp
@@ -4,6 +4,7 @@
 
 #include "PluginFactory.h"
 #include "Set.h"
+
 #include "actions/PluginTriggerAction.h"
 
 namespace mv
@@ -22,7 +23,8 @@ PluginFactory::PluginFactory(Type type) :
     _numberOfInstances(0),
     _maximumNumberOfInstances(-1),
     _pluginTriggerAction(this, this, "Plugin trigger", "A plugin trigger action creates a new plugin when triggered", QIcon()),
-    _triggerHelpAction(nullptr, "Trigger plugin help")
+    _triggerHelpAction(nullptr, "Trigger plugin help"),
+    _pluginGlobalSettingsGroupAction(nullptr)
 {
 }
 
@@ -49,6 +51,26 @@ void PluginFactory::initialize()
 
     _triggerHelpAction.setText(_kind);
     _triggerHelpAction.setIcon(getIcon());
+}
+
+QString PluginFactory::getGlobalSettingsPrefix() const
+{
+    return QString("%1/").arg(getKind());
+}
+
+mv::PluginGlobalSettingsGroupAction* PluginFactory::getGlobalSettingsGroupAction() const
+{
+    return _pluginGlobalSettingsGroupAction;
+}
+
+void PluginFactory::setGlobalSettingsGroupAction(PluginGlobalSettingsGroupAction* pluginGlobalSettingsGroupAction)
+{
+    if (pluginGlobalSettingsGroupAction == _pluginGlobalSettingsGroupAction)
+        return;
+
+    _pluginGlobalSettingsGroupAction = pluginGlobalSettingsGroupAction;
+
+    emit pluginGlobalSettingsGroupActionChanged(_pluginGlobalSettingsGroupAction);
 }
 
 bool PluginFactory::hasHelp()

--- a/HDPS/src/PluginFactory.h
+++ b/HDPS/src/PluginFactory.h
@@ -24,6 +24,8 @@ namespace mv
         using PluginTriggerActions = QVector<QPointer<PluginTriggerAction>>;
     }
 
+    class PluginGlobalSettingsGroupAction;
+
 namespace plugin
 {
 
@@ -61,6 +63,26 @@ public:
 
     /** Perform post-construction initialization */
     virtual void initialize();
+
+public: // Global settings
+
+    /**
+     * Get settings prefix
+     * @return Plugin factory global settings prefix
+     */
+    virtual QString getGlobalSettingsPrefix() const final;
+
+    /**
+     * Get global settings group action
+     * @return Pointer to plugin global settings group action (maybe nullptr if plugin does not have global settings)
+     */
+    virtual PluginGlobalSettingsGroupAction* getGlobalSettingsGroupAction() const;
+
+    /**
+     * Set plugin global settings group action to \p pluginGlobalSettingsGroupAction
+     * @param pluginGlobalSettingsGroupAction Pointer to plugin global settings group action (maybe a nullptr)
+     */
+    virtual void setGlobalSettingsGroupAction(PluginGlobalSettingsGroupAction* pluginGlobalSettingsGroupAction) final;
 
 public: // Help
 
@@ -203,15 +225,22 @@ signals:
      */
     void numberOfInstancesChanged(std::uint32_t numberOfInstances);
 
+    /**
+     * Signals that the plugin global settings group action changed to \p pluginGlobalSettingsGroupAction
+     * @param pluginGlobalSettingsGroupAction Pointer to plugin global settings group action (maybe a nullptr)
+     */
+    void pluginGlobalSettingsGroupActionChanged(PluginGlobalSettingsGroupAction* pluginGlobalSettingsGroupAction);
+
 private:
-    QString                     _kind;                          /** Kind of plugin (e.g. scatter plot plugin & TSNE analysis plugin) */
-    Type                        _type;                          /** Type of plugin (e.g. analysis, data, loader, writer & view) */
-    QString                     _guiName;                       /** Name of the plugin in the GUI */
-    QString                     _version;                       /** Plugin version */
-    gui::PluginTriggerAction    _pluginTriggerAction;           /** Standard plugin trigger action that produces an instance of the plugin without any special behavior (respects the maximum number of allowed instances) */
-    std::uint32_t               _numberOfInstances;             /** Number of plugin instances */
-    std::uint32_t               _maximumNumberOfInstances;      /** Maximum number of plugin instances (unlimited when -1) */
-    gui::TriggerAction          _triggerHelpAction;             /** Trigger action that triggers help (icon and text are already set) */
+    QString                             _kind;                                  /** Kind of plugin (e.g. scatter plot plugin & TSNE analysis plugin) */
+    Type                                _type;                                  /** Type of plugin (e.g. analysis, data, loader, writer & view) */
+    QString                             _guiName;                               /** Name of the plugin in the GUI */
+    QString                             _version;                               /** Plugin version */
+    gui::PluginTriggerAction            _pluginTriggerAction;                   /** Standard plugin trigger action that produces an instance of the plugin without any special behavior (respects the maximum number of allowed instances) */
+    std::uint32_t                       _numberOfInstances;                     /** Number of plugin instances */
+    std::uint32_t                       _maximumNumberOfInstances;              /** Maximum number of plugin instances (unlimited when -1) */
+    gui::TriggerAction                  _triggerHelpAction;                     /** Trigger action that triggers help (icon and text are already set) */
+    PluginGlobalSettingsGroupAction*    _pluginGlobalSettingsGroupAction;       /** Pointer to plugin global settings group action (maybe a nullptr) */
 };
 
 }

--- a/HDPS/src/PluginFactory.h
+++ b/HDPS/src/PluginFactory.h
@@ -13,20 +13,19 @@
 #include <QIcon>
 #include <QVariant>
 
-namespace mv
-{
+namespace mv {
     class DatasetImpl;
 
     namespace gui
     {
         class PluginTriggerAction;
+        class PluginGlobalSettingsGroupAction;
 
         using PluginTriggerActions = QVector<QPointer<PluginTriggerAction>>;
     }
+}
 
-    class PluginGlobalSettingsGroupAction;
-
-namespace plugin
+namespace mv::plugin
 {
 
 class Plugin;
@@ -76,13 +75,13 @@ public: // Global settings
      * Get global settings group action
      * @return Pointer to plugin global settings group action (maybe nullptr if plugin does not have global settings)
      */
-    virtual PluginGlobalSettingsGroupAction* getGlobalSettingsGroupAction() const;
+    virtual gui::PluginGlobalSettingsGroupAction* getGlobalSettingsGroupAction() const;
 
     /**
      * Set plugin global settings group action to \p pluginGlobalSettingsGroupAction
      * @param pluginGlobalSettingsGroupAction Pointer to plugin global settings group action (maybe a nullptr)
      */
-    virtual void setGlobalSettingsGroupAction(PluginGlobalSettingsGroupAction* pluginGlobalSettingsGroupAction) final;
+    virtual void setGlobalSettingsGroupAction(gui::PluginGlobalSettingsGroupAction* pluginGlobalSettingsGroupAction) final;
 
 public: // Help
 
@@ -229,22 +228,20 @@ signals:
      * Signals that the plugin global settings group action changed to \p pluginGlobalSettingsGroupAction
      * @param pluginGlobalSettingsGroupAction Pointer to plugin global settings group action (maybe a nullptr)
      */
-    void pluginGlobalSettingsGroupActionChanged(PluginGlobalSettingsGroupAction* pluginGlobalSettingsGroupAction);
+    void pluginGlobalSettingsGroupActionChanged(gui::PluginGlobalSettingsGroupAction* pluginGlobalSettingsGroupAction);
 
 private:
-    QString                             _kind;                                  /** Kind of plugin (e.g. scatter plot plugin & TSNE analysis plugin) */
-    Type                                _type;                                  /** Type of plugin (e.g. analysis, data, loader, writer & view) */
-    QString                             _guiName;                               /** Name of the plugin in the GUI */
-    QString                             _version;                               /** Plugin version */
-    gui::PluginTriggerAction            _pluginTriggerAction;                   /** Standard plugin trigger action that produces an instance of the plugin without any special behavior (respects the maximum number of allowed instances) */
-    std::uint32_t                       _numberOfInstances;                     /** Number of plugin instances */
-    std::uint32_t                       _maximumNumberOfInstances;              /** Maximum number of plugin instances (unlimited when -1) */
-    gui::TriggerAction                  _triggerHelpAction;                     /** Trigger action that triggers help (icon and text are already set) */
-    PluginGlobalSettingsGroupAction*    _pluginGlobalSettingsGroupAction;       /** Pointer to plugin global settings group action (maybe a nullptr) */
+    QString                                 _kind;                                  /** Kind of plugin (e.g. scatter plot plugin & TSNE analysis plugin) */
+    Type                                    _type;                                  /** Type of plugin (e.g. analysis, data, loader, writer & view) */
+    QString                                 _guiName;                               /** Name of the plugin in the GUI */
+    QString                                 _version;                               /** Plugin version */
+    gui::PluginTriggerAction                _pluginTriggerAction;                   /** Standard plugin trigger action that produces an instance of the plugin without any special behavior (respects the maximum number of allowed instances) */
+    std::uint32_t                           _numberOfInstances;                     /** Number of plugin instances */
+    std::uint32_t                           _maximumNumberOfInstances;              /** Maximum number of plugin instances (unlimited when -1) */
+    gui::TriggerAction                      _triggerHelpAction;                     /** Trigger action that triggers help (icon and text are already set) */
+    gui::PluginGlobalSettingsGroupAction*   _pluginGlobalSettingsGroupAction;       /** Pointer to plugin global settings group action (maybe a nullptr) */
 };
 
 }
 
-}
-
-Q_DECLARE_INTERFACE(mv::plugin::PluginFactory, "hdps.PluginFactory")
+Q_DECLARE_INTERFACE(mv::plugin::PluginFactory, "ManiVault.PluginFactory")

--- a/HDPS/src/PluginGlobalSettingsGroupAction.cpp
+++ b/HDPS/src/PluginGlobalSettingsGroupAction.cpp
@@ -6,25 +6,12 @@
 
 #include "Plugin.h"
 
-namespace mv
+namespace mv::gui
 {
-
-using namespace gui;
 
 PluginGlobalSettingsGroupAction::PluginGlobalSettingsGroupAction(QObject* parent, const plugin::PluginFactory* pluginFactory) :
-    GlobalSettingsGroupAction(parent, pluginFactory->getKind()),
-    _pluginFactory(pluginFactory)
+    GlobalSettingsGroupAction(parent, "Plugin: " + pluginFactory->getKind())
 {
 }
-
-//QString PluginGlobalSettingsGroupAction::getSettingsPrefix() const
-//{
-//    Q_ASSERT(_pluginFactory != nullptr);
-//
-//    if (!_pluginFactory)
-//        return {};
-//
-//    return GlobalSettingsGroupAction::getSettingsPrefix() + _pluginFactory->getGlobalSettingsPrefix();
-//}
 
 }

--- a/HDPS/src/PluginGlobalSettingsGroupAction.cpp
+++ b/HDPS/src/PluginGlobalSettingsGroupAction.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#include "PluginGlobalSettingsGroupAction.h"
+
+#include "Plugin.h"
+
+namespace mv
+{
+
+using namespace gui;
+
+PluginGlobalSettingsGroupAction::PluginGlobalSettingsGroupAction(QObject* parent, const plugin::PluginFactory* pluginFactory) :
+    GlobalSettingsGroupAction(parent, pluginFactory->getKind()),
+    _pluginFactory(pluginFactory)
+{
+}
+
+//QString PluginGlobalSettingsGroupAction::getSettingsPrefix() const
+//{
+//    Q_ASSERT(_pluginFactory != nullptr);
+//
+//    if (!_pluginFactory)
+//        return {};
+//
+//    return GlobalSettingsGroupAction::getSettingsPrefix() + _pluginFactory->getGlobalSettingsPrefix();
+//}
+
+}

--- a/HDPS/src/PluginGlobalSettingsGroupAction.cpp
+++ b/HDPS/src/PluginGlobalSettingsGroupAction.cpp
@@ -12,6 +12,7 @@ namespace mv::gui
 PluginGlobalSettingsGroupAction::PluginGlobalSettingsGroupAction(QObject* parent, const plugin::PluginFactory* pluginFactory) :
     GlobalSettingsGroupAction(parent, "Plugin: " + pluginFactory->getKind())
 {
+    setSerializationName(pluginFactory->getKind());
 }
 
 }

--- a/HDPS/src/PluginGlobalSettingsGroupAction.h
+++ b/HDPS/src/PluginGlobalSettingsGroupAction.h
@@ -19,6 +19,15 @@ namespace mv::gui
  * Plugin global settings group action class
  *
  * Global settings group action class for global plugin settings
+ * 
+ * Procedure for adding a plugin global setting:
+ * a. If a plugin does not have global settings yet:
+ *     1. Create a settings action (e.g. MyPluginGlobalSettingsAction) derived from PluginGlobalSettingsGroupAction
+ *     2. Add actions to MyPluginGlobalSettingsAction in its constructor (MyPluginGlobalSettingsAction::addAction(...))
+ *     3. Create an instance of MyPluginGlobalSettingsAction, and assign it to the plugin factory in the initialize()
+ *        member function of the plugin factory: setGlobalSettingsGroupAction(new MyPluginGlobalSettingsAction(this, this));
+ * b. If a plugin already has global settings:
+ *     - Add actions to the particular settings action (derived from PluginGlobalSettingsGroupAction)
  *
  * @author Thomas Kroes
  */

--- a/HDPS/src/PluginGlobalSettingsGroupAction.h
+++ b/HDPS/src/PluginGlobalSettingsGroupAction.h
@@ -6,12 +6,14 @@
 
 #include "GlobalSettingsGroupAction.h"
 
-namespace mv
-{
-
-namespace plugin {
-    class PluginFactory;
+namespace mv {
+    namespace plugin {
+        class PluginFactory;
+    }
 }
+
+namespace mv::gui
+{
 
 /**
  * Plugin global settings group action class
@@ -20,7 +22,7 @@ namespace plugin {
  *
  * @author Thomas Kroes
  */
-class PluginGlobalSettingsGroupAction : public mv::GlobalSettingsGroupAction
+class PluginGlobalSettingsGroupAction : public GlobalSettingsGroupAction
 {
 public:
 
@@ -30,15 +32,6 @@ public:
      * @param pluginFactory Pointer to plugin factory
      */
     PluginGlobalSettingsGroupAction(QObject* parent, const plugin::PluginFactory* pluginFactory);
-
-    /**
-     * Get settings prefix
-     * @return Plugin settings prefix
-     */
-    //QString getSettingsPrefix() const override;
-
-private:
-    const plugin::PluginFactory* _pluginFactory;  /** Pointer to plugin factory (for global settings prefix) */
 };
 
 }

--- a/HDPS/src/PluginGlobalSettingsGroupAction.h
+++ b/HDPS/src/PluginGlobalSettingsGroupAction.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#pragma once
+
+#include "GlobalSettingsGroupAction.h"
+
+namespace mv
+{
+
+namespace plugin {
+    class PluginFactory;
+}
+
+/**
+ * Plugin global settings group action class
+ *
+ * Global settings group action class for global plugin settings
+ *
+ * @author Thomas Kroes
+ */
+class PluginGlobalSettingsGroupAction : public mv::GlobalSettingsGroupAction
+{
+public:
+
+    /**
+     * Construct with pointer to \p parent object and \p pluginFactory
+     * @param parent Pointer to parent object
+     * @param pluginFactory Pointer to plugin factory
+     */
+    PluginGlobalSettingsGroupAction(QObject* parent, const plugin::PluginFactory* pluginFactory);
+
+    /**
+     * Get settings prefix
+     * @return Plugin settings prefix
+     */
+    //QString getSettingsPrefix() const override;
+
+private:
+    const plugin::PluginFactory* _pluginFactory;  /** Pointer to plugin factory (for global settings prefix) */
+};
+
+}

--- a/HDPS/src/TasksSettingsAction.cpp
+++ b/HDPS/src/TasksSettingsAction.cpp
@@ -5,7 +5,7 @@
 #include "TasksSettingsAction.h"
 #include "Application.h"
 
-namespace mv
+namespace mv::gui
 {
 
 TasksSettingsAction::TasksSettingsAction(QObject* parent) :

--- a/HDPS/src/TasksSettingsAction.cpp
+++ b/HDPS/src/TasksSettingsAction.cpp
@@ -15,8 +15,6 @@ TasksSettingsAction::TasksSettingsAction(QObject* parent) :
     setShowLabels(false);
 
     addAction(&_hideForegroundTasksPopupAction);
-
-    _hideForegroundTasksPopupAction.setSettingsPrefix(getSettingsPrefix() + "HideForegroundTasksPopup");
 }
 
 }

--- a/HDPS/src/TasksSettingsAction.h
+++ b/HDPS/src/TasksSettingsAction.h
@@ -8,7 +8,7 @@
 
 #include "actions/ToggleAction.h"
 
-namespace mv
+namespace mv::gui
 {
 
 /**
@@ -30,10 +30,10 @@ public:
 
 public: // Action getters
 
-    gui::ToggleAction& getHideForegroundTasksPopupAction() { return _hideForegroundTasksPopupAction; }
+    ToggleAction& getHideForegroundTasksPopupAction() { return _hideForegroundTasksPopupAction; }
 
 private:
-    gui::ToggleAction   _hideForegroundTasksPopupAction;     /** Toggle action for hiding the foreground tasks popup window */
+    ToggleAction   _hideForegroundTasksPopupAction;     /** Toggle action for hiding the foreground tasks popup window */
 };
 
 }

--- a/HDPS/src/TemporaryDirectoriesSettingsAction.cpp
+++ b/HDPS/src/TemporaryDirectoriesSettingsAction.cpp
@@ -5,9 +5,7 @@
 #include "TemporaryDirectoriesSettingsAction.h"
 #include "Application.h"
 
-using namespace mv::gui;
-
-namespace mv
+namespace mv::gui
 {
 
 TemporaryDirectoriesSettingsAction::TemporaryDirectoriesSettingsAction(QObject* parent) :
@@ -25,7 +23,6 @@ TemporaryDirectoriesSettingsAction::TemporaryDirectoriesSettingsAction(QObject* 
     addAction(&_removeStaleTemporaryDirsAtStartupAction);
     addAction(&_staleTemporaryDirectoriesGroupAction);
 
-    _removeStaleTemporaryDirsAtStartupAction.setSettingsPrefix(getSettingsPrefix() + "RAS");
     _removeStaleTemporaryDirsAtStartupAction.setToolTip("Remove stale temporary directories when ManiVault starts up");
 
     _scanForStaleTemporaryDirectoriesAction.setToolTip("Rescan for stale temporary directories");

--- a/HDPS/src/TemporaryDirectoriesSettingsAction.h
+++ b/HDPS/src/TemporaryDirectoriesSettingsAction.h
@@ -12,7 +12,7 @@
 #include "actions/TriggerAction.h"
 #include "actions/HorizontalGroupAction.h"
 
-namespace mv
+namespace mv::gui
 {
 
 /**
@@ -34,20 +34,20 @@ public:
 
 public: // Action getters
 
-    gui::StringAction& getApplicationTemporaryDirAction() { return _applicationTemporaryDirAction; }
-    gui::ToggleAction& getRemoveStaleTemporaryDirsAtStartupAction() { return _removeStaleTemporaryDirsAtStartupAction; }
-    gui::TriggerAction& getScanForStaleTemporaryDirectoriesAction() { return _scanForStaleTemporaryDirectoriesAction; }
-    gui::OptionsAction& getStaleTemporaryDirectoriesAction() { return _selectStaleTemporaryDirectoriesAction; }
-    gui::TriggerAction& getRemoveStaleTemporaryDirectoriesAction() { return _removeStaleTemporaryDirectoriesAction; }
-    gui::HorizontalGroupAction& getStaleTemporaryDirectoriesGroupAction() { return _staleTemporaryDirectoriesGroupAction; }
+    StringAction& getApplicationTemporaryDirAction() { return _applicationTemporaryDirAction; }
+    ToggleAction& getRemoveStaleTemporaryDirsAtStartupAction() { return _removeStaleTemporaryDirsAtStartupAction; }
+    TriggerAction& getScanForStaleTemporaryDirectoriesAction() { return _scanForStaleTemporaryDirectoriesAction; }
+    OptionsAction& getStaleTemporaryDirectoriesAction() { return _selectStaleTemporaryDirectoriesAction; }
+    TriggerAction& getRemoveStaleTemporaryDirectoriesAction() { return _removeStaleTemporaryDirectoriesAction; }
+    HorizontalGroupAction& getStaleTemporaryDirectoriesGroupAction() { return _staleTemporaryDirectoriesGroupAction; }
 
 private:
-    gui::StringAction           _applicationTemporaryDirAction;             /** String action for the application temporary dir */
-    gui::ToggleAction           _removeStaleTemporaryDirsAtStartupAction;   /** Turn on/off the automatic removal of the application temporary directories at application startup */
-    gui::TriggerAction          _scanForStaleTemporaryDirectoriesAction;    /** Action which scans for stale temporary directories */
-    gui::OptionsAction          _selectStaleTemporaryDirectoriesAction;     /** Action which lists stale temporary directories */
-    gui::TriggerAction          _removeStaleTemporaryDirectoriesAction;     /** Action which triggers the cleanup of stale temporary directories */
-    gui::HorizontalGroupAction  _staleTemporaryDirectoriesGroupAction;      /** Group action for working with stale temporary directories */
+    StringAction           _applicationTemporaryDirAction;             /** String action for the application temporary dir */
+    ToggleAction           _removeStaleTemporaryDirsAtStartupAction;   /** Turn on/off the automatic removal of the application temporary directories at application startup */
+    TriggerAction          _scanForStaleTemporaryDirectoriesAction;    /** Action which scans for stale temporary directories */
+    OptionsAction          _selectStaleTemporaryDirectoriesAction;     /** Action which lists stale temporary directories */
+    TriggerAction          _removeStaleTemporaryDirectoriesAction;     /** Action which triggers the cleanup of stale temporary directories */
+    HorizontalGroupAction  _staleTemporaryDirectoriesGroupAction;      /** Group action for working with stale temporary directories */
 };
 
 }

--- a/HDPS/src/actions/ColorAction.cpp
+++ b/HDPS/src/actions/ColorAction.cpp
@@ -37,6 +37,8 @@ void ColorAction::setColor(const QColor& color)
     _color = color;
 
     emit colorChanged(_color);
+
+    saveToSettings();
 }
 
 void ColorAction::connectToPublicAction(WidgetAction* publicAction, bool recursive)

--- a/HDPS/src/actions/GroupAction.h
+++ b/HDPS/src/actions/GroupAction.h
@@ -167,7 +167,7 @@ public: // Actions management
      * @param widgetFlags Action widget flags (default flags if -1)
      * @param widgetConfigurationFunction When set, overrides the standard widget configuration function in the widget action
      */
-    virtual void addAction(WidgetAction* action, std::int32_t widgetFlags = -1, WidgetConfigurationFunction widgetConfigurationFunction = WidgetConfigurationFunction()) final;
+    virtual void addAction(WidgetAction* action, std::int32_t widgetFlags = -1, WidgetConfigurationFunction widgetConfigurationFunction = WidgetConfigurationFunction());
 
     /**
      * Remove \p action from the group

--- a/HDPS/src/actions/NumericalAction.h
+++ b/HDPS/src/actions/NumericalAction.h
@@ -96,6 +96,8 @@ public:
             return;
 
         _valueChanged();
+
+        saveToSettings();
     }
 
     /** Gets the minimum value */

--- a/HDPS/src/actions/OptionAction.cpp
+++ b/HDPS/src/actions/OptionAction.cpp
@@ -213,6 +213,8 @@ void OptionAction::updateCurrentIndex()
         if (_currentIndex >= getModel()->rowCount())
             _currentIndex = getModel()->rowCount() - 1;
     }
+
+    saveToSettings();
 }
 
 void OptionAction::setCustomModel(QAbstractItemModel* itemModel)

--- a/HDPS/src/actions/OptionsAction.cpp
+++ b/HDPS/src/actions/OptionsAction.cpp
@@ -137,6 +137,8 @@ void OptionsAction::selectOption(const QString& option, bool unselect /*= false*
 
     if (!matches.isEmpty())
         _optionsModel.item(matches.first().row())->setData(unselect ? Qt::Unchecked : Qt::Checked, Qt::CheckStateRole);
+
+    saveToSettings();
 }
 
 void OptionsAction::setSelectedOptions(const QStringList& selectedOptions)
@@ -155,6 +157,8 @@ void OptionsAction::setSelectedOptions(const QStringList& selectedOptions)
 
     if (getSelectedOptions() != previousSelectedOptions)
         emit selectedOptionsChanged(getSelectedOptions());
+
+    saveToSettings();
 }
 
 void OptionsAction::connectToPublicAction(WidgetAction* publicAction, bool recursive /*= true*/)

--- a/HDPS/src/private/DataHierarchyManager.cpp
+++ b/HDPS/src/private/DataHierarchyManager.cpp
@@ -95,6 +95,8 @@ DataHierarchyItem* DataHierarchyManager::getItem(const QString& datasetId)
     catch (...) {
         exceptionMessageBox("Unable to get item from the data hierarchy manager");
     }
+
+    return nullptr;
 }
 
 mv::DataHierarchyItems DataHierarchyManager::getItems() const

--- a/HDPS/src/private/PluginManager.cpp
+++ b/HDPS/src/private/PluginManager.cpp
@@ -62,7 +62,7 @@ void PluginManager::initialize()
 
     beginInitialization();
     {
-        loadPlugins();
+        loadPluginFactories();
     }
     endInitialization();
 }
@@ -79,7 +79,7 @@ void PluginManager::reset()
     endReset();
 }
 
-void PluginManager::loadPlugins()
+void PluginManager::loadPluginFactories()
 {
 #ifdef PLUGIN_MANAGER_VERBOSE
     qDebug() << "Loading plugin factories";
@@ -156,6 +156,8 @@ void PluginManager::loadPlugins()
             return;
         }
     }
+
+    emit pluginFactoriesLoaded();
 }
 
 bool PluginManager::isPluginLoaded(const QString& kind) const

--- a/HDPS/src/private/PluginManager.h
+++ b/HDPS/src/private/PluginManager.h
@@ -27,8 +27,8 @@ public:
     /** Resets the contents of the plugin manager */
     void reset() override;
 
-    /** Loads all plugin factories from the plugin directory and adds them as menu items */
-    void loadPlugins();
+    /** Loads all plugin factories from the plugin directory */
+    void loadPluginFactories();
 
     /**
      * Determine whether a plugin of \p kind is loaded

--- a/HDPS/src/private/SettingsManager.cpp
+++ b/HDPS/src/private/SettingsManager.cpp
@@ -6,6 +6,7 @@
 #include "SettingsManagerDialog.h"
 
 #include <Application.h>
+#include <CoreInterface.h>
 
 #include <util/Exception.h>
 
@@ -34,7 +35,7 @@ SettingsManager::SettingsManager() :
 {
     _editSettingsAction.setShortcutContext(Qt::WidgetWithChildrenShortcut);
 
-    if(QOperatingSystemVersion::currentType() == QOperatingSystemVersion::MacOS) {
+    if (QOperatingSystemVersion::currentType() == QOperatingSystemVersion::MacOS) {
         _editSettingsAction.setShortcut(QKeySequence("Ctrl+,"));
         _editSettingsAction.setMenuRole(QAction::PreferencesRole);
     } else {
@@ -83,6 +84,31 @@ void SettingsManager::edit()
     connect(settingsManagerDialog, &SettingsManagerDialog::finished, settingsManagerDialog, &SettingsManagerDialog::deleteLater);
     
     settingsManagerDialog->open();
+}
+
+PluginGlobalSettingsGroupAction* SettingsManager::getPluginGlobalSettingsGroupAction(const QString& kind)
+{
+    try
+    {
+        if (kind.isEmpty())
+            throw std::runtime_error("Plugin kind is empty");
+
+        auto pluginFactory = mv::plugins().getPluginFactory(kind);
+
+        if (!pluginFactory)
+            throw std::runtime_error("No plugin factory loaded with kind");
+
+        return pluginFactory->getGlobalSettingsGroupAction();
+    }
+    catch (std::exception& e)
+    {
+        exceptionMessageBox("Unable to get plugin global settings group action", e);
+    }
+    catch (...) {
+        exceptionMessageBox("Unable to get plugin global settings group action");
+    }
+
+    return {};
 }
 
 }

--- a/HDPS/src/private/SettingsManager.cpp
+++ b/HDPS/src/private/SettingsManager.cpp
@@ -111,4 +111,29 @@ PluginGlobalSettingsGroupAction* SettingsManager::getPluginGlobalSettingsGroupAc
     return {};
 }
 
+mv::gui::PluginGlobalSettingsGroupAction* SettingsManager::getPluginGlobalSettingsGroupAction(const plugin::Plugin* plugin)
+{
+    try
+    {
+        if (!plugin)
+            throw std::runtime_error("Plugin is nullptr");
+
+        const auto pluginKind = plugin->getKind();
+
+        if (pluginKind.isEmpty())
+            throw std::runtime_error("Plugin kind is empty");
+
+        return getPluginGlobalSettingsGroupAction(pluginKind);
+    }
+    catch (std::exception& e)
+    {
+        exceptionMessageBox("Unable to get plugin global settings group action", e);
+    }
+    catch (...) {
+        exceptionMessageBox("Unable to get plugin global settings group action");
+    }
+
+    return {};
+}
+
 }

--- a/HDPS/src/private/SettingsManager.cpp
+++ b/HDPS/src/private/SettingsManager.cpp
@@ -79,7 +79,7 @@ void SettingsManager::reset()
 
 void SettingsManager::edit()
 {
-    auto* settingsManagerDialog = new SettingsManagerDialog(Application::getMainWindow());
+    auto* settingsManagerDialog = new SettingsManagerDialog();
 
     connect(settingsManagerDialog, &SettingsManagerDialog::finished, settingsManagerDialog, &SettingsManagerDialog::deleteLater);
     

--- a/HDPS/src/private/SettingsManager.h
+++ b/HDPS/src/private/SettingsManager.h
@@ -46,6 +46,13 @@ public: // Global settings actions
      */
     gui::PluginGlobalSettingsGroupAction* getPluginGlobalSettingsGroupAction(const QString& kind) override;
 
+    /**
+    * Get plugin global settings for \p plugin
+    * @param plugin Pointer to plugin
+    * @return Pointer to plugin global settings (if available, otherwise returns a nullptr)
+    */
+    gui::PluginGlobalSettingsGroupAction* getPluginGlobalSettingsGroupAction(const plugin::Plugin* plugin) override;
+
 private:
     gui::TriggerAction                          _editSettingsAction;                    /** Action for triggering the settings dialog */
     gui::ParametersSettingsAction               _parametersSettingsAction;              /** Parameters global settings */

--- a/HDPS/src/private/SettingsManager.h
+++ b/HDPS/src/private/SettingsManager.h
@@ -33,26 +33,26 @@ public: // Action getters
 
 public: // Global settings actions
 
-    ParametersSettingsAction& getParametersSettings() override { return _parametersSettingsAction; };
-    MiscellaneousSettingsAction& getMiscellaneousSettings() override { return _miscellaneousSettingsAction; };
-    TasksSettingsAction& getTasksSettingsAction() override { return _tasksSettingsAction; };
-    ApplicationSettingsAction& getApplicationSettings() override { return _applicationSettingsAction; };
-    TemporaryDirectoriesSettingsAction& getTemporaryDirectoriesSettingsAction() override { return _temporaryDirectoriesSettingsAction; };
+    gui::ParametersSettingsAction& getParametersSettings() override { return _parametersSettingsAction; };
+    gui::MiscellaneousSettingsAction& getMiscellaneousSettings() override { return _miscellaneousSettingsAction; };
+    gui::TasksSettingsAction& getTasksSettingsAction() override { return _tasksSettingsAction; };
+    gui::ApplicationSettingsAction& getApplicationSettings() override { return _applicationSettingsAction; };
+    gui::TemporaryDirectoriesSettingsAction& getTemporaryDirectoriesSettingsAction() override { return _temporaryDirectoriesSettingsAction; };
 
     /**
      * Get plugin global settings for plugin \p kind
      * @param kind Plugin kind
      * @return Pointer to plugin global settings (if available, otherwise returns a nullptr)
      */
-    PluginGlobalSettingsGroupAction* getPluginGlobalSettingsGroupAction(const QString& kind) override;
+    gui::PluginGlobalSettingsGroupAction* getPluginGlobalSettingsGroupAction(const QString& kind) override;
 
 private:
-    gui::TriggerAction                  _editSettingsAction;            /** Action for triggering the settings dialog */
-    ParametersSettingsAction            _parametersSettingsAction;      /** Parameters global settings */
-    MiscellaneousSettingsAction         _miscellaneousSettingsAction;   /** Miscellaneous global settings */
-    TasksSettingsAction                 _tasksSettingsAction;           /** Tasks global settings */
-    ApplicationSettingsAction           _applicationSettingsAction;     /** Application global settings */
-    TemporaryDirectoriesSettingsAction  _temporaryDirectoriesSettingsAction;  /** Temporary files global settings */
+    gui::TriggerAction                          _editSettingsAction;                    /** Action for triggering the settings dialog */
+    gui::ParametersSettingsAction               _parametersSettingsAction;              /** Parameters global settings */
+    gui::MiscellaneousSettingsAction            _miscellaneousSettingsAction;           /** Miscellaneous global settings */
+    gui::TasksSettingsAction                    _tasksSettingsAction;                   /** Tasks global settings */
+    gui::ApplicationSettingsAction              _applicationSettingsAction;             /** Application global settings */
+    gui::TemporaryDirectoriesSettingsAction     _temporaryDirectoriesSettingsAction;    /** Temporary files global settings */
 };
 
 }

--- a/HDPS/src/private/SettingsManager.h
+++ b/HDPS/src/private/SettingsManager.h
@@ -39,6 +39,13 @@ public: // Global settings actions
     ApplicationSettingsAction& getApplicationSettings() override { return _applicationSettingsAction; };
     TemporaryDirectoriesSettingsAction& getTemporaryDirectoriesSettingsAction() override { return _temporaryDirectoriesSettingsAction; };
 
+    /**
+     * Get plugin global settings for plugin \p kind
+     * @param kind Plugin kind
+     * @return Pointer to plugin global settings (if available, otherwise returns a nullptr)
+     */
+    PluginGlobalSettingsGroupAction* getPluginGlobalSettingsGroupAction(const QString& kind) override;
+
 private:
     gui::TriggerAction                  _editSettingsAction;            /** Action for triggering the settings dialog */
     ParametersSettingsAction            _parametersSettingsAction;      /** Parameters global settings */

--- a/HDPS/src/private/SettingsManagerDialog.cpp
+++ b/HDPS/src/private/SettingsManagerDialog.cpp
@@ -41,6 +41,13 @@ SettingsManagerDialog::SettingsManagerDialog(QWidget* parent /*= nullptr*/) :
 #endif
 
     _groupsAction.addGroupAction(&mv::settings().getTemporaryDirectoriesSettingsAction());
+
+    for (auto pluginFactory : mv::plugins().getPluginFactoriesByTypes()) {
+        auto pluginGlobalSettingsGroupAction = pluginFactory->getGlobalSettingsGroupAction();
+
+        if (pluginGlobalSettingsGroupAction)
+            _groupsAction.addGroupAction(pluginGlobalSettingsGroupAction);
+    }
 }
 
 QSize SettingsManagerDialog::sizeHint() const

--- a/HDPS/src/private/ViewPluginDockWidget.cpp
+++ b/HDPS/src/private/ViewPluginDockWidget.cpp
@@ -362,10 +362,20 @@ void ViewPluginDockWidget::setViewPlugin(mv::plugin::ViewPlugin* viewPlugin)
     };
 
     for (auto settingsAction : _viewPlugin->getDockingActions()) {
-        auto settingsDockWidget = new CDockWidget(settingsAction->text());
-        auto settingsWidget     = new SettingsActionWidget(this, settingsAction);
+        auto settingsDockWidget     = new CDockWidget(settingsAction->text());
+        auto settingsWidget         = new SettingsActionWidget(this, settingsAction);
+        auto containerWidget        = new QWidget();
+        auto containerWidgetLayout  = new QVBoxLayout();
 
-        settingsDockWidget->setWidget(settingsWidget, eInsertMode::ForceNoScrollArea);
+        containerWidgetLayout->setContentsMargins(0, 0, 0, 0);
+
+        containerWidgetLayout->addWidget(settingsWidget);
+        containerWidgetLayout->addStretch(1);
+
+        containerWidget->setAutoFillBackground(true);
+        containerWidget->setLayout(containerWidgetLayout);
+
+        settingsDockWidget->setWidget(containerWidget, eInsertMode::ForceNoScrollArea);
         settingsDockWidget->setAutoFillBackground(true);
         settingsDockWidget->setFeature(CDockWidget::DockWidgetFloatable, false);
         settingsDockWidget->setFeature(CDockWidget::DockWidgetPinnable, true);


### PR DESCRIPTION
### Summary
This PR extends the global settings API:

First, the `GlobalSettingsGroupAction` base class now overrides the base `GroupAction:addAction(...)` to automatically set the correct action settings prefix. This ensures that all global settings are neatly organized and that the plugin developer is not burdened with setting the settings prefix manually (which can lead to errors). 

Using this new API, global settings can now be found in:
`ManiVault/GlobalSettings/<global_settings_action_serialization_name>/<action_serialization_name>`.

### Procedure(s) for adding a common global setting:
* Add an action to an existing global settings group (derived from `GlobalSettingsGroupAction`):
  * `ApplicationSettingsAction::addAction(...)`
  * `MiscellaneousSettingsAction::addAction(...)`
  * `ParametersSettingsAction::addAction(...)`
  * `TasksSettingsAction::addAction(...)`
  * `TemporaryDirectoriesSettingsAction::addAction(...)`
* Create a new settings action derived from `GlobalSettingsGroupAction`, add it to the `SettingsManager`
    class and add actions to it: `MySettingsAction::addAction(...)`

Additionally, a `PluginGlobalSettingsGroupAction` class has been implemented to manage global plugin settings.

### Procedure for adding a plugin global setting:
* If a plugin does not have global settings yet:
  * Create a settings action (e.g. `MyPluginGlobalSettingsAction`) derived from PluginGlobalSettingsGroupAction
  * Add actions to MyPluginGlobalSettingsAction in its constructor (`MyPluginGlobalSettingsAction::addAction(...)`)
  * Create an instance of `MyPluginGlobalSettingsAction`, and assign it to the plugin factory in the `initialize()` member function of the plugin factory: `setGlobalSettingsGroupAction(new MyPluginGlobalSettingsAction(this, this));`
* If a plugin already has global settings:
  * Add actions to the particular settings action (derived from `PluginGlobalSettingsGroupAction`)

### Procedure for retrieving global settings:
**Common global setting example**
`mv::settings().getMiscellaneousSettings().getAskConfirmationBeforeRemovingDatasetsAction()`

**Plugin global setting example**
`mv::settings().getPluginGlobalSettingsGroupAction<GlobalSettingsAction>(_exampleViewGLPlugin)->getDefaultPointSizeAction().getValue()`

Note: this PR also solves #357