### PR TITLE
Fix unexpected behavior when clicking on a toggle action checkbox label

### DIFF
--- a/HDPS/src/actions/ToggleAction.cpp
+++ b/HDPS/src/actions/ToggleAction.cpp
@@ -170,7 +170,7 @@ bool ToggleAction::CheckBoxWidget::eventFilter(QObject* target, QEvent* event)
     {
         case QEvent::MouseButtonPress:
         {
-            _toggleAction->toggle();
+            _toggleAction->setChecked(!_toggleAction->isChecked());
             return true;
             break;
         }


### PR DESCRIPTION
It turns out that `ToggleAction::setChecked(...)` was not called because `QAction::toggle()` is not virtual, as well as `QAction::setChecked(...)`. Solved it by calling `ToggleAction::setChecked(...)` directly.