### PR TITLE
Fix registry issues with multiple MV applications

### DIFF
--- a/HDPS/src/Main.cpp
+++ b/HDPS/src/Main.cpp
@@ -83,9 +83,9 @@ int main(int argc, char *argv[])
     commandLineParser.addVersionOption();
 
     QCommandLineOption projectOption({ "p", "project" }, "File path of the project to load upon startup", "project");
-    QCommandLineOption organizationNameOption({ "org_name", "organization_name" }, "Name of the organization", "organization_name");
-    QCommandLineOption organizationDomainOption({ "org_dom", "organization_domain" }, "Domain of the organization", "organization_domain");
-    QCommandLineOption applicationNameOption({ "app_name", "application_name" }, "Name of the application", "application_name");
+    QCommandLineOption organizationNameOption({ "org_name", "organization_name" }, "Name of the organization", "organization_name", "BioVault");
+    QCommandLineOption organizationDomainOption({ "org_dom", "organization_domain" }, "Domain of the organization", "organization_domain", "LUMC (LKEB) & TU Delft (CGV)");
+    QCommandLineOption applicationNameOption({ "app_name", "application_name" }, "Name of the application", "application_name", "ManiVault");
 
     commandLineParser.addOption(projectOption);
     commandLineParser.addOption(organizationNameOption);
@@ -97,9 +97,9 @@ int main(int argc, char *argv[])
     // Remove the temporary application
     coreApplication.reset();
 
-    QCoreApplication::setOrganizationName(commandLineParser.isSet("organization_name") ? commandLineParser.value("organization_name") : "BioVault");
-    QCoreApplication::setOrganizationDomain(commandLineParser.isSet("organization_domain") ? commandLineParser.value("organization_domain") : "LUMC (LKEB) & TU Delft (CGV)");
-    QCoreApplication::setApplicationName(commandLineParser.isSet("application_name") ? commandLineParser.value("application_name") : "ManiVault");
+    QCoreApplication::setOrganizationName(commandLineParser.value("organization_name"));
+    QCoreApplication::setOrganizationDomain(commandLineParser.value("organization_domain"));
+    QCoreApplication::setApplicationName(commandLineParser.value("application_name"));
     
     // Necessary to instantiate QWebEngine from a plugin
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts, true);

--- a/HDPS/src/Main.cpp
+++ b/HDPS/src/Main.cpp
@@ -9,6 +9,7 @@
 #include <Application.h>
 #include <ProjectMetaAction.h>
 #include <BackgroundTask.h>
+#include <ManiVaultVersion.h>
 
 #include <QSurfaceFormat>
 #include <QStyleFactory>
@@ -16,6 +17,8 @@
 #include <QQuickWindow>
 #include <QCommandLineParser>
 #include <QTemporaryDir>
+
+#include <iostream>
 
 using namespace mv;
 using namespace mv::util;
@@ -70,9 +73,33 @@ ProjectMetaAction* getStartupProjectMetaAction(const QString& startupProjectFile
 
 int main(int argc, char *argv[])
 {
-    QCoreApplication::setOrganizationName("BioVault");
-    QCoreApplication::setOrganizationDomain("LUMC (LKEB) & TU Delft (CGV)");
-    QCoreApplication::setApplicationName("ManiVault");
+    // Create a temporary core application to be able to read command line arguments without implicit interfacing with settings
+    auto coreApplication = QSharedPointer<QCoreApplication>(new QCoreApplication(argc, argv));
+
+    QCommandLineParser commandLineParser;
+
+    commandLineParser.setApplicationDescription("Application for viewing and analyzing high-dimensional data");
+    commandLineParser.addHelpOption();
+    commandLineParser.addVersionOption();
+
+    QCommandLineOption projectOption({ "p", "project" }, "File path of the project to load upon startup", "project");
+    QCommandLineOption organizationNameOption({ "org_name", "organization_name" }, "Name of the organization", "organization_name");
+    QCommandLineOption organizationDomainOption({ "org_dom", "organization_domain" }, "Domain of the organization", "organization_domain");
+    QCommandLineOption applicationNameOption({ "app_name", "application_name" }, "Name of the application", "application_name");
+
+    commandLineParser.addOption(projectOption);
+    commandLineParser.addOption(organizationNameOption);
+    commandLineParser.addOption(organizationDomainOption);
+    commandLineParser.addOption(applicationNameOption);
+
+    commandLineParser.process(QCoreApplication::arguments());
+
+    // Remove the temporary application
+    coreApplication.reset();
+
+    QCoreApplication::setOrganizationName(commandLineParser.isSet("organization_name") ? commandLineParser.value("organization_name") : "BioVault");
+    QCoreApplication::setOrganizationDomain(commandLineParser.isSet("organization_domain") ? commandLineParser.value("organization_domain") : "LUMC (LKEB) & TU Delft (CGV)");
+    QCoreApplication::setApplicationName(commandLineParser.isSet("application_name") ? commandLineParser.value("application_name") : "ManiVault");
     
     // Necessary to instantiate QWebEngine from a plugin
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts, true);
@@ -89,6 +116,8 @@ int main(int argc, char *argv[])
 
     QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
 
+    qDebug() << "Starting ManiVault" << QString("%1.%2").arg(QString::number(MV_VERSION_MAJOR), QString::number(MV_VERSION_MINOR));
+
     Application application(argc, argv);
 
     Core core;
@@ -97,17 +126,6 @@ int main(int argc, char *argv[])
 
     core.createManagers();
 
-    QCommandLineParser commandLineParser;
-
-    commandLineParser.setApplicationDescription("Application for viewing and analyzing high-dimensional data");
-    commandLineParser.addHelpOption();
-    commandLineParser.addVersionOption();
-
-    QCommandLineOption projectOption({ "p", "project" }, "File path of the project to load upon startup", "project");
-
-    commandLineParser.addOption(projectOption);
-    commandLineParser.process(QCoreApplication::arguments());
-    
     SplashScreenAction splashScreenAction(&application, false);
 
     if (commandLineParser.isSet("project")) {


### PR DESCRIPTION
Three MV command line arguments have been added to solve the issues regarding colliding multi-application registry issues:
- Organization name: `--org_name, -organization_name`, defaults to `BioVault`
- Organization domain: `--org_dom, -organization_domain`, defaults to `LUMC (LKEB) & TU Delft (CGV)`
- Application name: `--app_name, -application_name`, defaults to `ManiVault`

This means published applications can interface with Qt settings in their context, without disturbing the main ManiVault application settings.