### PR TITLE
Check if cluster data has a parent before trying to use it

### DIFF
--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
@@ -311,12 +311,12 @@ std::vector<std::uint32_t>& Clusters::getSelectionIndices()
 
 void Clusters::setSelectionIndices(const std::vector<std::uint32_t>& indices)
 {
-    if (!getDataHierarchyItem().hasParent())
-        return;
-
     getSelection<Clusters>()->indices = indices;
 
     events().notifyDatasetDataSelectionChanged(this);
+
+    if (!getDataHierarchyItem().hasParent())
+        return;
 
     // Get reference to input dataset
     auto points             = getDataHierarchyItem().getParent()->getDataset<Points>();

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
@@ -311,6 +311,9 @@ std::vector<std::uint32_t>& Clusters::getSelectionIndices()
 
 void Clusters::setSelectionIndices(const std::vector<std::uint32_t>& indices)
 {
+    if (!getDataHierarchyItem().hasParent())
+        return;
+
     getSelection<Clusters>()->indices = indices;
 
     events().notifyDatasetDataSelectionChanged(this);


### PR DESCRIPTION
Small fix for setSelectionIndices() in ClusterData where it tries to get the parent of the clusters dataset and set its selection.

This results in a crash when trying to select a cluster in a clusterdata that isn't under any point dataset in the hierarchy.
