### PR TITLE
Emit datasetsChanged in DatasetPickerAction

### DIFF
--- a/ManiVault/src/actions/DatasetPickerAction.cpp
+++ b/ManiVault/src/actions/DatasetPickerAction.cpp
@@ -88,7 +88,7 @@ void DatasetPickerAction::setMode(Mode mode)
     }
 }
 
-void DatasetPickerAction::setDatasets(Datasets datasets)
+void DatasetPickerAction::setDatasets(Datasets datasets, bool silent)
 {
 #ifdef DATASET_PICKER_ACTION_VERBOSE
     qDebug() << __FUNCTION__;
@@ -97,6 +97,9 @@ void DatasetPickerAction::setDatasets(Datasets datasets)
     _mode = Mode::Manual;
 
     _datasetsModel.setDatasets(datasets);
+
+    if (!silent)
+        emit datasetsChanged(_datasetsModel.getDatasets());
 
     for (auto& dataset : _datasetsModel.getDatasets()) {
 
@@ -173,6 +176,8 @@ void DatasetPickerAction::populateDatasetsFromCore()
         datasets = _datasetsFilterFunction(datasets);
 
     _datasetsModel.setDatasets(datasets);
+
+    emit datasetsChanged(_datasetsModel.getDatasets());
 
     for (auto& dataset : datasets)
         connect(dataset.get(), &DatasetImpl::locationChanged, &_datasetsModel, &DatasetsModel::updateData);

--- a/ManiVault/src/actions/DatasetPickerAction.h
+++ b/ManiVault/src/actions/DatasetPickerAction.h
@@ -177,8 +177,9 @@ public:
     /**
      * Set the datasets from which can be picked (mode is set to Mode::Manual)
      * @param datasets Datasets from which can be picked
+     * @param silent Whether the signal datasetsChanged is emitted
      */
-    void setDatasets(mv::Datasets datasets);
+    void setDatasets(mv::Datasets datasets, bool silent = false);
 
     /**
      * Set datasets filter function (mode is set to Mode::Automatic)


### PR DESCRIPTION
The signal `datasetsChanged` in `DatasetPickerAction` is never emitted. It should be emitted when the data sets change, e.g. by setting them explicitly or when automatically updated.