### PR TITLE
Unity build on CI, optional for local

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ file(TO_CMAKE_PATH ${MV_INSTALL_DIR} MV_INSTALL_DIR)
 # Other user-facing options
 option(HDPS_USE_GTEST "Use GoogleTest" OFF)
 option(MV_USE_AVX "Use AVX if available - by default OFF" OFF)
+option(MV_PRECOMPILE_HEADERS "Precompile several headers for faster compilation" ON)
 option(MV_UNITY_BUILD "Combine target source files into batches for faster compilation" OFF)
 
 if (HDPS_USE_GTEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ file(TO_CMAKE_PATH ${MV_INSTALL_DIR} MV_INSTALL_DIR)
 # Other user-facing options
 option(HDPS_USE_GTEST "Use GoogleTest" OFF)
 option(MV_USE_AVX "Use AVX if available - by default OFF" OFF)
+option(MV_UNITY_BUILD "Combine target source files into batches for faster compilation" OFF)
 
 if (HDPS_USE_GTEST)
     enable_testing()

--- a/HDPS/CMakeLists.txt
+++ b/HDPS/CMakeLists.txt
@@ -50,6 +50,11 @@ include(CMakeCheckSetAVX)
 # create a file that defines MV_VERSION_MAJOR, etc
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/ManiVaultVersion.h.in" "${CMAKE_CURRENT_SOURCE_DIR}/src/ManiVaultVersion.h" @ONLY)
 
+# when building on CI, use unity builds
+if(DEFINED ENV{CI} AND "$ENV{CI}" STREQUAL "true")
+    set(MV_UNITY_BUILD ON)
+endif()
+
 # -----------------------------------------------------------------------------
 # Apple settings
 # -----------------------------------------------------------------------------
@@ -125,6 +130,10 @@ message(STATUS "Using Qt Advanced Docking System version ${ADS_VERSION}")
 set(BUILD_EXAMPLES OFF CACHE BOOL "Qt-ads examples")
 add_subdirectory(external/advanced_docking)
 
+if(MV_UNITY_BUILD)
+    set_target_properties(qt6advanceddocking PROPERTIES UNITY_BUILD ON)
+endif()
+
 # File compression: ZLib, a dependency for QuaZip
 if(APPLE)
     message(STATUS "********Using brew zlib for QUAZIP *********")
@@ -154,7 +163,7 @@ add_subdirectory(external/quazip)
 set(CMAKE_MESSAGE_LOG_LEVEL "STATUS")
 get_target_property(QuaZip_VERSION QuaZip VERSION)
 message(STATUS "Using QuaZip version ${QuaZip_VERSION}")
- 
+
 # -----------------------------------------------------------------------------
 # Source files
 # -----------------------------------------------------------------------------
@@ -195,6 +204,10 @@ target_precompile_headers(${MV_PUBLIC_LIB} PRIVATE
     ${PUBLIC_UTIL_HEADERS}
 )
 
+if(MV_UNITY_BUILD)
+    set_target_properties(${MV_PUBLIC_LIB} PROPERTIES UNITY_BUILD ON)
+endif()
+
 # -----------------------------------------------------------------------------
 # Target MV_PRIVATE_LIB
 # -----------------------------------------------------------------------------
@@ -222,6 +235,10 @@ check_and_set_AVX(${MV_PRIVATE_LIB} ${MV_USE_AVX})
 add_dependencies(${MV_PRIVATE_LIB} ${MV_PUBLIC_LIB} QuaZip qt6advanceddocking)
 
 target_precompile_headers(${MV_PRIVATE_LIB} REUSE_FROM ${MV_PUBLIC_LIB})
+
+if(MV_UNITY_BUILD)
+    set_target_properties(${MV_PRIVATE_LIB} PROPERTIES UNITY_BUILD ON)
+endif()
 
 # -----------------------------------------------------------------------------
 # Target MV_EXE

--- a/HDPS/CMakeLists.txt
+++ b/HDPS/CMakeLists.txt
@@ -50,6 +50,14 @@ include(CMakeCheckSetAVX)
 # create a file that defines MV_VERSION_MAJOR, etc
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/ManiVaultVersion.h.in" "${CMAKE_CURRENT_SOURCE_DIR}/src/ManiVaultVersion.h" @ONLY)
 
+if(MV_PRECOMPILE_HEADERS)
+    message(STATUS "Using precompiled headers: ON")
+endif()
+
+if(MV_UNITY_BUILD)
+    message(STATUS "Using unity build: ON")
+endif()
+
 # -----------------------------------------------------------------------------
 # Apple settings
 # -----------------------------------------------------------------------------

--- a/HDPS/CMakeLists.txt
+++ b/HDPS/CMakeLists.txt
@@ -50,8 +50,9 @@ include(CMakeCheckSetAVX)
 # create a file that defines MV_VERSION_MAJOR, etc
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/ManiVaultVersion.h.in" "${CMAKE_CURRENT_SOURCE_DIR}/src/ManiVaultVersion.h" @ONLY)
 
-# when building on CI, use unity builds
+# when building on CI, use unity builds but not precompiled headers
 if(DEFINED ENV{CI} AND "$ENV{CI}" STREQUAL "true")
+    set(MV_PRECOMPILE_HEADERS OFF)
     set(MV_UNITY_BUILD ON)
 endif()
 
@@ -196,13 +197,15 @@ target_link_libraries(${MV_PUBLIC_LIB} PRIVATE Qt6::WebEngineWidgets)
 # Use avx if enabled and available
 check_and_set_AVX(${MV_PUBLIC_LIB} ${MV_USE_AVX})
 
-target_precompile_headers(${MV_PUBLIC_LIB} PRIVATE 
-    src/actions/Actions.h
-    src/event/EventListener.h
-    src/AbstractManager.h
-    src/Task.h
-    ${PUBLIC_UTIL_HEADERS}
-)
+if(MV_PRECOMPILE_HEADERS)
+    target_precompile_headers(${MV_PUBLIC_LIB} PRIVATE 
+        src/actions/Actions.h
+        src/event/EventListener.h
+        src/AbstractManager.h
+        src/Task.h
+        ${PUBLIC_UTIL_HEADERS}
+    )
+endif()
 
 if(MV_UNITY_BUILD)
     set_target_properties(${MV_PUBLIC_LIB} PROPERTIES UNITY_BUILD ON)
@@ -234,7 +237,9 @@ check_and_set_AVX(${MV_PRIVATE_LIB} ${MV_USE_AVX})
 
 add_dependencies(${MV_PRIVATE_LIB} ${MV_PUBLIC_LIB} QuaZip qt6advanceddocking)
 
-target_precompile_headers(${MV_PRIVATE_LIB} REUSE_FROM ${MV_PUBLIC_LIB})
+if(MV_PRECOMPILE_HEADERS)
+    target_precompile_headers(${MV_PRIVATE_LIB} REUSE_FROM ${MV_PUBLIC_LIB})
+endif()
 
 if(MV_UNITY_BUILD)
     set_target_properties(${MV_PRIVATE_LIB} PROPERTIES UNITY_BUILD ON)

--- a/HDPS/CMakeLists.txt
+++ b/HDPS/CMakeLists.txt
@@ -50,12 +50,6 @@ include(CMakeCheckSetAVX)
 # create a file that defines MV_VERSION_MAJOR, etc
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/ManiVaultVersion.h.in" "${CMAKE_CURRENT_SOURCE_DIR}/src/ManiVaultVersion.h" @ONLY)
 
-# when building on CI, use unity builds but not precompiled headers
-if(DEFINED ENV{CI} AND "$ENV{CI}" STREQUAL "true")
-    set(MV_PRECOMPILE_HEADERS OFF)
-    set(MV_UNITY_BUILD ON)
-endif()
-
 # -----------------------------------------------------------------------------
 # Apple settings
 # -----------------------------------------------------------------------------

--- a/HDPS/cmake/CMakeMvSourcesPublic.cmake
+++ b/HDPS/cmake/CMakeMvSourcesPublic.cmake
@@ -469,6 +469,9 @@ set(PUBLIC_UTIL_HEADERS
 	${PUBLIC_UTIL_HEADERS}
     src/util/MacThemeHelper.h
 )
+    set_source_files_properties(src/ApplicationSettingsAction.cpp src/util/MacThemeHelper.mm PROPERTIES
+      SKIP_UNITY_BUILD_INCLUSION ON
+    )
 endif()
 
 set(PUBLIC_UTIL_SOURCES

--- a/HDPS/src/actions/WidgetActionBadge.cpp
+++ b/HDPS/src/actions/WidgetActionBadge.cpp
@@ -4,6 +4,8 @@
 
 #include "WidgetActionBadge.h"
 
+#include "util/Icon.h"
+
 #include <QDebug>
 
 namespace mv::gui {

--- a/HDPS/src/actions/WidgetActionCollapsedWidget.cpp
+++ b/HDPS/src/actions/WidgetActionCollapsedWidget.cpp
@@ -3,7 +3,8 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "WidgetActionCollapsedWidget.h"
-#include "WidgetAction.h"
+
+#include "util/Icon.h"
 
 #include <QDebug>
 #include <QPainter>

--- a/HDPS/src/actions/WidgetActionCollapsedWidget.h
+++ b/HDPS/src/actions/WidgetActionCollapsedWidget.h
@@ -6,6 +6,8 @@
 
 #include "WidgetActionViewWidget.h"
 
+#include "WidgetAction.h"
+
 #include <QHBoxLayout>
 #include <QToolButton>
 

--- a/HDPS/src/plugins/ClusterData/CMakeLists.txt
+++ b/HDPS/src/plugins/ClusterData/CMakeLists.txt
@@ -120,6 +120,13 @@ target_link_libraries(${CLUSTERDATA} PRIVATE PointData)
 # Use avx if enabled and available
 check_and_set_AVX(${CLUSTERDATA} ${MV_USE_AVX})
 
+if(MV_UNITY_BUILD)
+    set_target_properties(${CLUSTERDATA} PROPERTIES UNITY_BUILD ON)
+    set_source_files_properties(${CLUSTERDATA_MOC} PROPERTIES
+                    SKIP_UNITY_BUILD_INCLUSION TRUE)
+
+endif()
+
 set_target_properties(${CLUSTERDATA} PROPERTIES PUBLIC_HEADER "${CLUSTER_HEADERS}")
 
 install(TARGETS ${CLUSTERDATA}

--- a/HDPS/src/plugins/DataHierarchyPlugin/CMakeLists.txt
+++ b/HDPS/src/plugins/DataHierarchyPlugin/CMakeLists.txt
@@ -86,6 +86,12 @@ target_link_libraries(${DATAHIERARCHYPLUGIN} PRIVATE ${MV_PUBLIC_LIB})
 # Use avx if enabled and available
 check_and_set_AVX(${DATAHIERARCHYPLUGIN} ${MV_USE_AVX})
 
+if(MV_UNITY_BUILD)
+    set_target_properties(${DATAHIERARCHYPLUGIN} PROPERTIES UNITY_BUILD ON)
+    set_source_files_properties(${DATAHIERARCHY_MOC} PROPERTIES
+                            SKIP_UNITY_BUILD_INCLUSION TRUE)
+endif()
+
 install(TARGETS ${DATAHIERARCHYPLUGIN}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so

--- a/HDPS/src/plugins/DataPropertiesPlugin/CMakeLists.txt
+++ b/HDPS/src/plugins/DataPropertiesPlugin/CMakeLists.txt
@@ -67,6 +67,12 @@ target_link_libraries(${DATAPROPERTIESPLUGIN} PRIVATE ${MV_PUBLIC_LIB})
 # Use avx if enabled and available
 check_and_set_AVX(${DATAPROPERTIESPLUGIN} ${MV_USE_AVX})
 
+if(MV_UNITY_BUILD)
+    set_target_properties(${DATAPROPERTIESPLUGIN} PROPERTIES UNITY_BUILD ON)
+    set_source_files_properties(${DATAPROPERTIES_MOC} PROPERTIES
+                        SKIP_UNITY_BUILD_INCLUSION TRUE)
+endif()
+
 install(TARGETS ${DATAPROPERTIESPLUGIN}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so

--- a/HDPS/src/plugins/ImageData/CMakeLists.txt
+++ b/HDPS/src/plugins/ImageData/CMakeLists.txt
@@ -78,6 +78,12 @@ target_link_libraries(${IMAGEDATA} PRIVATE ClusterData)
 
 set_target_properties(${IMAGEDATA} PROPERTIES PUBLIC_HEADER "${IMAGE_DATA_HEADERS}")
 
+if(MV_UNITY_BUILD)
+    set_target_properties(${IMAGEDATA} PROPERTIES UNITY_BUILD ON)
+    set_source_files_properties(${IMAGEDATA_MOC} PROPERTIES
+                        SKIP_UNITY_BUILD_INCLUSION TRUE)
+endif()
+
 install(TARGETS ${IMAGEDATA}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so

--- a/HDPS/src/plugins/PointData/CMakeLists.txt
+++ b/HDPS/src/plugins/PointData/CMakeLists.txt
@@ -131,6 +131,12 @@ if(UNIX AND NOT APPLE)
    target_link_libraries(${POINTDATA} PRIVATE TBB::tbb)
 endif()
 
+if(MV_UNITY_BUILD)
+    set_target_properties(${POINTDATA} PROPERTIES UNITY_BUILD ON)
+    set_source_files_properties(${POINTDATA_MOC} PROPERTIES
+                        SKIP_UNITY_BUILD_INCLUSION TRUE)
+endif()
+
 set_target_properties(${POINTDATA} PROPERTIES PUBLIC_HEADER "${POINTS_HEADERS}")
 
 install(TARGETS ${POINTDATA}

--- a/HDPS/src/util/Miscellaneous.cpp
+++ b/HDPS/src/util/Miscellaneous.cpp
@@ -7,8 +7,6 @@
 #include <QStringList>
 #include <QAction>
 
-using namespace std;
-
 namespace mv::util
 {
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -156,6 +156,11 @@ class HdpsCoreConan(ConanFile):
         zlibpath = pathlib.Path(self.deps_cpp_info["zlib"].rootpath).as_posix()
         tc.variables["ZLIB_ROOT"] = zlibpath
 
+        # Set some build options
+        tc.variables["MV_PRECOMPILE_HEADERS"] = "OFF"
+        tc.variables["MV_UNITY_BUILD"] = "ON"
+
+        # OS specific settings 
         if self.settings.os == "Linux":
             tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release"
         try:

--- a/conanfile.py
+++ b/conanfile.py
@@ -157,7 +157,7 @@ class HdpsCoreConan(ConanFile):
         tc.variables["ZLIB_ROOT"] = zlibpath
 
         # Set some build options
-        tc.variables["MV_PRECOMPILE_HEADERS"] = "OFF"
+        tc.variables["MV_PRECOMPILE_HEADERS"] = "ON"
         tc.variables["MV_UNITY_BUILD"] = "ON"
 
         # OS specific settings 


### PR DESCRIPTION
Unity builds combine target source files into batches for faster compilation:
- Enable [unity builds](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html) on the CI by default
- Add cmake option `MV_UNITY_BUILD` to also use unity builds locally - the option is OFF by default
- Add cmake option `MV_PRECOMPILE_HEADERS` for enabling precompiling headers - the option is ON by default, since precompiled headers are not new. I.e. the default build behavior does not change.

This reduces the build times on the CI considerably and has similar speed-ups for local builds:
- Windows: from ~16min to ~14min
- Linux: from ~25 to ~11min
- Mac: from ~25 to ~16min