### PR TITLE
Add datasets list to plugin trigger action 

### DIFF
--- a/ManiVault/src/AbstractPluginManager.h
+++ b/ManiVault/src/AbstractPluginManager.h
@@ -221,6 +221,16 @@ protected:
      */
     virtual QStringList resolveDependencies(QDir pluginDir) const = 0;
 
+    /**
+     * Initializes a list of plugin trigger actions
+     * @param pluginTriggerActions List of plugin trigger actions to be initialized
+     */
+    virtual void initializePluginTriggerActions(gui::PluginTriggerActions& pluginTriggerActions) const final
+    {
+        for (auto& pluginTriggerAction : pluginTriggerActions)
+            pluginTriggerAction->initialize();
+    }
+
 signals:
 
     /**

--- a/ManiVault/src/AbstractPluginManager.h
+++ b/ManiVault/src/AbstractPluginManager.h
@@ -221,16 +221,6 @@ protected:
      */
     virtual QStringList resolveDependencies(QDir pluginDir) const = 0;
 
-    /**
-     * Initializes a list of plugin trigger actions
-     * @param pluginTriggerActions List of plugin trigger actions to be initialized
-     */
-    virtual void initializePluginTriggerActions(gui::PluginTriggerActions& pluginTriggerActions) const final
-    {
-        for (auto& pluginTriggerAction : pluginTriggerActions)
-            pluginTriggerAction->initialize();
-    }
-
 signals:
 
     /**

--- a/ManiVault/src/PluginFactory.h
+++ b/ManiVault/src/PluginFactory.h
@@ -192,6 +192,15 @@ public:
         return gui::PluginTriggerActions();
     }
 
+    /**
+     * Initializes a list of plugin trigger actions
+     * @param pluginTriggerActions List of plugin trigger actions to be initialized
+     */
+    static void initializePluginTriggerActions(gui::PluginTriggerActions& pluginTriggerActions) {
+        for (auto& pluginTriggerAction : pluginTriggerActions)
+            pluginTriggerAction->initialize();
+    }
+
 public: // Number of instances
 
     /** Get number of plugin instances currently loaded */

--- a/ManiVault/src/actions/PluginTriggerAction.cpp
+++ b/ManiVault/src/actions/PluginTriggerAction.cpp
@@ -3,9 +3,8 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "PluginTriggerAction.h"
-#include "CoreInterface.h"
-#include "AbstractPluginManager.h"
 
+#include "CoreInterface.h"
 #include "PluginFactory.h"
 
 #include <QCryptographicHash>
@@ -17,6 +16,7 @@ PluginTriggerAction::PluginTriggerAction(QObject* parent, const plugin::PluginFa
     _pluginFactory(pluginFactory),
     _menuLocation(),
     _sha(),
+    _datasets(),
     _configurationAction(nullptr),
     _requestPluginCallback()
 {
@@ -81,6 +81,11 @@ QString PluginTriggerAction::getSha() const
     return _sha;
 }
 
+ mv::Datasets PluginTriggerAction::getDatasets() const
+{
+    return _datasets;
+}
+
 WidgetAction* PluginTriggerAction::getConfigurationAction()
 {
     return _configurationAction;
@@ -89,6 +94,11 @@ WidgetAction* PluginTriggerAction::getConfigurationAction()
 void PluginTriggerAction::setConfigurationAction(WidgetAction* configurationAction)
 {
     _configurationAction = configurationAction;
+}
+
+void PluginTriggerAction::setDatasets(const mv::Datasets& datasets)
+{
+    _datasets = datasets;
 }
 
 void PluginTriggerAction::initialize()

--- a/ManiVault/src/actions/PluginTriggerAction.h
+++ b/ManiVault/src/actions/PluginTriggerAction.h
@@ -9,10 +9,6 @@
 #include "PluginType.h"
 #include "Dataset.h"
 
-namespace mv {
-    class AbstractPluginManager;
-}
-
 namespace mv::plugin {
     class PluginFactory;
 }
@@ -146,7 +142,6 @@ private:
     RequestPluginCallback           _requestPluginCallback;     /** Request plugin callback function which should create the plugin (invoked when the trigger action is triggered) */
 
     friend class plugin::PluginFactory;
-    friend class AbstractPluginManager;
 };
 
 using PluginTriggerActions = QVector<QPointer<PluginTriggerAction>>;

--- a/ManiVault/src/actions/PluginTriggerAction.h
+++ b/ManiVault/src/actions/PluginTriggerAction.h
@@ -9,6 +9,10 @@
 #include "PluginType.h"
 #include "Dataset.h"
 
+namespace mv {
+    class AbstractPluginManager;
+}
+
 namespace mv::plugin {
     class PluginFactory;
 }
@@ -142,6 +146,7 @@ private:
     RequestPluginCallback           _requestPluginCallback;     /** Request plugin callback function which should create the plugin (invoked when the trigger action is triggered) */
 
     friend class plugin::PluginFactory;
+    friend class AbstractPluginManager;
 };
 
 using PluginTriggerActions = QVector<QPointer<PluginTriggerAction>>;

