### PR TITLE
DatasetImpl::_properties serialization 

### DIFF
--- a/ManiVault/src/Set.cpp
+++ b/ManiVault/src/Set.cpp
@@ -190,7 +190,10 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
         _mayUnderive = variantMap["MayUnderive"].toBool();
 
     if (variantMap.contains("Properties"))
-        _properties = variantMap["Properties"].toMap();
+    {
+        _properties = mv::util::loadQVariant(variantMap["Properties"]).toMap();
+    }
+    
 
     if (getStorageType() == StorageType::Proxy && variantMap.contains("ProxyMembers")) {
         Datasets proxyMembers;
@@ -239,7 +242,7 @@ QVariantMap DatasetImpl::toVariantMap() const
         { "FullDatasetID", isFull() ? "" : QVariant::fromValue(_fullDataset->getId()) },
         { "GroupIndex", QVariant::fromValue(getGroupIndex()) },
         { "LinkedData", linkedDataList },
-        { "Properties", QVariant::fromValue(_properties)}
+        { "Properties", mv::util::storeQVariant(_properties)}
     });
 
     return variantMap;

--- a/ManiVault/src/util/Serialization.h
+++ b/ManiVault/src/util/Serialization.h
@@ -52,4 +52,16 @@ void populateDataBufferFromVariantMap(const QVariantMap& variantMap, char* bytes
  */
 void variantMapMustContain(const QVariantMap& variantMap, const QString& key);
 
+/**
+* Store QVariant on disk if it is too large (divide up in blocks when the total number of bytes exceeds maxBlockSize) and return a QVariantMap with the file information, otherwise return the QVariant parameter.
+* @param variant QVariant to store
+*/
+QVariant storeQVariant(const QVariant& variant);
+
+/**
+ * Load QVariant from disk if it was large, othewise return QVariant.
+ * @param variant QVariant to load
+ */
+QVariant loadQVariant(const QVariant& variant);
+
 }


### PR DESCRIPTION
Added storeQVariant an loadQVariant helper function for serialization and used them for DatasetImpl::_properties (#544).

It should be backward compatible when it comes to loading old projects since those shouldn't have am item "QVariantOnDiskVersion".