### PR TITLE
Fix `PointData::setIndexOfVariant` accidentally doing pass-by-value

### DIFF
--- a/HDPS/src/plugins/PointData/src/PointData.h
+++ b/HDPS/src/plugins/PointData/src/PointData.h
@@ -78,7 +78,7 @@ private:
     // Inspired by `expand_type` from kmbeutel at
     // https://www.reddit.com/r/cpp/comments/f8cbzs/creating_stdvariant_based_on_index_at_runtime/?rdt=52905
     template <typename... Alternatives>
-    static void setIndexOfVariant(std::variant<Alternatives...> var, std::size_t index)
+    static void setIndexOfVariant(std::variant<Alternatives...>& var, std::size_t index)
     {
         if (index != var.index())
         {


### PR DESCRIPTION
The first parameter of the private member function `PointData::setIndexOfVariant` should be passed by reference. Before this commit, it did pass-by-value, causing calls to `PointData::setElementTypeSpecifier` to have no effect at all.

The bug was introduced with pull request https://github.com/ManiVaultStudio/core/pull/454 commit 55f50a9aefd85becb9f097dea0b3dd8df0d8d08d "Replace private `PointData::VectorHolder` class with `std::variant` (merged on 5 February 2024) and reported to me by Jeroen Eggermont (@jeggermont).