### PR TITLE
Add cluster name getter

### DIFF
--- a/ManiVault/src/actions/HorizontalHeaderAction.cpp
+++ b/ManiVault/src/actions/HorizontalHeaderAction.cpp
@@ -3,8 +3,11 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "HorizontalHeaderAction.h"
+
+#include "Application.h"
 #include "OptionsAction.h"
 
+#include <QEvent>
 #include <QHeaderView>
 
 namespace mv::gui {

--- a/ManiVault/src/actions/ModelSelectionAction.cpp
+++ b/ManiVault/src/actions/ModelSelectionAction.cpp
@@ -4,6 +4,8 @@
 
 #include "ModelSelectionAction.h"
 
+#include "Application.h"
+
 #include <QAbstractItemModel>
 #include <QItemSelectionModel>
 

--- a/ManiVault/src/actions/OptionsAction.cpp
+++ b/ManiVault/src/actions/OptionsAction.cpp
@@ -29,7 +29,7 @@ OptionsAction::OptionsAction(QObject* parent, const QString& title, const QStrin
     setDefaultWidgetFlags(WidgetFlag::Default);
     initialize(options, selectedOptions);
 
-    connect(&_optionsModel, &QStandardItemModel::dataChanged, this, [this]() -> void {
+    connect(&_optionsModel, &QAbstractItemModel::dataChanged, this, [this]() -> void {
         selectedOptionsChanged(getSelectedOptions());
     });
 }

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
@@ -79,6 +79,7 @@ void ClusterData::setClusterNames(const std::vector<QString>& clusterNames)
 std::vector<QString> ClusterData::getClusterNames()
 {
     std::vector<QString> clusterNames;
+    clusterNames.reserve(_clusters.size());
 
     for (const auto& clusters : _clusters)
         clusterNames.push_back(clusters.getName());

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
@@ -61,14 +61,14 @@ void ClusterData::addCluster(Cluster& cluster)
     _clusters.push_back(cluster);
 }
 
-void ClusterData::setDimensionNames(const std::vector<QString>& clusterNames)
+void ClusterData::setClusterNames(const std::vector<QString>& clusterNames)
 {
     if (clusterNames.empty())
         return;
 
     if (clusterNames.size() != _clusters.size())
     {
-        qWarning() << "PointData: Number of dimension names does not equal the number of data dimensions";
+        qWarning() << "ClusterData: Number of cluster names does not equal the number of data cluster";
     }
 
     for (size_t i = 0; i < clusterNames.size(); i++)

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
@@ -68,7 +68,8 @@ void ClusterData::setClusterNames(const std::vector<QString>& clusterNames)
 
     if (clusterNames.size() != _clusters.size())
     {
-        qWarning() << "ClusterData: Number of cluster names does not equal the number of data cluster";
+        qWarning() << "ClusterData: Number of cluster names does not equal the number of data cluster. No cluster names assigned.";
+        return;
     }
 
     for (size_t i = 0; i < clusterNames.size(); i++)

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
@@ -61,6 +61,16 @@ void ClusterData::addCluster(Cluster& cluster)
     _clusters.push_back(cluster);
 }
 
+std::vector<QString> ClusterData::getClusterNames()
+{
+    std::vector<QString> clusterNames;
+
+    for (const auto& clusters : _clusters)
+        clusterNames.push_back(clusters.getName());
+
+    return clusterNames;
+}
+
 void ClusterData::removeClusterById(const QString& id)
 {
     _clusters.erase(std::remove_if(_clusters.begin(), _clusters.end(), [id](const Cluster& cluster) -> bool

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
@@ -61,6 +61,20 @@ void ClusterData::addCluster(Cluster& cluster)
     _clusters.push_back(cluster);
 }
 
+void ClusterData::setDimensionNames(const std::vector<QString>& clusterNames)
+{
+    if (clusterNames.empty())
+        return;
+
+    if (clusterNames.size() != _clusters.size())
+    {
+        qWarning() << "PointData: Number of dimension names does not equal the number of data dimensions";
+    }
+
+    for (size_t i = 0; i < clusterNames.size(); i++)
+        _clusters[i].setName(clusterNames[i]);
+}
+
 std::vector<QString> ClusterData::getClusterNames()
 {
     std::vector<QString> clusterNames;

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.h
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.h
@@ -66,6 +66,12 @@ public:
     void addCluster(Cluster& cluster);
 
     /**
+     * Get cluster names
+     * @return Vector of cluster names
+     */
+    std::vector<QString> getClusterNames();
+
+    /**
      * Removes a cluster by its unique identifier
      * @param id Unique identifier of the cluster to remove
      */
@@ -138,6 +144,15 @@ public:
      * @param cluster Cluster to add
      */
     void addCluster(Cluster& cluster);
+
+    /**
+     * Get cluster names
+     * @return Vector of cluster names
+     */
+    std::vector<QString> getClusterNames()
+    {
+        return getRawData<ClusterData>()->getClusterNames();
+    }
 
     /**
      * Removes a cluster by its unique identifier

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.h
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.h
@@ -66,6 +66,12 @@ public:
     void addCluster(Cluster& cluster);
 
     /**
+     * Set cluster names
+     * @param Vector of cluster names
+     */
+    void setDimensionNames(const std::vector<QString>& clusterNames);
+
+    /**
      * Get cluster names
      * @return Vector of cluster names
      */
@@ -144,6 +150,15 @@ public:
      * @param cluster Cluster to add
      */
     void addCluster(Cluster& cluster);
+
+    /**
+     * Set cluster names
+     * @param Vector of cluster names
+     */
+    void setDimensionNames(const std::vector<QString>& clusterNames)
+    {
+        getRawData<ClusterData>()->setDimensionNames(clusterNames);
+    }
 
     /**
      * Get cluster names

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.h
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.h
@@ -69,7 +69,7 @@ public:
      * Set cluster names
      * @param Vector of cluster names
      */
-    void setDimensionNames(const std::vector<QString>& clusterNames);
+    void setClusterNames(const std::vector<QString>& clusterNames);
 
     /**
      * Get cluster names
@@ -155,9 +155,9 @@ public:
      * Set cluster names
      * @param Vector of cluster names
      */
-    void setDimensionNames(const std::vector<QString>& clusterNames)
+    void setClusterNames(const std::vector<QString>& clusterNames)
     {
-        getRawData<ClusterData>()->setDimensionNames(clusterNames);
+        getRawData<ClusterData>()->setClusterNames(clusterNames);
     }
 
     /**


### PR DESCRIPTION
Adds convenience functions `getClusterNames` and `setClusterNames` for setting and getting cluster names in ClusterData.

Same syntax as `getDimensionNames` and `setDimensionNames` in [PointData](https://github.com/ManiVaultStudio/core/blob/39d44b90078e3a95583c6da82848e7d632260b8e/ManiVault/src/plugins/PointData/src/PointData.h#L398).