### PR TITLE
Allow large .h5ad files to save correctly in a project

### DIFF
--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -52,14 +52,19 @@ mv::Dataset<DatasetImpl> PointData::createDataSet(const QString& guid /*= ""*/) 
     return mv::Dataset<DatasetImpl>(new Points(getName(), true, guid));
 }
 
-unsigned int PointData::getNumPoints() const
+std::uint32_t PointData::getNumPoints() const
 {
     return static_cast<unsigned int>(_vectorHolder.size() / _numDimensions);
 }
 
-unsigned int PointData::getNumDimensions() const
+std::uint32_t PointData::getNumDimensions() const
 {
     return _numDimensions;
+}
+
+std::uint64_t PointData::getNumberOfElements() const
+{
+    return _vectorHolder.size();
 }
 
 const std::vector<QString>& PointData::getDimensionNames() const
@@ -195,7 +200,7 @@ QVariantMap PointData::toVariantMap() const
     const auto typeSpecifier        = _vectorHolder.getElementTypeSpecifier();
     const auto typeSpecifierName    = _vectorHolder.getElementTypeNames()[static_cast<std::int32_t>(typeSpecifier)];
     const auto typeIndex            = static_cast<std::int32_t>(typeSpecifier);
-    const auto numberOfElements     = static_cast<std::uint64_t>(getNumPoints() * getNumDimensions());
+    const auto numberOfElements     = getNumberOfElements();
 
     switch (typeSpecifier)
     {

--- a/HDPS/src/plugins/PointData/src/PointData.h
+++ b/HDPS/src/plugins/PointData/src/PointData.h
@@ -327,9 +327,11 @@ public:
 
     mv::Dataset<mv::DatasetImpl> createDataSet(const QString& guid = "") const override;
 
-    unsigned int getNumPoints() const;
+    std::uint32_t getNumPoints() const;
 
-    unsigned int getNumDimensions() const;
+    std::uint32_t getNumDimensions() const;
+
+    std::uint64_t getNumberOfElements() const;
 
     /**
      * Get amount of data occupied by the raw data

--- a/HDPS/src/util/Serialization.cpp
+++ b/HDPS/src/util/Serialization.cpp
@@ -73,7 +73,7 @@ void loadRawDataFromBinaryFile(const char* bytes, const std::uint64_t& numberOfB
     memcpy((void*)bytes, (void*)rawData.data(), numberOfBytes);
 }
 
-QVariantMap rawDataToVariantMap(const char* bytes, const std::uint64_t& numberOfBytes, bool saveToDisk /*= false*/, std::uint64_t maxBlockSize /*= -1*/)
+QVariantMap rawDataToVariantMap(const char* bytes, const std::uint64_t& numberOfBytes, bool saveToDisk /*= false*/, std::uint64_t maxBlockSize /*= DEFAULT_MAX_BLOCK_SIZE*/)
 {
     Q_ASSERT(maxBlockSize != 0);
 

--- a/HDPS/src/util/Serialization.h
+++ b/HDPS/src/util/Serialization.h
@@ -34,9 +34,9 @@ void loadRawDataFromBinaryFile(const char* bytes, const std::uint64_t& numberOfB
  * @param bytes Pointer to input buffer
  * @param numberOfBytes Number of input bytes 
  * @param saveToDisk Whether to save the raw data to disk or inline in the variant
- * @param maxBlockSize Maximum size per block (DEFAULT_MAX_BLOCK_SIZE when maxBlockSize == -1)
+ * @param maxBlockSize Maximum size per block (defaults to DEFAULT_MAX_BLOCK_SIZE)
  */
-QVariantMap rawDataToVariantMap(const char* bytes, const std::uint64_t& numberOfBytes, bool saveToDisk = false, std::uint64_t maxBlockSize = -1);
+QVariantMap rawDataToVariantMap(const char* bytes, const std::uint64_t& numberOfBytes, bool saveToDisk = false, std::uint64_t maxBlockSize = DEFAULT_MAX_BLOCK_SIZE);
 
 /**
  * Convert variant map to raw data


### PR DESCRIPTION
It turns out that the computation for the number of elements in `PointData` was incorrect for large datasets (tested with `num_pts`: 74979 x `num_dims`: 59357 = 4450528503 raw data elements). A member function has been added to the `PointData` to query the number of elements directly from the `_vectorHolder`, so no manual computation of the number of elements is necessary anymore.