### PR TITLE
Fix support for dataset removal in data properties widget

### DIFF
--- a/HDPS/src/Set.cpp
+++ b/HDPS/src/Set.cpp
@@ -475,6 +475,8 @@ DatasetTask& DatasetImpl::getTask()
 void DatasetImpl::setAboutToBeRemoved(bool aboutToBeRemoved /*= true*/)
 {
     _aboutToBeRemoved = aboutToBeRemoved;
+
+    getDataHierarchyItem().deselect();
 }
 
 bool DatasetImpl::isAboutToBeRemoved() const

--- a/HDPS/src/actions/GroupAction.cpp
+++ b/HDPS/src/actions/GroupAction.cpp
@@ -10,6 +10,10 @@
 #include <QDebug>
 #include <QHBoxLayout>
 
+#ifdef _DEBUG
+    //#define GROUP_ACTION_VERBOSE
+#endif
+
 using namespace mv::util;
 
 namespace mv::gui {
@@ -421,6 +425,13 @@ GroupAction::VerticalWidget::VerticalWidget(QWidget* parent, GroupAction* groupA
     setLayout(layout);
 }
 
+GroupAction::VerticalWidget::~VerticalWidget()
+{
+#ifdef GROUP_ACTION_VERBOSE
+    qDebug() << __FUNCTION__ << _groupAction->text();
+#endif
+}
+
 GroupAction::HorizontalWidget::HorizontalWidget(QWidget* parent, GroupAction* groupAction, const std::int32_t& widgetFlags) :
     WidgetActionWidget(parent, groupAction, widgetFlags),
     _groupAction(groupAction)
@@ -481,6 +492,13 @@ GroupAction::HorizontalWidget::HorizontalWidget(QWidget* parent, GroupAction* gr
     connect(groupAction, &GroupAction::actionsChanged, this, updateLayout);
 
     setLayout(layout);
+}
+
+GroupAction::HorizontalWidget::~HorizontalWidget()
+{
+#ifdef GROUP_ACTION_VERBOSE
+    qDebug() << __FUNCTION__ << _groupAction->text();
+#endif
 }
 
 }

--- a/HDPS/src/actions/GroupAction.h
+++ b/HDPS/src/actions/GroupAction.h
@@ -62,6 +62,9 @@ public: // Widgets
          */
         VerticalWidget(QWidget* parent, GroupAction* groupAction, const std::int32_t& widgetFlags);
 
+        /** Destructor */
+        ~VerticalWidget();
+
     protected:
         GroupAction*    _groupAction;   /** Pointer to group action which created the widget */
         QGridLayout     _layout;        /** Vertical layout */
@@ -81,6 +84,9 @@ public: // Widgets
          * @param widgetFlags Widget flags for the configuration of the widget (type)
          */
         HorizontalWidget(QWidget* parent, GroupAction* groupAction, const std::int32_t& widgetFlags);
+
+        /** Destructor */
+        ~HorizontalWidget();
 
     protected:
         GroupAction* _groupAction;   /** Pointer to group action which created the widget */