--- a/ManiVault/src/actions/PluginTriggerAction.h
+++ b/ManiVault/src/actions/PluginTriggerAction.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "TriggerAction.h"
-#include "DecimalAction.h"
 
 #include "PluginType.h"
 #include "Dataset.h"
@@ -89,6 +88,12 @@ public:
     QString getSha() const;
 
     /**
+     * Get list of datasets that the plugin can work with when triggered
+     * @return Dataset list
+     */
+    mv::Datasets getDatasets() const;
+
+    /**
      * Get configuration action
      * @return Action for configuring the plugin creation (if available)
      */
@@ -105,6 +110,12 @@ public:
      * @param text Action text
      */
     void setText(const QString& text);
+
+    /**
+     * Set list of datasets that the plugin can work with when triggered
+     * @param datasets Dataset list
+     */
+    void setDatasets(const mv::Datasets& datasets);
 
     /**
      * Set the callback function which is invoked when the trigger action is triggered
@@ -126,6 +137,7 @@ private:
     const plugin::PluginFactory*    _pluginFactory;             /** Pointer to plugin factory */
     QString                         _menuLocation;              /** Determines where the plugin trigger action resides w.r.t. other plugin trigger actions (for instance in the data hierarchy context menu) in a path like fashion e.g. import/images */
     QString                         _sha;                       /** Cryptographic hash of the plugin kind and trigger title */
+    mv::Datasets                    _datasets;                  /** List of datasets that the plugin should work with when triggered */
     WidgetAction*                   _configurationAction;       /** Action for configuring the plugin creation */
     RequestPluginCallback           _requestPluginCallback;     /** Request plugin callback function which should create the plugin (invoked when the trigger action is triggered) */
 

