### PR TITLE
Distinguish data and view bounds in Point Renderer

### DIFF
--- a/ManiVault/src/renderers/PointRenderer.cpp
+++ b/ManiVault/src/renderers/PointRenderer.cpp
@@ -299,31 +299,31 @@ namespace mv
 
         Bounds PointRenderer::getBounds() const
         {
-            return getBoundsView();
+            return getViewBounds();
         }
 
-        Bounds PointRenderer::getBoundsView() const
+        Bounds PointRenderer::getViewBounds() const
         {
             return _boundsView;
         }
 
-        Bounds PointRenderer::getBoundsData() const
+        Bounds PointRenderer::getDataBounds() const
         {
             return _boundsData;
         }
 
         void PointRenderer::setBounds(const Bounds& bounds)
         {
-            setBoundsView(bounds);
-            setBoundsData(bounds);
+            setViewBounds(bounds);
+            setDataBounds(bounds);
         }
 
-        void PointRenderer::setBoundsView(const Bounds& boundsView)
+        void PointRenderer::setViewBounds(const Bounds& boundsView)
         {
             _boundsView = boundsView;
         }
 
-        void PointRenderer::setBoundsData(const Bounds& boundsData)
+        void PointRenderer::setDataBounds(const Bounds& boundsData)
         {
             _boundsData = boundsData;
         }

--- a/ManiVault/src/renderers/PointRenderer.cpp
+++ b/ManiVault/src/renderers/PointRenderer.cpp
@@ -299,12 +299,33 @@ namespace mv
 
         Bounds PointRenderer::getBounds() const
         {
-            return _bounds;
+            return getBoundsView();
+        }
+
+        Bounds PointRenderer::getBoundsView() const
+        {
+            return _boundsView;
+        }
+
+        Bounds PointRenderer::getBoundsData() const
+        {
+            return _boundsData;
         }
 
         void PointRenderer::setBounds(const Bounds& bounds)
         {
-            _bounds = bounds;
+            setBoundsView(bounds);
+            setBoundsData(bounds);
+        }
+
+        void PointRenderer::setBoundsView(const Bounds& boundsView)
+        {
+            _boundsView = boundsView;
+        }
+
+        void PointRenderer::setBoundsData(const Bounds& boundsData)
+        {
+            _boundsData = boundsData;
         }
 
         Matrix3f PointRenderer::getProjectionMatrix() const
@@ -425,7 +446,7 @@ namespace mv
             glViewport(w / 2 - size / 2, h / 2 - size / 2, size, size);
 
             // World to clip transformation
-            _orthoM = createProjectionMatrix(_bounds);
+            _orthoM = createProjectionMatrix(_boundsView);
 
             _shader.bind();
 
@@ -438,7 +459,7 @@ namespace mv
             _shader.uniform1f("pointOpacity", _pointSettings._alpha);
             _shader.uniform1i("scalarEffect", _pointEffect);
             
-            _shader.uniform4f("dataBounds", _bounds.getLeft(), _bounds.getRight(), _bounds.getBottom(), _bounds.getTop());
+            _shader.uniform4f("dataBounds", _boundsData.getLeft(), _boundsData.getRight(), _boundsData.getBottom(), _boundsData.getTop());
 
             _shader.uniform1i("selectionDisplayMode", static_cast<std::int32_t>(_selectionDisplayMode));
             _shader.uniform1f("selectionOutlineScale", _selectionOutlineScale);

--- a/ManiVault/src/renderers/PointRenderer.h
+++ b/ManiVault/src/renderers/PointRenderer.h
@@ -128,8 +128,23 @@ namespace mv
 
             void setColormap(const QImage& image);
 
+            // Returns getBoundsView()
             Bounds getBounds() const;
+
+            // Retuns _boundsView
+            Bounds getBoundsView() const;
+
+            // Returns _boundsData
+            Bounds getBoundsData() const;
+
+            // Calls both setBoundsView() and setBoundsData()
             void setBounds(const Bounds& bounds);
+
+            // sets _boundsView, used for computing the projection matrix _orthoM
+            void setBoundsView(const Bounds& boundsView);
+
+            // sets _boundsData, used for scaling the 2d _colormap
+            void setBoundsData(const Bounds& boundsData);
 
             Matrix3f getProjectionMatrix() const;
 
@@ -183,12 +198,13 @@ namespace mv
             ShaderProgram               _shader;
 
             PointArrayObject            _gpuPoints;
-            Texture2D                   _colormap;
+            Texture2D                   _colormap;                                                          /** 2D colormap, sets point color based on point position */
 
-            Matrix3f                    _orthoM                             = {};       /** Projection matrix from bounds space to clip space */
-            Bounds                      _bounds                             = Bounds(-1, 1, -1, 1);
+            Matrix3f                    _orthoM                             = {};                           /** Projection matrix from bounds space to clip space */
+            Bounds                      _boundsView                         = Bounds(-1, 1, -1, 1);         /** Used for computing the projection matrix _orthoM */
+            Bounds                      _boundsData                         = Bounds(-1, 1, -1, 1);         /** Used for scaling the 2d _colormap */
 
-            std::int32_t                _numSelectedPoints                  = 0;     /** Number of selected (highlighted points) */
+            std::int32_t                _numSelectedPoints                  = 0;                            /** Number of selected (highlighted points) */
         };
 
     } // namespace gui

--- a/ManiVault/src/renderers/PointRenderer.h
+++ b/ManiVault/src/renderers/PointRenderer.h
@@ -128,23 +128,23 @@ namespace mv
 
             void setColormap(const QImage& image);
 
-            // Returns getBoundsView()
+            // Returns getViewBounds()
             Bounds getBounds() const;
 
             // Retuns _boundsView
-            Bounds getBoundsView() const;
+            Bounds getViewBounds() const;
 
             // Returns _boundsData
-            Bounds getBoundsData() const;
+            Bounds getDataBounds() const;
 
-            // Calls both setBoundsView() and setBoundsData()
+            // Calls both setViewBounds() and setDataBounds()
             void setBounds(const Bounds& bounds);
 
             // sets _boundsView, used for computing the projection matrix _orthoM
-            void setBoundsView(const Bounds& boundsView);
+            void setViewBounds(const Bounds& boundsView);
 
             // sets _boundsData, used for scaling the 2d _colormap
-            void setBoundsData(const Bounds& boundsData);
+            void setDataBounds(const Bounds& boundsData);
 
             Matrix3f getProjectionMatrix() const;
 


### PR DESCRIPTION
Adds the option to distinguish between view bounds (used for projection matrix) and data bounds (used for 2D colormapping).

This is useful since we want the 2D colormap to fit the data bounds tightly whereas the view should extend a bit further than the data (adding some white space all around).

Currently, 2D colormaps in the ImageViewer and Scatterplot assign different colors to the same data values. This PR helps solve that issue.

All plugins that use the existing API will behave the same as before, as the existing method `PointRenderer::setBounds` now will automatically set both view and data bounds. 