### PR TITLE
Fix proxy points selection updates

### DIFF
--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -853,18 +853,16 @@ bool Points::canSelectInvert() const
 
 void Points::selectAll()
 {
-    auto& selectionIndices = getSelection<Points>()->indices;
+    std::vector<unsigned int> selectionIndices;
 
-    selectionIndices.clear();
     selectionIndices.resize(getNumPoints());
 
-    if (isFull()) {
+    if (isFull())
         std::iota(selectionIndices.begin(), selectionIndices.end(), 0);
-    }
-    else {
-        for (const auto& index : indices)
-            selectionIndices.push_back(index);
-    }
+    else
+        selectionIndices = indices;
+
+    setSelectionIndices(selectionIndices);
 
     events().notifyDatasetDataSelectionChanged(this);
 }

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -913,19 +913,17 @@ void Points::fromVariantMap(const QVariantMap& variantMap)
     }
 
     // Load raw point data
-    if (!isProxy()) {
-        if (isFull())
-            getRawData<PointData>()->fromVariantMap(variantMap);
-        else
-        {
-            variantMapMustContain(variantMap, "Indices");
-
-            const auto& indicesMap = variantMap["Indices"].toMap();
-
-            indices.resize(indicesMap["Count"].toInt());
-
-            populateDataBufferFromVariantMap(indicesMap["Raw"].toMap(), (char*)indices.data());
-        }
+    if (isFull())
+        getRawData<PointData>()->fromVariantMap(variantMap);
+    else
+    {
+        variantMapMustContain(variantMap, "Indices");
+    
+        const auto& indicesMap = variantMap["Indices"].toMap();
+    
+        indices.resize(indicesMap["Count"].toInt());
+    
+        populateDataBufferFromVariantMap(indicesMap["Raw"].toMap(), (char*)indices.data());
     }
 
     // Load dimension names

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -869,9 +869,7 @@ void Points::selectAll()
 
 void Points::selectNone()
 {
-    auto& selectionIndices = getSelection<Points>()->indices;
-
-    selectionIndices.clear();
+    setSelectionIndices({});
 
     events().notifyDatasetDataSelectionChanged(this);
 }
@@ -880,7 +878,9 @@ void Points::selectInvert()
 {
     std::vector<unsigned int> selectionIndices;
 
-    std::set<std::uint32_t> selectionSet(getSelection<Points>()->indices.begin(), getSelection<Points>()->indices.end());
+    auto selection = getSelection<Points>();
+
+    std::set<std::uint32_t> selectionSet(selection->indices.begin(), selection->indices.end());
 
     const auto numberOfPoints = getNumPoints();
 
@@ -897,20 +897,18 @@ void Points::selectInvert()
 
 void Points::fromVariantMap(const QVariantMap& variantMap)
 {
-    qDebug() << __FUNCTION__ << getGuiName();
-
     DatasetImpl::fromVariantMap(variantMap);
 
     variantMapMustContain(variantMap, "DimensionNames");
     variantMapMustContain(variantMap, "Selection");
 
-    // For backwards compatability, check PluginVersion
+    // For backwards compatibility, check PluginVersion
     if (variantMap["PluginVersion"] == "No Version" && !variantMap["Full"].toBool())
     {
         makeSubsetOf(getParent()->getFullDataset<mv::DatasetImpl>());
 
         qWarning() << "[ManiVault deprecation warning]: This project was saved with an older ManiVault version (<1.0). "
-            "Please save the project again to ensure compatability with newer ManiVault versions. "
+            "Please save the project again to ensure compatibility with newer ManiVault versions. "
             "Future releases may not be able to load this projects otherwise. ";
     }
 

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -878,19 +878,19 @@ void Points::selectNone()
 
 void Points::selectInvert()
 {
-    auto& selectionIndices = getSelection<Points>()->indices;
+    std::vector<unsigned int> selectionIndices;
 
-    std::set<std::uint32_t> selectionSet(selectionIndices.begin(), selectionIndices.end());
+    std::set<std::uint32_t> selectionSet(getSelection<Points>()->indices.begin(), getSelection<Points>()->indices.end());
 
-    const auto noPixels = getNumPoints();
+    const auto numberOfPoints = getNumPoints();
 
-    selectionIndices.clear();
-    selectionIndices.reserve(noPixels - selectionSet.size());
+    selectionIndices.reserve(numberOfPoints - selectionSet.size());
 
-    for (std::uint32_t i = 0; i < noPixels; i++) {
+    for (std::uint32_t i = 0; i < numberOfPoints; i++)
         if (selectionSet.find(i) == selectionSet.end())
             selectionIndices.push_back(i);
-    }
+
+    setSelectionIndices(selectionIndices);
 
     events().notifyDatasetDataSelectionChanged(this);
 }

--- a/HDPS/src/plugins/PointData/src/PointData.cpp
+++ b/HDPS/src/plugins/PointData/src/PointData.cpp
@@ -502,6 +502,7 @@ void Points::setProxyMembers(const Datasets& proxyMembers)
     DatasetImpl::setProxyMembers(proxyMembers);
 
     getTask().setName("Creating proxy");
+    getTask().setVisible(!(projects().isOpeningProject() || projects().isImportingProject()));
     getTask().setRunning();
 
     auto pointIndexOffset = 0u;

--- a/HDPS/src/private/DataHierarchyManager.cpp
+++ b/HDPS/src/private/DataHierarchyManager.cpp
@@ -250,7 +250,7 @@ void DataHierarchyManager::fromVariantMap(const QVariantMap& variantMap)
             const auto datasetId    = dataset["ID"].toString();
 
             subtasks << datasetId;
-            datasetList.emplace_back(dataset, dataset["Derived"].toBool());
+            datasetList.emplace_back(dataset, dataset["Derived"].toBool() || !dataset["ProxyMembers"].toStringList().isEmpty());
         }
     };
 


### PR DESCRIPTION
- [x] Fix de-serialization of proxy datasets; load proxy members befóre proxy dataset
- [x] Fix points resolve linked data (use source data)
- [x] Fix select all; uses `Points::setSelectionIndices(...)` now
- [x] Fix select none; uses `Points::setSelectionIndices(...)` now
- [x] Fix select invert; uses `Points::setSelectionIndices(...)` now
- [x] Do not show foreground task for proxy datasets during project open/import

Note: Selection fixes are not complete yet, for some reason selection notifications are not being broadcasted on distant datasets. This will solved in a separate PR.

Closes ManiVaultStudio/t-SNE-Analysis/issues/104