--- a/HDPS/src/actions/GroupSectionTreeItem.cpp
+++ b/HDPS/src/actions/GroupSectionTreeItem.cpp
@@ -81,6 +81,7 @@ GroupSectionTreeItem::PushButton::PushButton(QTreeWidgetItem* treeWidgetItem, Gr
     _overlayLayout.addStretch(1);
 
     _iconLabel.setAlignment(Qt::AlignCenter);
+
     if(isMacOS) {
         _iconLabel.setFont(fontAwesome.getFont());
     } else {

--- a/HDPS/src/actions/GroupWidgetTreeItem.cpp
+++ b/HDPS/src/actions/GroupWidgetTreeItem.cpp
@@ -12,7 +12,9 @@
 #include <QScrollBar>
 #include <QCoreApplication>
 
-#define GROUP_WIDGET_TREE_ITEM_VERBOSE
+#ifdef _DEBUG
+    //#define GROUP_WIDGET_TREE_ITEM_VERBOSE
+#endif
 
 namespace mv::gui {
 
@@ -47,8 +49,11 @@ GroupWidgetTreeItem::GroupWidgetTreeItem(GroupSectionTreeItem* groupSectionTreeI
 GroupWidgetTreeItem::~GroupWidgetTreeItem()
 {
 #ifdef GROUP_WIDGET_TREE_ITEM_VERBOSE
-    qDebug() << QString("Destructing %1 group widget item").arg(_groupAction->text());
+    qDebug() << __FUNCTION__ << _groupAction->text();
 #endif
+
+    if (_groupWidget)
+        delete _groupWidget;
 }
 
 GroupSectionTreeItem* GroupWidgetTreeItem::getGroupSectionTreeItem()

--- a/HDPS/src/actions/GroupWidgetTreeItem.cpp
+++ b/HDPS/src/actions/GroupWidgetTreeItem.cpp
@@ -12,11 +12,9 @@
 #include <QScrollBar>
 #include <QCoreApplication>
 
-//#define GROUP_WIDGET_TREE_ITEM_VERBOSE
+#define GROUP_WIDGET_TREE_ITEM_VERBOSE
 
-namespace mv {
-
-namespace gui {
+namespace mv::gui {
 
 GroupWidgetTreeItem::GroupWidgetTreeItem(GroupSectionTreeItem* groupSectionTreeItem, GroupAction* groupAction) :
     QTreeWidgetItem(groupSectionTreeItem),
@@ -49,7 +47,7 @@ GroupWidgetTreeItem::GroupWidgetTreeItem(GroupSectionTreeItem* groupSectionTreeI
 GroupWidgetTreeItem::~GroupWidgetTreeItem()
 {
 #ifdef GROUP_WIDGET_TREE_ITEM_VERBOSE
-    qDebug() << QString("Destructing %1 group widget item").arg(_groupAction->getSettingsPath());
+    qDebug() << QString("Destructing %1 group widget item").arg(_groupAction->text());
 #endif
 }
 
@@ -105,5 +103,4 @@ bool GroupWidgetTreeItem::SizeSynchronizer::eventFilter(QObject* target, QEvent*
     return QObject::eventFilter(target, event);
 }
 
-}
 }

--- a/HDPS/src/actions/GroupWidgetTreeItem.h
+++ b/HDPS/src/actions/GroupWidgetTreeItem.h
@@ -11,9 +11,7 @@
 
 class QWidget;
 
-namespace mv {
-
-namespace gui {
+namespace mv::gui {
 
 class GroupAction;
 class GroupSectionTreeItem;
@@ -95,5 +93,4 @@ protected:
     SizeSynchronizer        _sizeSynchronizer;          /** Synchronizer for widget size */
 };
 
-}
 }

--- a/HDPS/src/actions/GroupWidgetTreeItem.h
+++ b/HDPS/src/actions/GroupWidgetTreeItem.h
@@ -89,7 +89,7 @@ protected:
     GroupAction*            _groupAction;               /** Pointer to group action */
     QWidget*                _containerWidget;           /** Pointer to container widget */
     QVBoxLayout*            _containerLayout;           /** Pointer to container widget layout */
-    QWidget*                _groupWidget;               /** Pointer to group widget */
+    QPointer<QWidget>       _groupWidget;               /** Pointer to group widget */
     SizeSynchronizer        _sizeSynchronizer;          /** Synchronizer for widget size */
 };
 

--- a/HDPS/src/plugins/DataPropertiesPlugin/src/DataPropertiesPlugin.h
+++ b/HDPS/src/plugins/DataPropertiesPlugin/src/DataPropertiesPlugin.h
@@ -7,6 +7,7 @@
 #include "DataPropertiesWidget.h"
 
 #include <ViewPlugin.h>
+
 #include <actions/TriggerAction.h>
 
 using namespace mv::plugin;
@@ -30,15 +31,16 @@ public:
 protected:
 
     /**
-     * Callback when is called when the selected items in the data hierarchy changes
-     * @param datasetId Globally unique identifier of the dataset
+     * Updates the window title based on the \p selectedDataHierarchyItems in the data hierarchy
+     * @param selectedDataHierarchyItems Items selected in the data hierarchy
      */
-    void selectedItemsChanged(DataHierarchyItems selectedItems);
+    void updateWindowTitle(DataHierarchyItems selectedDataHierarchyItems);
 
 private:
-    DataPropertiesWidget    _dataPropertiesWidget;      /** Data properties widget */
     gui::TriggerAction      _additionalEditorAction;    /** Trigger action to start the data set editor */
-    Dataset<DatasetImpl>    _dataset;                   /** Smart pointer to currently selected dataset */
+    DataPropertiesWidget    _dataPropertiesWidget;      /** Data properties widget */
+
+    friend class DataPropertiesWidget;
 };
 
 class DataPropertiesPluginFactory : public ViewPluginFactory

--- a/HDPS/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.cpp
+++ b/HDPS/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.cpp
@@ -3,23 +3,18 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "DataPropertiesWidget.h"
+#include "DataPropertiesPlugin.h"
 
-#include <Application.h>
-#include <AbstractDataHierarchyManager.h>
-#include <AbstractProjectManager.h>
-#include <DataHierarchyItem.h>
+#include <CoreInterface.h>
 #include <Set.h>
-
-#include <actions/GroupAction.h>
-#include <actions/OptionsAction.h>
-#include <actions/PluginTriggerAction.h>
 
 #include <QDebug>
 
 using namespace mv;
 
-DataPropertiesWidget::DataPropertiesWidget(QWidget* parent) :
+DataPropertiesWidget::DataPropertiesWidget(DataPropertiesPlugin* dataPropertiesPlugin, QWidget* parent /*= nullptr*/) :
     QWidget(parent),
+    _dataPropertiesPlugin(dataPropertiesPlugin),
     _layout(),
     _groupsAction(parent, "Groups"),
     _groupsActionWidget(nullptr)
@@ -48,10 +43,13 @@ void DataPropertiesWidget::dataHierarchySelectionChanged()
 
     _selectedDataHierarchyItems = mv::dataHierarchy().getSelectedItems();
 
-    for (auto selectedDataHierarchyItem : _selectedDataHierarchyItems)
+    _dataPropertiesPlugin->updateWindowTitle(_selectedDataHierarchyItems);
+
+    for (auto selectedDataHierarchyItem : _selectedDataHierarchyItems) {
         connect(&selectedDataHierarchyItem->getDatasetReference(), &Dataset<DatasetImpl>::aboutToBeRemoved, this, [this]() -> void {
             _groupsAction.setGroupActions({});
         });
+    }
 
     try
     {

--- a/HDPS/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.h
+++ b/HDPS/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.h
@@ -40,7 +40,8 @@ protected:
     void dataHierarchySelectionChanged();
 
 protected:
-    QVBoxLayout             _layout;                /** Main layout */
-    GroupsAction            _groupsAction;          /** Groups action */
-    GroupsAction::Widget*   _groupsActionWidget;    /** Pointer to groups action widget (used to change label sizing) */
+    QVBoxLayout             _layout;                        /** Main layout */
+    DataHierarchyItems      _selectedDataHierarchyItems;    /** Selected data hierarchy items */
+    GroupsAction            _groupsAction;                  /** Groups action */
+    GroupsAction::Widget*   _groupsActionWidget;            /** Pointer to groups action widget (used to change label sizing) */
 };

--- a/HDPS/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.h
+++ b/HDPS/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <DataHierarchyItem.h>
-#include <Dataset.h>
 
 #include <actions/GroupsAction.h>
 
@@ -14,6 +13,8 @@
 using namespace mv;
 using namespace mv::util;
 using namespace mv::gui;
+
+class DataPropertiesPlugin;
 
 /**
  * Data properties widget class
@@ -29,10 +30,11 @@ class DataPropertiesWidget : public QWidget
 public:
 
     /**
-     * Constructor
+     * Construct with pointer to owning \p dataPropertiesPlugin and \p parent widget
+     * @param dataPropertiesPlugin Pointer to owning data properties plugin
      * @param parent Pointer to parent widget
      */
-    DataPropertiesWidget(QWidget* parent);
+    DataPropertiesWidget(DataPropertiesPlugin* dataPropertiesPlugin, QWidget* parent = nullptr);
 
 protected:
 
@@ -40,6 +42,7 @@ protected:
     void dataHierarchySelectionChanged();
 
 protected:
+    DataPropertiesPlugin*   _dataPropertiesPlugin;          /** Pointer to owning data properties plugin */
     QVBoxLayout             _layout;                        /** Main layout */
     DataHierarchyItems      _selectedDataHierarchyItems;    /** Selected data hierarchy items */
     GroupsAction            _groupsAction;                  /** Groups action */

--- a/HDPS/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.h
+++ b/HDPS/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.h
@@ -40,7 +40,6 @@ protected:
     void dataHierarchySelectionChanged();
 
 protected:
-    Dataset<DatasetImpl>    _dataset;               /** Smart point to current dataset */
     QVBoxLayout             _layout;                /** Main layout */
     GroupsAction            _groupsAction;          /** Groups action */
     GroupsAction::Widget*   _groupsActionWidget;    /** Pointer to groups action widget (used to change label sizing) */


### PR DESCRIPTION
In some cases, the `DataPropertiesWidget` still attempts to show widget actions belonging to already removed datasets. This should be fixed. This happens for instance when an HSNE scale dataset is removed.

This PR addresses the above issue by:
- De-selecting a data hierarchy item before its corresponding dataset is about to be removed
- Adjust the data properties display properly; reset it when the displayed dataset is about to be removed
- Properly remove the `GroupAction` widget when the `GroupWidgetTreeItem` is removed in the `GroupsAction`