### PR TITLE
Fixed performance issue for OptionsAction::setOptions (#517)

### DIFF
--- a/HDPS/src/actions/OptionsAction.cpp
+++ b/HDPS/src/actions/OptionsAction.cpp
@@ -75,8 +75,11 @@ void OptionsAction::setOptions(const QStringList& options, bool clearSelection /
 
     _optionsModel.clear();
 
+    //since adding a lot of options can become really slow we first add them to a list and then set the list using appendColumn.
+    QList<QStandardItem*> items;
+    items.reserve(options.size());
+
     for (const auto& option : options) {
-        const auto row = _optionsModel.rowCount();
 
         auto item = new QStandardItem();
 
@@ -84,8 +87,9 @@ void OptionsAction::setOptions(const QStringList& options, bool clearSelection /
         item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled);
         item->setData(clearSelection ? Qt::Unchecked : (selectedOptions.contains(option) ? Qt::Checked : Qt::Unchecked), Qt::CheckStateRole);
 
-        _optionsModel.setItem(row, 0, item);
+        items.append(item);
     }
+    _optionsModel.appendColumn(items);
 
     emit optionsChanged(getOptions());
 }


### PR DESCRIPTION
Fixed performance issue for OptionsAction::setOptions (#517).

Options are now first added to a list and set as a column instead of setting all options 1 by 1.