--- a/ManiVault/src/actions/PluginTriggerPickerAction.cpp
+++ b/ManiVault/src/actions/PluginTriggerPickerAction.cpp
@@ -64,9 +64,10 @@ void PluginTriggerPickerAction::initialize(const QString& pluginKind, const Data
 
 QPointer<PluginTriggerAction> PluginTriggerPickerAction::getPluginTriggerAction(const QString& sha)
 {
-    for (const auto& pluginTriggerAction : _pluginTriggerActions)
-        if (pluginTriggerAction->getSha() == sha)
-            return pluginTriggerAction;
+    if(!sha.isEmpty())
+        for (const auto& pluginTriggerAction : _pluginTriggerActions)
+            if (pluginTriggerAction->getSha() == sha)
+                return pluginTriggerAction;
 
     return nullptr;
 }

--- a/ManiVault/src/private/PluginManager.cpp
+++ b/ManiVault/src/private/PluginManager.cpp
@@ -549,6 +549,8 @@ mv::gui::PluginTriggerActions PluginManager::getPluginTriggerActions(const plugi
 
     sortActions(pluginProducerActions);
 
+    initializePluginTriggerActions(pluginProducerActions);
+
     return pluginProducerActions;
 }
 
@@ -561,6 +563,8 @@ PluginTriggerActions PluginManager::getPluginTriggerActions(const Type& pluginTy
             pluginProducerActions << pluginFactory->getPluginTriggerActions(datasets);
 
     sortActions(pluginProducerActions);
+
+    initializePluginTriggerActions(pluginProducerActions);
 
     return pluginProducerActions;
 }
@@ -575,6 +579,8 @@ PluginTriggerActions PluginManager::getPluginTriggerActions(const plugin::Type& 
 
     sortActions(pluginProducerActions);
 
+    initializePluginTriggerActions(pluginProducerActions);
+
     return pluginProducerActions;
 }
 
@@ -588,6 +594,8 @@ PluginTriggerActions PluginManager::getPluginTriggerActions(const QString& plugi
 
     sortActions(pluginProducerActions);
 
+    initializePluginTriggerActions(pluginProducerActions);
+
     return pluginProducerActions;
 }
 
@@ -600,6 +608,8 @@ PluginTriggerActions PluginManager::getPluginTriggerActions(const QString& plugi
             pluginProducerActions << pluginFactory->getPluginTriggerActions(dataTypes);
 
     sortActions(pluginProducerActions);
+
+    initializePluginTriggerActions(pluginProducerActions);
 
     return pluginProducerActions;
 }

--- a/ManiVault/src/private/PluginManager.cpp
+++ b/ManiVault/src/private/PluginManager.cpp
@@ -549,7 +549,7 @@ mv::gui::PluginTriggerActions PluginManager::getPluginTriggerActions(const plugi
 
     sortActions(pluginProducerActions);
 
-    initializePluginTriggerActions(pluginProducerActions);
+    PluginFactory::initializePluginTriggerActions(pluginProducerActions);
 
     return pluginProducerActions;
 }
@@ -564,7 +564,7 @@ PluginTriggerActions PluginManager::getPluginTriggerActions(const Type& pluginTy
 
     sortActions(pluginProducerActions);
 
-    initializePluginTriggerActions(pluginProducerActions);
+    PluginFactory::initializePluginTriggerActions(pluginProducerActions);
 
     return pluginProducerActions;
 }
@@ -579,7 +579,7 @@ PluginTriggerActions PluginManager::getPluginTriggerActions(const plugin::Type& 
 
     sortActions(pluginProducerActions);
 
-    initializePluginTriggerActions(pluginProducerActions);
+    PluginFactory::initializePluginTriggerActions(pluginProducerActions);
 
     return pluginProducerActions;
 }
@@ -594,7 +594,7 @@ PluginTriggerActions PluginManager::getPluginTriggerActions(const QString& plugi
 
     sortActions(pluginProducerActions);
 
-    initializePluginTriggerActions(pluginProducerActions);
+    PluginFactory::initializePluginTriggerActions(pluginProducerActions);
 
     return pluginProducerActions;
 }
@@ -609,7 +609,7 @@ PluginTriggerActions PluginManager::getPluginTriggerActions(const QString& plugi
 
     sortActions(pluginProducerActions);
 
-    initializePluginTriggerActions(pluginProducerActions);
+    PluginFactory::initializePluginTriggerActions(pluginProducerActions);
 
     return pluginProducerActions;
 }


### PR DESCRIPTION
This PR re-enables some functionalities that got disabled during refactors, etc:
- Add list of datasets that a plugin should work with when triggered to the `PluginTriggerAction`
- Adds a function that initializes a list of `PluginTriggerActions` to the `PluginFactory` class
- Check for empty strings in `PluginTriggerPickerAction::getPluginTriggerAction`