### PR TITLE
Fix compile error trying to access `_vectorHolder`

### DIFF
--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -64,7 +64,7 @@ std::uint32_t PointData::getNumDimensions() const
 
 std::uint64_t PointData::getNumberOfElements() const
 {
-    return _vectorHolder.size();
+    return getSizeOfVector();
 }
 
 const std::vector<QString>& PointData::getDimensionNames() const


### PR DESCRIPTION
`_vectorHolder` was removed by pull request https://github.com/ManiVaultStudio/core/pull/454 commit 55f50a9aefd85becb9f097dea0b3dd8df0d8d08d "Replace private `PointData::VectorHolder` class with `std::variant`"

Reported by Julian Thijssen.