### PR TITLE
 Performance improvements loading and saving PointData #498

### DIFF
--- a/HDPS/CMakeLists.txt
+++ b/HDPS/CMakeLists.txt
@@ -527,6 +527,7 @@ add_subdirectory(src/plugins/ImageData)
 
 # Automatically set the debug environment (command + working directory) for MSVC
 if(MSVC)
+    set_property(TARGET ${MV_EXE} PROPERTY VS_DEBUGGER_ENVIRONMENT "PATH=${QT_DIR}/../../../bin")
     set_property(TARGET ${MV_EXE} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY  $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
     set_property(TARGET ${MV_EXE} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug/${MV_APPLICATION_NAME}.exe,${MV_INSTALL_DIR}/release/${MV_APPLICATION_NAME}.exe>)
 endif()

--- a/HDPS/src/plugins/PointData/src/PointData.h
+++ b/HDPS/src/plugins/PointData/src/PointData.h
@@ -107,7 +107,6 @@ private:
         }
     }
 
-
     template <typename T>
     static constexpr ElementTypeSpecifier getElementTypeSpecifier()
     {
@@ -218,32 +217,14 @@ public:
      * Get amount of data occupied by the raw data
      * @return Size of the raw data in bytes
      */
-    std::uint64_t getRawDataSize() const override {
-        std::uint64_t elementSize = 0u;
+    std::uint64_t getRawDataSize() const override;
 
-        switch (getElementTypeSpecifier())
-        {
-            case ElementTypeSpecifier::float32:
-                elementSize = 4u;
-                break;
 
-            case ElementTypeSpecifier::bfloat16:
-            case ElementTypeSpecifier::int16:
-            case ElementTypeSpecifier::uint16:
-                elementSize = 2u;
-                break;
-
-            case ElementTypeSpecifier::int8:
-            case ElementTypeSpecifier::uint8:
-                elementSize = 1u;
-                break;
-
-            default:
-                break;
-        }
-
-        return elementSize * getNumPoints() * getNumDimensions();
-    }
+    /**
+     *Returns void pointer to the underlying array serving as element storage.
+     */
+    void* getDataVoidPtr();
+    const void* getDataConstVoidPtr() const;
 
     static constexpr std::array<const char*, std::variant_size_v<VariantOfVectors>> getElementTypeNames()
     {

--- a/HDPS/src/util/Serialization.h
+++ b/HDPS/src/util/Serialization.h
@@ -27,7 +27,7 @@ void saveRawDataToBinaryFile(const char* bytes, const std::uint64_t& numberOfByt
  * @param numberOfBytes Number of input bytes
  * @param filePath Path of the file on disk
  */
-void loadRawDataFromBinaryFile(const char* bytes, const std::uint64_t& numberOfBytes, const QString& filePath);
+void loadRawDataFromBinaryFile(char* bytes, const std::uint64_t& numberOfBytes, const QString& filePath);
 
 /**
  * Convert raw data buffer to variant map (divide up in blocks when the total number of bytes exceeds maxBlockSize)
@@ -43,7 +43,7 @@ QVariantMap rawDataToVariantMap(const char* bytes, const std::uint64_t& numberOf
  * @param variantMap Variant map containing the data blocks
  * @param bytes Output buffer to which the data is copied
  */
-void populateDataBufferFromVariantMap(const QVariantMap& variantMap, const char* bytes);
+void populateDataBufferFromVariantMap(const QVariantMap& variantMap, char* bytes);
 
 /**
  * Raises an exception if an item with key is not found in a variant map


### PR DESCRIPTION
 Performance improvements loading and saving PointData #498

There are several performance issues with loading and saving PointData.

Issue 1: PointData::fromVariantMap
PointData::fromVariantMap loads the data into a std::vector and then copies that vector using setData.
Why not load the data directly into _variantOfVectors ? This also saved a lot of lines of code and is easier to maintain.
It just required a function to get a void pointer to the current std::vector::data()

Issue 2: PointData::toVariantMap()
PointData::toVariantMap() uses a switch statement which needs to be maintained if we ever add more datatypes to _variantOfVectors. Also it doesn't use member function getRawDataSize().

Issue 3: PointData::getRawDataSize()
This function can be moved to the cpp and again a switch statement can be removed which makes it easier to maintain.

Issue 4: Serialization -> saveRawDataToBinaryFile(...)
bytes are first copied into a QByteArray using a deep-copy.
Then the bytes are copied again into the QByteArray which doesn't seem needed.
QByteArray also has static function fromRawData(...) which will not make a deep-copy which saves time and memory.

Issue 5: Serialization ->loadRawDataFromBinaryFile
The first parameter bytes is a const char* which is confusing since the function copies data into bytes so it makes more sense to make it a char *.
The function would also first load all data into a QByteArray and then copy that data into bytes.
It seems better to load the data directly into bytes thereby saving time and memory

Issue 6: Serialization -> populateDataBufferFromVariantMap
The second parameter is a const char* which is confusing since the data will be copied into bytes so it makes more sense to make it a char *.