### PR TITLE
Fix manual cluster recoloring

### DIFF
--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
@@ -46,6 +46,11 @@ QVector<Cluster>& ClusterData::getClusters()
     return _clusters;
 }
 
+const QVector<Cluster>& ClusterData::getClusters() const
+{
+    return _clusters;
+}
+
 void ClusterData::setClusters(const QVector<Cluster>&clusters)
 {
     _clusters = clusters;

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
@@ -46,6 +46,11 @@ QVector<Cluster>& ClusterData::getClusters()
     return _clusters;
 }
 
+void ClusterData::setClusters(const QVector<Cluster>&clusters)
+{
+    _clusters = clusters;
+}
+
 void ClusterData::addCluster(Cluster& cluster)
 {
     _clusters.push_back(cluster);

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.h
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.h
@@ -41,13 +41,22 @@ public:
      */
     Dataset<DatasetImpl> createDataSet(const QString& guid = "") const override;
 
-    /** Returns reference to the clusters */
+    /**
+     * Get clusters
+     * @return Reference to the clusters
+     */
     QVector<Cluster>& getClusters();
 
-    /** Returns a const reference to the clusters */
+    /**
+     * Get clusters
+     * @return Const reference to the clusters 
+     */
     const QVector<Cluster>& getClusters() const;
 
-    /** Set the clusters */
+    /**
+     * Set clusters to \p clusters
+     * @param clusters New clusters
+     */
     void setClusters(const QVector<Cluster>& clusters);
 
     /**
@@ -144,7 +153,7 @@ public:
 
     /**
      * Get a copy of the dataset
-     * @return Smart pointer to copy of dataset
+     * @return Smart pointer to copy of the dataset
      */
     Dataset<DatasetImpl> copy() const override
     {
@@ -268,6 +277,4 @@ public:
     QIcon getIcon(const QColor& color = Qt::black) const override;
 
     mv::plugin::RawData* produce() override;
-
-
 };

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.h
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.h
@@ -44,6 +44,9 @@ public:
     /** Returns reference to the clusters */
     QVector<Cluster>& getClusters();
 
+    /** Returns a const reference to the clusters */
+    const QVector<Cluster>& getClusters() const;
+
     /** Set the clusters */
     void setClusters(const QVector<Cluster>& clusters);
 

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.h
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.h
@@ -44,6 +44,9 @@ public:
     /** Returns reference to the clusters */
     QVector<Cluster>& getClusters();
 
+    /** Set the clusters */
+    void setClusters(const QVector<Cluster>& clusters);
+
     /**
      * Adds a cluster
      * @param cluster Cluster to add
@@ -111,6 +114,11 @@ public:
     const QVector<Cluster>& getClusters() const
     {
         return getRawData<ClusterData>()->getClusters();
+    }
+
+    void setClusters(const QVector<Cluster>& clusters)
+    {
+        getRawData<ClusterData>()->setClusters(clusters);
     }
 
     /**

--- a/ManiVault/src/plugins/ClusterData/src/ClustersAction.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersAction.cpp
@@ -87,20 +87,55 @@ void ClustersAction::updateClustersModel()
 
 void ClustersAction::updateClustersDataset()
 {
+    qDebug() << "ClustersAction::updateClustersDataset START";
+
+    qDebug() << "_clustersModel.getClusters";
+    qDebug() << _clustersModel.getClusters()[0].getColor();
+    qDebug() << "_clustersDataset->getClusters";
+    qDebug() << _clustersDataset->getClusters()[0].getColor();
+
     auto temp = _clustersModel.getClusters()[0].getColor();
 
     const auto& newClusters = _clustersModel.getClusters();
     const auto& currentClusters = _clustersDataset->getClusters();
 
     if (newClusters == currentClusters)
+    {
+        qDebug() << "ClustersAction::updateClustersDataset RETURN";
         return;
+    }
+
+    qDebug() << "ClustersAction::updateClustersDataset YES CHANGE";
 
     bool automaticRecolor = newClusters.size() != currentClusters.size();
 
     _clustersDataset->setClusters(newClusters);
 
+    qDebug() << "ClustersAction::updateClustersDataset MIDDLE 1";
+
+    qDebug() << "_clustersModel.getClusters";
+    qDebug() << _clustersModel.getClusters()[0].getColor();
+    qDebug() << "_clustersDataset->getClusters";
+    qDebug() << _clustersDataset->getClusters()[0].getColor();
+
     if (automaticRecolor)
         _colorizeClustersAction.updateColorsInModel();
 
+    qDebug() << "ClustersAction::updateClustersDataset MIDDLE 2";
+
+    qDebug() << "_clustersModel.getClusters";
+    qDebug() << _clustersModel.getClusters()[0].getColor();
+    qDebug() << "_clustersDataset->getClusters";
+    qDebug() << _clustersDataset->getClusters()[0].getColor();
+
     events().notifyDatasetDataChanged(_clustersDataset);
+
+    qDebug() << "ClustersAction::updateClustersDataset MIDDLE 3";
+
+    qDebug() << "_clustersModel.getClusters";
+    qDebug() << _clustersModel.getClusters()[0].getColor();
+    qDebug() << "_clustersDataset->getClusters";
+    qDebug() << _clustersDataset->getClusters()[0].getColor();
+
+    qDebug() << "ClustersAction::updateClustersDataset END";
 }

--- a/ManiVault/src/plugins/ClusterData/src/ClustersAction.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersAction.cpp
@@ -87,12 +87,18 @@ void ClustersAction::updateClustersModel()
 
 void ClustersAction::updateClustersDataset()
 {
-    if (_clustersModel.getClusters() == _clustersDataset->getClusters())
+    const auto& newClusters = _clustersModel.getClusters();
+    const auto& currentClusters = _clustersDataset->getClusters();
+
+    if (newClusters == currentClusters)
         return;
 
-    _clustersDataset->getClusters() = _clustersModel.getClusters();
+    bool automaticRecolor = newClusters.size() != currentClusters.size();
 
-    _colorizeClustersAction.updateColorsInModel();
+    _clustersDataset->setClusters(newClusters);
+
+    if (automaticRecolor)
+        _colorizeClustersAction.updateColorsInModel();
 
     events().notifyDatasetDataChanged(_clustersDataset);
 }

--- a/ManiVault/src/plugins/ClusterData/src/ClustersAction.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersAction.cpp
@@ -87,55 +87,19 @@ void ClustersAction::updateClustersModel()
 
 void ClustersAction::updateClustersDataset()
 {
-    qDebug() << "ClustersAction::updateClustersDataset START";
-
-    qDebug() << "_clustersModel.getClusters";
-    qDebug() << _clustersModel.getClusters()[0].getColor();
-    qDebug() << "_clustersDataset->getClusters";
-    qDebug() << _clustersDataset->getClusters()[0].getColor();
-
-    auto temp = _clustersModel.getClusters()[0].getColor();
-
-    const auto& newClusters = _clustersModel.getClusters();
+    const auto& newClusters     = _clustersModel.getClusters();
     const auto& currentClusters = _clustersDataset->getClusters();
 
     if (newClusters == currentClusters)
-    {
-        qDebug() << "ClustersAction::updateClustersDataset RETURN";
         return;
-    }
-
-    qDebug() << "ClustersAction::updateClustersDataset YES CHANGE";
 
     bool automaticRecolor = newClusters.size() != currentClusters.size();
 
     _clustersDataset->setClusters(newClusters);
 
-    qDebug() << "ClustersAction::updateClustersDataset MIDDLE 1";
-
-    qDebug() << "_clustersModel.getClusters";
-    qDebug() << _clustersModel.getClusters()[0].getColor();
-    qDebug() << "_clustersDataset->getClusters";
-    qDebug() << _clustersDataset->getClusters()[0].getColor();
-
+    // Re-color if a cluster was deleted
     if (automaticRecolor)
         _colorizeClustersAction.updateColorsInModel();
 
-    qDebug() << "ClustersAction::updateClustersDataset MIDDLE 2";
-
-    qDebug() << "_clustersModel.getClusters";
-    qDebug() << _clustersModel.getClusters()[0].getColor();
-    qDebug() << "_clustersDataset->getClusters";
-    qDebug() << _clustersDataset->getClusters()[0].getColor();
-
     events().notifyDatasetDataChanged(_clustersDataset);
-
-    qDebug() << "ClustersAction::updateClustersDataset MIDDLE 3";
-
-    qDebug() << "_clustersModel.getClusters";
-    qDebug() << _clustersModel.getClusters()[0].getColor();
-    qDebug() << "_clustersDataset->getClusters";
-    qDebug() << _clustersDataset->getClusters()[0].getColor();
-
-    qDebug() << "ClustersAction::updateClustersDataset END";
 }

--- a/ManiVault/src/plugins/ClusterData/src/ClustersAction.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersAction.cpp
@@ -87,6 +87,8 @@ void ClustersAction::updateClustersModel()
 
 void ClustersAction::updateClustersDataset()
 {
+    auto temp = _clustersModel.getClusters()[0].getColor();
+
     const auto& newClusters = _clustersModel.getClusters();
     const auto& currentClusters = _clustersDataset->getClusters();
 

--- a/ManiVault/src/plugins/ClusterData/src/ClustersModel.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersModel.cpp
@@ -133,7 +133,7 @@ bool ClustersModel::setData(const QModelIndex& index, const QVariant& value, int
 {
     const auto column = static_cast<Column>(index.column());
 
-    auto cluster = static_cast<Cluster*>((void*)index.internalPointer());
+    auto& cluster = _clusters[index.row()];
 
     switch (role)
     {
@@ -141,12 +141,12 @@ bool ClustersModel::setData(const QModelIndex& index, const QVariant& value, int
         {
             switch (column) {
                 case Column::Color:
-                    cluster->setColor(value.value<QColor>());
+                    cluster.setColor(value.value<QColor>());
                     _modifiedByUser[index.row()] = true;
                     break;
 
                 case Column::Name:
-                    cluster->setName(value.toString());
+                    cluster.setName(value.toString());
                     _modifiedByUser[index.row()] = true;
                     break;
 
@@ -168,7 +168,7 @@ bool ClustersModel::setData(const QModelIndex& index, const QVariant& value, int
             break;
     }
 
-    emit dataChanged(index, index);
+    emit dataChanged(index, index, { index.column() });
 
     return true;
 }

--- a/ManiVault/src/plugins/ClusterData/src/ClustersModel.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersModel.cpp
@@ -264,6 +264,11 @@ QVector<Cluster>& ClustersModel::getClusters()
     return _clusters;
 }
 
+const QVector<Cluster>& ClustersModel::getClusters() const
+{
+    return _clusters;
+}
+
 void ClustersModel::setClusters(const QVector<Cluster>& clusters)
 {
     // Allocate the same number of items for the modified by user column

--- a/ManiVault/src/plugins/ClusterData/src/ClustersModel.h
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersModel.h
@@ -94,10 +94,16 @@ public:
      */
     Qt::ItemFlags flags(const QModelIndex& index) const override;
 
-    /** Get clusters */
+    /**
+     * Get clusters
+     * @return vector of clusters
+     */
     QVector<Cluster>& getClusters();
 
-    /** Get clusters */
+    /**
+     * Get clusters
+     * @return Const reference vector of clusters
+     */
     const QVector<Cluster>& getClusters() const;
 
     /**

--- a/ManiVault/src/plugins/ClusterData/src/ClustersModel.h
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersModel.h
@@ -97,6 +97,9 @@ public:
     /** Get clusters */
     QVector<Cluster>& getClusters();
 
+    /** Get clusters */
+    const QVector<Cluster>& getClusters() const;
+
     /**
      * Set clusters
      * @param clusters Pointer to clusters


### PR DESCRIPTION
Two small fixes for updating the `ClusterModel`:
- Only call `_colorizeClustersAction.updateColorsInModel()` in `ClustersAction::updateClustersDataset` if the new cluster data has a different size from the current cluster data, i.e. when a cluster was deleted or removed
- Modify cluster data in `ClustersModel::setData` the same way as when accessing it in `ClustersModel::data`, i.e. avoid `QModelIndex::internalPointer`

Also, adding some convenience getter and setter here.