### PR TITLE
Check if Analysis implements serialization 

### DIFF
--- a/HDPS/src/AnalysisPlugin.h
+++ b/HDPS/src/AnalysisPlugin.h
@@ -98,9 +98,6 @@ public: // Serialization
      */
     QVariantMap toVariantMap() const override;
 
-    /** Whether the analysis plugin implements serialization */
-    virtual bool implementsSerialization() const { return false; }
-
 protected:
     /** Returns whether any output dataset is given */
     bool outputDataInit() const { return _output.size() > 0; }

--- a/HDPS/src/AnalysisPlugin.h
+++ b/HDPS/src/AnalysisPlugin.h
@@ -98,6 +98,9 @@ public: // Serialization
      */
     QVariantMap toVariantMap() const override;
 
+    /** Whether the analysis plugin implements serialization */
+    virtual bool implementsSerialization() const { return false; }
+
 protected:
     /** Returns whether any output dataset is given */
     bool outputDataInit() const { return _output.size() > 0; }


### PR DESCRIPTION
Currently, if an analysis plugin does *not* implement serialization, the core still calls `AnalysisPlugin::toVariantMap` and `AnalysisPlugin::fromVariantMap` - this leads to duplicated entries in the data hierarchy and adds non-functional UI elements.

To reproduce: compute t-SNE or PCA analysis, save the project, load it.

With this PR, analysis plugins that want to implement serialization need to apply the macro `Q_INVOKABLE` to the serialization functions `toVariantMap` and `fromVariantMap`.

```cpp
public: // Serialization

    /**
     * Load plugin from variant map
     * @param Variant map representation of the plugin
     */
    Q_INVOKABLE void fromVariantMap(const QVariantMap& variantMap) override;               // NEW: the qt macro

    /**
     * Save plugin to variant map
     * @return Variant map representation of the plugin
     */
    Q_INVOKABLE QVariantMap toVariantMap() const override;                                 // NEW: the qt macro
```

All plugin types *may* use these signatures from now on, but only analysis plugins **have** to. 

This PR supersedes #481, which tries to solve the same problem using an additional member function and discusses another template-based approach.