### PR TITLE
Restore PixelSelectionAction modifier key behaviour

### DIFF
--- a/ManiVault/src/actions/PixelSelectionAction.cpp
+++ b/ManiVault/src/actions/PixelSelectionAction.cpp
@@ -311,13 +311,11 @@ void PixelSelectionAction::initModifier()
     });
 
     connect(&_modifierAddAction, &QAction::toggled, [this](bool toggled) {
-        if (toggled)
-            _modifierAction.setCurrentIndex(static_cast<std::int32_t>(PixelSelectionModifierType::Add));
+        _modifierAction.setCurrentIndex(toggled ? static_cast<std::int32_t>(PixelSelectionModifierType::Add) : static_cast<std::int32_t>(PixelSelectionModifierType::Replace));
     });
 
     connect(&_modifierSubtractAction, &QAction::toggled, [this](bool toggled) {
-        if (toggled)
-            _modifierAction.setCurrentIndex(static_cast<std::int32_t>(PixelSelectionModifierType::Subtract));
+        _modifierAction.setCurrentIndex(toggled ? static_cast<std::int32_t>(PixelSelectionModifierType::Subtract) : static_cast<std::int32_t>(PixelSelectionModifierType::Replace));
     });
 
     if (!isInitialized())

--- a/ManiVault/src/actions/PixelSelectionAction.cpp
+++ b/ManiVault/src/actions/PixelSelectionAction.cpp
@@ -418,6 +418,9 @@ QMenu* PixelSelectionAction::getContextMenu()
 
 bool PixelSelectionAction::eventFilter(QObject* object, QEvent* event)
 {
+    if (!isEnabled())
+        return QObject::eventFilter(object, event);
+
     const auto keyEvent = dynamic_cast<QKeyEvent*>(event);
 
     if (!keyEvent)


### PR DESCRIPTION
Restores the intended behavior of the `shift` and `ctrl` key bindings in the `PixelSelectionAction`:
- [x] Hold down `shift` to enable additive selection, release to exit
- [x] Hold down `ctrl` to enable subtractive selection, release to exit