### PR TITLE
Add option to enforce task status update

### DIFF
--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -158,7 +158,7 @@ message(STATUS "Using QuaZip version ${QuaZip_VERSION}")
 # -----------------------------------------------------------------------------
 include(CMakeMvSourcesApplication)    # defines MAIN_SOURCES, PRIVATE_SOURCES and PRIVATE_HEADERS
 include(CMakeMvSourcesPublic)         # defines PUBLIC_SOURCES, PUBLIC_HEADERS and PRECOMPILE_HEADERS
-include(CMakeMvSourcesResources)      # defines RESOURCE_FILES, UI_HEADERS and MAIN_APP_ICON_RESOURCE
+include(CMakeMvSourcesResources)      # defines RESOURCE_FILES, MAIN_APP_ICON_RESOURCE and MAIN_STYLES
 
 # -----------------------------------------------------------------------------
 # Target MV_PUBLIC_LIB
@@ -220,6 +220,7 @@ target_sources(${MV_EXE}
     PRIVATE
     src/.editorconfig
     ${MAIN_SOURCES}
+    ${MAIN_STYLES}
     ${PRIVATE_SOURCES}
     ${RESOURCE_FILES}
     ${MAIN_APP_ICON_RESOURCE}

--- a/ManiVault/cmake/CMakeMvSourcesApplication.cmake
+++ b/ManiVault/cmake/CMakeMvSourcesApplication.cmake
@@ -5,7 +5,6 @@
 
 set(MAIN_SOURCES
     src/Main.cpp
-    res/styles/default.qss
 )
 
 set(PRIVATE_CORE_HEADERS
@@ -322,7 +321,7 @@ list(REMOVE_DUPLICATES PRIVATE_SOURCES)
 
 source_group(Core FILES ${PRIVATE_CORE_FILES})
 source_group(Actions FILES ${PRIVATE_ACTION_FILES})
-source_group(Application FILES ${PRIVATE_APPLICATION_FILES})
+source_group(Application FILES ${PRIVATE_APPLICATION_FILES} ${MAIN_SOURCES})
 source_group(Managers\\Layout FILES ${PRIVATE_LAYOUT_MANAGER_FILES})
 source_group(Managers\\Plugin FILES ${PRIVATE_PLUGIN_MANAGER_FILES})
 source_group(Managers\\Data FILES ${PRIVATE_DATA_MANAGER_FILES})

--- a/ManiVault/cmake/CMakeMvSourcesResources.cmake
+++ b/ManiVault/cmake/CMakeMvSourcesResources.cmake
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # Resource files MV_EXE
 # -----------------------------------------------------------------------------
-# defines RESOURCE_FILES and MAIN_APP_ICON_RESOURCE
+# defines RESOURCE_FILES, MAIN_APP_ICON_RESOURCE and MAIN_STYLES
 
 set(QRESOURCES
     res/ResourcesCore.qrc
@@ -17,6 +17,10 @@ if(APPLE)
     set_source_files_properties(res/icons/AppIcon.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 endif(APPLE)
 
+set(MAIN_STYLES
+    res/styles/default.qss
+)
+
 qt_add_resources(RESOURCE_FILES ${QRESOURCES})
 
-source_group(Resources FILES ${QRESOURCES})
+source_group(Resources FILES ${QRESOURCES} ${MAIN_STYLES})

--- a/ManiVault/src/ApplicationStartupTask.cpp
+++ b/ManiVault/src/ApplicationStartupTask.cpp
@@ -29,8 +29,8 @@ ApplicationStartupTask::ApplicationStartupTask(QObject* parent, const QString& n
     setStatus(Task::Status::Idle, true);
 
     // Call QCoreApplication::processEvents() on each task update since we live before Qt's main event loop
-    _loadCoreManagersTask.setAlwaysProcessEvent(true);
-    _loadGuiTask.setAlwaysProcessEvent(true);
+    _loadCoreManagersTask.setAlwaysProcessEvents(true);
+    _loadGuiTask.setAlwaysProcessEvents(true);
 
     connect(this, &Task::statusChangedToFinished, this, [this]() -> void {
         if (Application::current()->shouldOpenProjectAtStartup())

--- a/ManiVault/src/ApplicationStartupTask.cpp
+++ b/ManiVault/src/ApplicationStartupTask.cpp
@@ -28,6 +28,10 @@ ApplicationStartupTask::ApplicationStartupTask(QObject* parent, const QString& n
 
     setStatus(Task::Status::Idle, true);
 
+    // Call QCoreApplication::processEvents() on each task update since we live before Qt's main event loop
+    _loadCoreManagersTask.setAlwaysProcessEvent(true);
+    _loadGuiTask.setAlwaysProcessEvent(true);
+
     connect(this, &Task::statusChangedToFinished, this, [this]() -> void {
         if (Application::current()->shouldOpenProjectAtStartup())
             setProgressDescription("Loaded " + QFileInfo(Application::current()->getStartupProjectFilePath()).fileName());

--- a/ManiVault/src/Main.cpp
+++ b/ManiVault/src/Main.cpp
@@ -209,7 +209,6 @@ int main(int argc, char *argv[])
     QString styleSheet = QLatin1String(styleSheetFile.readAll());
 
     application.setStyleSheet(styleSheet);
-
     loadGuiTask.setSubtaskFinished("Apply styles");
 
     QIcon appIcon;
@@ -223,17 +222,13 @@ int main(int argc, char *argv[])
 
     application.setWindowIcon(appIcon);
 
-    loadGuiTask.setSubtaskStarted("Create main window");
-
-    QCoreApplication::processEvents();
-
     MainWindow mainWindow;
 
-    loadGuiTask.setSubtaskFinished("Create main window");
-
-    QCoreApplication::processEvents();
+    loadGuiTask.setSubtaskStarted("Create main window");
 
     mainWindow.show();
+
+    loadGuiTask.setSubtaskFinished("Create main window");
 
     return application.exec();
 }

--- a/ManiVault/src/Task.cpp
+++ b/ManiVault/src/Task.cpp
@@ -52,6 +52,7 @@ Task::Task(QObject* parent, const QString& name, const GuiScopes& guiScopes /*= 
     _deferredStatus(Status::Undefined),
     _deferredStatusRecursive(false),
     _mayKill(mayKill),
+    _alwaysProcessEvents(false),
     _handler(handler),
     _progressMode(ProgressMode::Manual),
     _guiScopes(guiScopes),
@@ -361,6 +362,16 @@ bool Task::isKillable() const
 void Task::reset(bool recursive /*= false*/)
 {
     emit privateResetSignal(recursive, QPrivateSignal());
+}
+
+void Task::setAlwaysProcessEvent(bool val)
+{
+    _alwaysProcessEvents = val;
+}
+
+bool Task::getAlwaysProcessEvent() const
+{
+    return _alwaysProcessEvents;
 }
 
 Task::Status Task::getStatus() const
@@ -1434,7 +1445,8 @@ void Task::privateEmitProgressChanged()
         getTimer(TimerType::EmitProgressChanged).start();
     }
 
-    //QCoreApplication::processEvents();
+    if (_alwaysProcessEvents)
+        QCoreApplication::processEvents();
 }
 
 void Task::privateEmitProgressDescriptionChanged()
@@ -1447,7 +1459,8 @@ void Task::privateEmitProgressDescriptionChanged()
         getTimer(TimerType::EmitProgressDescriptionChanged).start();
     }
 
-    //QCoreApplication::processEvents();
+    if (_alwaysProcessEvents)
+        QCoreApplication::processEvents();
 }
 
 void Task::privateEmitProgressTextChanged()
@@ -1460,7 +1473,8 @@ void Task::privateEmitProgressTextChanged()
         getTimer(TimerType::EmitProgressTextChanged).start();
     }
 
-    //QCoreApplication::processEvents();
+    if (_alwaysProcessEvents)
+        QCoreApplication::processEvents();
 }
 
 void Task::addToTaskManager()

--- a/ManiVault/src/Task.cpp
+++ b/ManiVault/src/Task.cpp
@@ -364,9 +364,9 @@ void Task::reset(bool recursive /*= false*/)
     emit privateResetSignal(recursive, QPrivateSignal());
 }
 
-void Task::setAlwaysProcessEvent(bool val)
+void Task::setAlwaysProcessEvents(bool alwaysProcessEvents)
 {
-    _alwaysProcessEvents = val;
+    _alwaysProcessEvents = alwaysProcessEvents;
 }
 
 bool Task::getAlwaysProcessEvent() const

--- a/ManiVault/src/Task.cpp
+++ b/ManiVault/src/Task.cpp
@@ -369,7 +369,7 @@ void Task::setAlwaysProcessEvents(bool alwaysProcessEvents)
     _alwaysProcessEvents = alwaysProcessEvents;
 }
 
-bool Task::getAlwaysProcessEvent() const
+bool Task::getAlwaysProcessEvents() const
 {
     return _alwaysProcessEvents;
 }

--- a/ManiVault/src/Task.h
+++ b/ManiVault/src/Task.h
@@ -334,9 +334,9 @@ public: // Name, description, icon and may kill
 
     /**
      * Envoke Qt's processEvents on updates
-     * @param val Whether to envoke Qt's processEvents on updates
+     * @param alwaysProcessEvent Whether to invoke Qt's processEvents on updates
      */
-    virtual void setAlwaysProcessEvent(bool val) final;
+    virtual void setAlwaysProcessEvent(bool alwaysProcessEvent) final;
 
     /**
      * Get whether the task envokes Qt processEvents on updates
@@ -719,9 +719,9 @@ public: // Advanced (only use methods if consequences are understood)
     /**
      * Adds this task to the task manager
      * Under normal circumstances, tasks are automatically added to the task manager during construction.
-     * In some cases, the task manager is not yet present then and therefor this method allows to
+     * In some cases, the task manager is not yet present then and therefore this method allows to
      * manually add this task to the task manager at a later point in time.
-     * Only use this in edge-cases!
+     * Only use this in edge cases!
      */
     void addToTaskManager();
 

--- a/ManiVault/src/Task.h
+++ b/ManiVault/src/Task.h
@@ -332,6 +332,10 @@ public: // Name, description, icon and may kill
      */
     virtual void reset(bool recursive = false) final;
 
+    virtual void setAlwaysProcessEvent(bool val) final;
+
+    virtual bool getAlwaysProcessEvent() const final;
+
 public: // Status
 
     /** Get task status */
@@ -956,6 +960,7 @@ private:
     Status                  _deferredStatus;                                /** Task status which is set after a delay */
     bool                    _deferredStatusRecursive;                       /** Whether to set the task status deferred recursively */
     bool                    _mayKill;                                       /** Whether the task may be killed or not */
+    bool                    _alwaysProcessEvents;                           /** Whether the task envokes Qt processEvents on updates, e.g. for task before the main event loop started. Default: false */
     AbstractTaskHandler*    _handler;                                       /** Task handler */
     ProgressMode            _progressMode;                                  /** The way progress is recorded */
     GuiScopes               _guiScopes;                                     /** The gui scope(s) in which the task will present itself to the user */

--- a/ManiVault/src/Task.h
+++ b/ManiVault/src/Task.h
@@ -334,15 +334,15 @@ public: // Name, description, icon and may kill
 
     /**
      * Envoke Qt's processEvents on updates
-     * @param alwaysProcessEvent Whether to invoke Qt's processEvents on updates
+     * @param alwaysProcessEvents Whether to invoke Qt's processEvents on updates
      */
-    virtual void setAlwaysProcessEvent(bool alwaysProcessEvent) final;
+    virtual void setAlwaysProcessEvents(bool alwaysProcessEvents) final;
 
     /**
      * Get whether the task envokes Qt processEvents on updates
      * @return Whether the task envokes Qt's processEvents on updates
      */
-    virtual bool getAlwaysProcessEvent() const final;
+    virtual bool getAlwaysProcessEvents() const final;
 
 public: // Status
 

--- a/ManiVault/src/Task.h
+++ b/ManiVault/src/Task.h
@@ -332,8 +332,16 @@ public: // Name, description, icon and may kill
      */
     virtual void reset(bool recursive = false) final;
 
+    /**
+     * Envoke Qt's processEvents on updates
+     * @param val Whether to envoke Qt's processEvents on updates
+     */
     virtual void setAlwaysProcessEvent(bool val) final;
 
+    /**
+     * Get whether the task envokes Qt processEvents on updates
+     * @return Whether the task envokes Qt's processEvents on updates
+     */
     virtual bool getAlwaysProcessEvent() const final;
 
 public: // Status
@@ -960,7 +968,7 @@ private:
     Status                  _deferredStatus;                                /** Task status which is set after a delay */
     bool                    _deferredStatusRecursive;                       /** Whether to set the task status deferred recursively */
     bool                    _mayKill;                                       /** Whether the task may be killed or not */
-    bool                    _alwaysProcessEvents;                           /** Whether the task envokes Qt processEvents on updates, e.g. for task before the main event loop started. Default: false */
+    bool                    _alwaysProcessEvents;                           /** Whether the task envokes Qt's processEvents on updates, e.g. for task before the main event loop started. Default: false */
     AbstractTaskHandler*    _handler;                                       /** Task handler */
     ProgressMode            _progressMode;                                  /** The way progress is recorded */
     GuiScopes               _guiScopes;                                     /** The gui scope(s) in which the task will present itself to the user */

--- a/ManiVault/src/private/Core.cpp
+++ b/ManiVault/src/private/Core.cpp
@@ -90,8 +90,6 @@ void Core::initialize()
                 manager->initialize();
             }
             loadCoreManagersTask.setSubtaskFinished(manager->getSerializationName(), "Initializing " + manager->getSerializationName().toLower() + " manager");
