### PR TITLE
CI update: Mac OS, python and zlib versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
             build-cc: gcc
             build-cxx: g++
             build-compiler: gcc
-            build-cversion: 10
+            build-cversion: 11
             build-config: Release
             build-os: Linux
             build-libcxx: libstdc++

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,13 +44,13 @@ jobs:
             build-os: Linux
             build-libcxx: libstdc++
 
-          - name: Macos_xcode14.2
-            os: macos-13
+          - name: Macos_xcode13.4
+            os: macos-12
             build-compiler: apple-clang
-            build-cversion: "13.1"
+            build-cversion: 13
             build-config: Release
             build-os: Macos
-            build-xcode-version: 14.2
+            build-xcode-version: 13.4
             build-libcxx: libc++
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,13 +44,13 @@ jobs:
             build-os: Linux
             build-libcxx: libstdc++
 
-          - name: Macos_xcode13.4
-            os: macos-12
+          - name: Macos_xcode14.2
+            os: macos-13
             build-compiler: apple-clang
             build-cversion: "13.1"
             build-config: Release
             build-os: Macos
-            build-xcode-version: 13.4
+            build-xcode-version: 14.2
             build-libcxx: libc++
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,15 @@ jobs:
             build-xcode-version: 12.4
             build-libcxx: libc++
 
+          - name: Macos_xcode13.4
+            os: macos-12
+            build-compiler: apple-clang
+            build-cversion: "13.1"
+            build-config: Release
+            build-os: Macos
+            build-xcode-version: 13.4
+            build-libcxx: libc++
+
     steps:
       - name: Checkout the source
         if: ${{ github.event_name != 'pull_request'}}
@@ -88,7 +97,7 @@ jobs:
       - name: Setup python version
         uses: actions/setup-python@v1
         with:
-          python-version: "3.7"
+          python-version: "3.11"
 
       # windows-2016 need the SSHAgentFeature added
       #- name: Start ssh key agent

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             build-runtime: MD
             build-config: Release
 
-          - name: Linux_gcc10
+          - name: Linux_gcc11
             os: ubuntu-22.04
             build-cc: gcc
             build-cxx: g++

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,26 +44,6 @@ jobs:
             build-os: Linux
             build-libcxx: libstdc++
 
-          # - name: Macos_xcode10.3
-          #  os: macos-10.14
-          #  build-cc: clang
-          #  build-cxx: clang++
-          #  build-compiler: apple-clang
-          #  build-cversion: "10.0"
-          #  build-config: Release
-          #  build-os: Macos
-          #  build-xcode-version: 10.3
-          #  build-libcxx: libc++
-
-          - name: Macos_xcode12.4
-            os: macos-11
-            build-compiler: apple-clang
-            build-cversion: "12.0"
-            build-config: Release
-            build-os: Macos
-            build-xcode-version: 12.4
-            build-libcxx: libc++
-
           - name: Macos_xcode13.4
             os: macos-12
             build-compiler: apple-clang

--- a/conanfile.py
+++ b/conanfile.py
@@ -34,7 +34,7 @@ class HdpsCoreConan(ConanFile):
     branch = "develop"  # should come from profile
     author = "B. van Lew <b.van_lew@lumc.nl>"
     license = (
-        " LGPL-3.0-or-later"  # Indicates license: use SPDX Identifiers https://spdx.org/licenses/
+        "LGPL-3.0-or-later"  # Indicates license: use SPDX Identifiers https://spdx.org/licenses/
     )
     short_paths = True
     generators = "CMakeDeps"
@@ -52,7 +52,7 @@ class HdpsCoreConan(ConanFile):
     install_dir = None
     this_dir = os.path.dirname(os.path.realpath(__file__))
 
-    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.2.8@")
+    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.3.1@")
 
     scm = {"type": "git", "subfolder": "hdps/core", "url": "auto", "revision": "auto"}
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -52,7 +52,7 @@ class HdpsCoreConan(ConanFile):
     install_dir = None
     this_dir = os.path.dirname(os.path.realpath(__file__))
 
