### PR TITLE
Fix: Do not export header only classes

### DIFF
--- a/ManiVault/src/graphics/Framebuffer.h
+++ b/ManiVault/src/graphics/Framebuffer.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "ManiVaultGlobals.h"
-
 #include "Texture.h"
 
 #include <QOpenGLFunctions_3_3_Core>
@@ -15,7 +13,7 @@
 
 namespace mv
 {
-    class CORE_EXPORT Framebuffer : protected QOpenGLFunctions_3_3_Core
+    class Framebuffer : protected QOpenGLFunctions_3_3_Core
     {
     public:
         Framebuffer() :

--- a/ManiVault/src/graphics/OffscreenBuffer.h
+++ b/ManiVault/src/graphics/OffscreenBuffer.h
@@ -4,12 +4,10 @@
 
 #pragma once
 
-#include "ManiVaultGlobals.h"
-
 #include <QWindow>
 #include <QOpenGLContext>
 
-class CORE_EXPORT OffscreenBuffer : public QWindow
+class OffscreenBuffer : public QWindow
 {
 public:
     OffscreenBuffer()

--- a/ManiVault/src/graphics/Texture.h
+++ b/ManiVault/src/graphics/Texture.h
@@ -13,8 +13,6 @@
 
 #pragma once
 
-#include "ManiVaultGlobals.h"
-
 #include <QOpenGLFunctions_3_3_Core>
 
 #include <QPixmap>
@@ -133,7 +131,7 @@ protected:
     GLenum _target;
 };
 
-class CORE_EXPORT Texture1D : public Texture
+class Texture1D : public Texture
 {
 public:
     Texture1D() : Texture(GL_TEXTURE_1D) { }
@@ -158,7 +156,7 @@ public:
     }
 };
 
-class CORE_EXPORT Texture2D : public Texture
+class Texture2D : public Texture
 {
 public:
     Texture2D() : Texture(GL_TEXTURE_2D) { }


### PR DESCRIPTION
No need to export symbols that are not compiled here