-
-            QCoreApplication::processEvents();
         }
         
         loadCoreManagersTask.setFinished();

--- a/ManiVault/src/private/MainWindow.h
+++ b/ManiVault/src/private/MainWindow.h
@@ -60,8 +60,4 @@ public: // Miscellaneous
     /** Does a graphics requirements check (used at startup of the application) */
     void checkGraphicsCapabilities();
 
-private:
-
-    /** Sets up the GUI */
-    void initialize();
 };


### PR DESCRIPTION
Currently, we manually call `QCoreApplication::processEvents()` to update the task status in the splash screen before the main Qt event loop started. But we do not call it everywhere which leads to some tasks descriptions not showing up.

This PR adds an option to the Task class that automatically triggers the event processing.

- Add `Task:setAlwaysProcessEvent` and `Task:getAlwaysProcessEvent`, default is `false`
- Enable it for `ApplicationStartupTask::_loadCoreManagersTask` and `ApplicationStartupTask::_loadGuiTask`
- Remove manual `QCoreApplication::processEvents()` calls

Drive-by changes:
- cmake: add `Main.cpp` to the "Application" source group - currently it is not listed in any group but rather falls under MSVC "Source files", which otherwise lists automatically generated files like mocs, cmake_pch and unity_x
- cmake: list `res/styles/default.qss` under "Resources" - currently it is not listed in any group
- Remove non-implemented `MainWindow::initialize`