### PR TITLE
Check if Analysis implements serialization

### DIFF
--- a/HDPS/src/AnalysisPlugin.h
+++ b/HDPS/src/AnalysisPlugin.h
@@ -98,6 +98,9 @@ public: // Serialization
      */
     QVariantMap toVariantMap() const override;
 
+    /** Whether the analysis plugin implements serialization */
+    virtual bool implementsSerialization() const { return false; }
+
 protected:
     /** Returns whether any output dataset is given */
     bool outputDataInit() const { return _output.size() > 0; }


### PR DESCRIPTION
Currently, if an analysis plugin does *not* implement serialization, the core still calls `AnalysisPlugin::toVariantMap` and `AnalysisPlugin::fromVariantMap` - this leads to duplicated entries in the data hierarchy and adds non-functional UI elements.

To reproduce: compute t-SNE or PCA analysis, save the project, load it.

With this PR, analysis plugins that want to implement serialization need to overload the new function `implementsSerialization`. If an analysis plugin does not implement serialization, nothing changes.

```cpp
public: // Serialization

    /**
     * Load plugin from variant map
     * @param Variant map representation of the plugin
     */
    void fromVariantMap(const QVariantMap& variantMap) override;               // AS BEFORE

    /**
     * Save plugin to variant map
     * @return Variant map representation of the plugin
     */
    QVariantMap toVariantMap() const override;                                 // AS BEFORE

    /** Whether the analysis plugin implements serialization */
    bool implementsSerialization() const override { return true; }             // NEW OVERLOAD
```

The main problem is, that the PluginManager somehow needs to know whether an AnalysisPlugin overloads `toVariantMap` and `fromVariantMap`, without knowing the derived AnalysisPlugin class. Since c++ does not have much reflection capabilities, this is rather difficult without an extra member function/variable. I implemented an alternative approach based on [Curiously recurring template pattern](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern) in [this branch](https://github.com/ManiVaultStudio/core/compare/master...feature/FixAnalysisSavingWithCRTP) - but that would involve changing every existing analysis plugin (e.g. derive it from AnalysisPlugin\<HsneAnalysisPlugin\> instead of just AnalysisPlugin), comes with a bunch of ugly template-related changes in the core and is all around less readable...