### PR TITLE
Use hslSaturation instead of saturation

### DIFF
--- a/ManiVault/src/actions/ColorPickerAction.cpp
+++ b/ManiVault/src/actions/ColorPickerAction.cpp
@@ -78,7 +78,7 @@ ColorPickerAction::Widget::Widget(QWidget* parent, ColorPickerAction* colorPicke
     _layout(),
     _colorDialog(),
     _hueAction(this, "Hue", 0, 359, colorPickerAction->getColor().hue()),
-    _saturationAction(this, "Saturation", 0, 255, colorPickerAction->getColor().saturation()),
+    _saturationAction(this, "Saturation", 0, 255, colorPickerAction->getColor().hslSaturation()),
     _lightnessAction(this, "Lightness", 0, 255, colorPickerAction->getColor().lightness()),
     _updateColorPickerAction(true)
 {

--- a/ManiVault/src/actions/ColorPickerAction.cpp
+++ b/ManiVault/src/actions/ColorPickerAction.cpp
@@ -149,7 +149,7 @@ ColorPickerAction::Widget::Widget(QWidget* parent, ColorPickerAction* colorPicke
         {
             _colorDialog.setCurrentColor(color);
             _hueAction.setValue(color.hue());
-            _saturationAction.setValue(color.saturation());
+            _saturationAction.setValue(color.hslSaturation());
             _lightnessAction.setValue(color.lightness());
         }
         _updateColorPickerAction = true;


### PR DESCRIPTION
The `QColor::saturation()` function [returns the HSV saturation](https://doc.qt.io/qt-6/qcolor.html#saturation), but here we want the HSL saturation which is given by `QColor::hslSaturation()`, see [Qt docs: The HSL Color Model](https://doc.qt.io/qt-6/qcolor.html#the-hsl-color-model)