-    requires = ("qt/6.3.2@lkeb/stable", "bzip2/1.0.8@", "zlib/1.2.8@")
+    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.2.8@")
 
     scm = {"type": "git", "subfolder": "hdps/core", "url": "auto", "revision": "auto"}
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -52,7 +52,7 @@ class HdpsCoreConan(ConanFile):
     install_dir = None
     this_dir = os.path.dirname(os.path.realpath(__file__))
 
-    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.2.11@lkeb")
+    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.2.11@lkeb/_")
 
     scm = {"type": "git", "subfolder": "hdps/core", "url": "auto", "revision": "auto"}
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -52,7 +52,7 @@ class HdpsCoreConan(ConanFile):
     install_dir = None
     this_dir = os.path.dirname(os.path.realpath(__file__))
 
-    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.3.1")
+    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.2.11@lkeb")
 
     scm = {"type": "git", "subfolder": "hdps/core", "url": "auto", "revision": "auto"}
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -50,7 +50,7 @@ class HdpsCoreConan(ConanFile):
     install_dir = None
     this_dir = os.path.dirname(os.path.realpath(__file__))
 
-    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.3.1")
+    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.3")
 
     scm = {"type": "git", "subfolder": "hdps/core", "url": "auto", "revision": "auto"}
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -52,7 +52,7 @@ class HdpsCoreConan(ConanFile):
     install_dir = None
     this_dir = os.path.dirname(os.path.realpath(__file__))
 
-    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.3.1@")
+    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.3.1")
 
     scm = {"type": "git", "subfolder": "hdps/core", "url": "auto", "revision": "auto"}
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,6 +12,7 @@ from rules_support import CoreBranchInfo
 import subprocess
 import traceback
 
+required_conan_version = "==1.54.0"
 
 class HdpsCoreConan(ConanFile):
     """Class to package hdps-core using conan
@@ -33,7 +34,7 @@ class HdpsCoreConan(ConanFile):
     branch = "develop"  # should come from profile
     author = "B. van Lew <b.van_lew@lumc.nl>"
     license = (
-        "MIT"  # Indicates license: use SPDX Identifiers https://spdx.org/licenses/
+        " LGPL-3.0-or-later"  # Indicates license: use SPDX Identifiers https://spdx.org/licenses/
     )
     short_paths = True
     generators = "CMakeDeps"

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,8 +12,6 @@ from rules_support import CoreBranchInfo
 import subprocess
 import traceback
 
-required_conan_version = "==1.54.0"
-
 class HdpsCoreConan(ConanFile):
     """Class to package hdps-core using conan
 
@@ -52,7 +50,7 @@ class HdpsCoreConan(ConanFile):
     install_dir = None
     this_dir = os.path.dirname(os.path.realpath(__file__))
 
-    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.2.11@lkeb/_")
+    requires = ("qt/6.3.2@lkeb/stable", "zlib/1.3.1")
 
     scm = {"type": "git", "subfolder": "hdps/core", "url": "auto", "revision": "auto"}
 


### PR DESCRIPTION
Supersedes #508 which does not build on CI due to naming conventions...

- [Mac OS 11 is deprecated on github's CI](https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images) and by brew. This creates problems when installing e.g. libomp
- Updating to Mac OS 12 requires newer python and zlib version: [github's CI does not support python 3.7](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#python) anymore and conan does not support the current version [1.2.8 for newer mac OS anymore](https://conan.io/center/recipes/zlib)
- Newer zlib versions require gcc 11 instead of our current setting gcc 10 for linux and clang 13 instead of 12 for mac os

**Summary**
- Mac:
  - MacOS to `12` from `11`
  - XCode to `13.4` form `12.4` 
  - clang to `13` form `12`
- Linux:
  - gcc to `11` from `10` for conan requirements - the CI already used gcc 11
- All platforms:
  - zlib to `1.3` from `1.2.8`
  - python to `3.11` from `3.7`
  - bzip2 `removed`, as it was unused