### PR TITLE
Add optional density weighting

### DIFF
--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -198,6 +198,7 @@ target_sources(${MV_PUBLIC_LIB}
     PRIVATE
     src/.editorconfig
     ${PUBLIC_SOURCES}
+    ${SHADERS}
 )
 
 target_include_directories(${MV_PUBLIC_LIB} PUBLIC

--- a/ManiVault/cmake/CMakeMvSourcesResources.cmake
+++ b/ManiVault/cmake/CMakeMvSourcesResources.cmake
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
-# Resource files MV_EXE
+# Resource files
 # -----------------------------------------------------------------------------
-# defines RESOURCE_FILES, MAIN_APP_ICON_RESOURCE and MAIN_STYLES
+# defines RESOURCE_FILES, MAIN_APP_ICON_RESOURCE, SHADERS and MAIN_STYLES
 
 set(QRESOURCES
     res/ResourcesCore.qrc
@@ -21,6 +21,23 @@ set(MAIN_STYLES
     res/styles/default.qss
 )
 
+set(SHADERS
+    res/shaders/Color.frag
+    res/shaders/DensityCompute.frag
+    res/shaders/DensityCompute.vert
+    res/shaders/DensityDraw.frag
+    res/shaders/GradientCompute.frag
+    res/shaders/GradientDraw.frag
+    res/shaders/IsoDensityDraw.frag
+    res/shaders/MeanshiftCompute.frag
+    res/shaders/PointPlot.frag
+    res/shaders/PointPlot.vert
+    res/shaders/Quad.vert
+    res/shaders/SelectionBox.vert
+    res/shaders/Texture.frag
+)
+
 qt_add_resources(RESOURCE_FILES ${QRESOURCES})
 
 source_group(Resources FILES ${QRESOURCES} ${MAIN_STYLES})
+source_group(Resources\\Shaders FILES ${SHADERS})

--- a/ManiVault/res/shaders/DensityCompute.frag
+++ b/ManiVault/res/shaders/DensityCompute.frag
@@ -7,9 +7,12 @@
 uniform sampler2D gaussSampler;
 
 in vec2 pass_texCoord;
+flat in float pass_weight;
 
 out float value;
 
 void main() {
-    value = texture(gaussSampler, pass_texCoord).r;
+    float density = texture(gaussSampler, pass_texCoord).r;
+
+    value = density * pass_weight;
 }

--- a/ManiVault/res/shaders/DensityCompute.vert
+++ b/ManiVault/res/shaders/DensityCompute.vert
@@ -5,17 +5,25 @@
 #version 330 core
 
 uniform float sigma;
-
 uniform mat3 projMatrix;
+uniform bool hasWeight;
 
 layout(location = 0) in vec2 vertex;
 layout(location = 1) in vec2 texCoord;
 layout(location = 2) in vec2 position;
+layout(location = 3) in float weight;
 
 out vec2 pass_texCoord;
+flat out float pass_weight;
 
 void main() {
     pass_texCoord = texCoord;
+
+    if(hasWeight)
+        pass_weight = weight;
+    else
+        pass_weight = 1;
+
     vec2 pos = (projMatrix * vec3(position, 1)).xy;
     gl_Position = vec4(vertex * sigma + pos, 0, 1);
 }

--- a/ManiVault/src/renderers/DensityRenderer.cpp
+++ b/ManiVault/src/renderers/DensityRenderer.cpp
@@ -34,6 +34,11 @@ namespace mv
             _densityComputation.setData(points);
         }
 
+        void DensityRenderer::setWeights(const std::vector<float>* weights)
+        {
+            _densityComputation.setWeights(weights);
+        }
+
         void DensityRenderer::setBounds(const Bounds& bounds)
         {
             _densityComputation.setBounds(bounds.getLeft(), bounds.getRight(), bounds.getBottom(), bounds.getTop());

--- a/ManiVault/src/renderers/DensityRenderer.h
+++ b/ManiVault/src/renderers/DensityRenderer.h
@@ -34,6 +34,7 @@ namespace mv
 
             void setRenderMode(RenderMode renderMode);
             void setData(const std::vector<Vector2f>* data);
+            void setWeights(const std::vector<float>* weights);
             void setBounds(const Bounds& bounds);
             void setSigma(const float sigma);
             void computeDensity();

--- a/ManiVault/src/renderers/PointRenderer.cpp
+++ b/ManiVault/src/renderers/PointRenderer.cpp
@@ -333,6 +333,21 @@ namespace mv
             return _orthoM;
         }
 
+        const PointArrayObject& PointRenderer::getGpuPoints() const
+        {
+            return _gpuPoints;
+        }
+
+        QSize PointRenderer::getWindowsSize() const
+        {
+            return _windowSize;
+        }
+
+        std::int32_t PointRenderer::getNumSelectedPoints() const
+        {
+            return _numSelectedPoints;
+        }
+
         void PointRenderer::setPointSize(const float size)
         {
             _pointSettings._pointSize = size;

--- a/ManiVault/src/renderers/PointRenderer.h
+++ b/ManiVault/src/renderers/PointRenderer.h
@@ -41,7 +41,7 @@ namespace mv
             BufferObject _opacityScalarBuffer;
             BufferObject _colorBuffer;
 
-            PointArrayObject() : _handle(0), _colorScalarsRange(0, 1, 1) {}
+            PointArrayObject() : QOpenGLFunctions_3_3_Core(), _handle(0), _colorScalarsRange(0, 1, 1) {}
             void init();
             void setPositions(const std::vector<Vector2f>& positions);
             void setHighlights(const std::vector<char>& highlights);
@@ -49,6 +49,13 @@ namespace mv
             void setSizeScalars(const std::vector<float>& scalars);
             void setOpacityScalars(const std::vector<float>& scalars);
             void setColors(const std::vector<Vector3f>& colors);
+
+            const std::vector<Vector2f>& getPositions() const { return _positions; }
+            const std::vector<char>& getHighlights() const { return _highlights; }
+            const std::vector<float>& getScalars() const { return _colorScalars; }
+            const std::vector<float>& getSizeScalars() const { return _sizeScalars; }
+            const std::vector<float>& getOpacityScalars() const { return _opacityScalars; }
+            const std::vector<Vector3f>& getColors() const { return _colors; }
 
             void enableAttribute(uint index, bool enable);
 
@@ -147,6 +154,10 @@ namespace mv
             void setDataBounds(const Bounds& boundsData);
 
             Matrix3f getProjectionMatrix() const;
+
+            const PointArrayObject& getGpuPoints() const;
+            QSize getWindowsSize() const;
+            std::int32_t getNumSelectedPoints() const;
 
             const PointSettings& getPointSettings() const;
             void setPointSize(const float size);

--- a/ManiVault/src/util/DensityComputation.h
+++ b/ManiVault/src/util/DensityComputation.h
@@ -38,22 +38,22 @@ public:
 
     Texture2D& getDensityTexture() { return _densityTexture; }
     float getMaxDensity() const { return _maxKDE; }
-    unsigned int getNumPoints() { return _numPoints; }
+    unsigned int getNumPoints() const { return _numPoints; }
 
     void compute();
 
 private:
-    bool hasData();
+    bool hasData() const;
     float calculateMaxKDE();
 
 private:
-    const unsigned int RESOLUTION = 128;
-    const float DEFAULT_SIGMA = 0.15f;
+    const unsigned int RESOLUTION       = 128;
+    const float DEFAULT_SIGMA           = 0.15f;
 
-    float _sigma = DEFAULT_SIGMA;
-    float _maxKDE = -1;
-    unsigned int _numPoints = 0;
-    Bounds _bounds = Bounds(-1, 1, 2, 2);
+    float _sigma                        = DEFAULT_SIGMA;
+    float _maxKDE                       = -1;
+    unsigned int _numPoints             = 0;
+    Bounds _bounds                      = Bounds(-1, 1, 2, 2);
 
     ShaderProgram _shaderDensityCompute;
     Framebuffer _densityBuffer;

--- a/ManiVault/src/util/DensityComputation.h
+++ b/ManiVault/src/util/DensityComputation.h
@@ -33,6 +33,7 @@ public:
 
     // Note: setData does not take the ownership of the vector specified by the argument.
     void setData(const std::vector<Vector2f>* data);
+    void setWeights(const std::vector<float>* weights);
     void setBounds(float left, float right, float bottom, float top);
     void setSigma(float sigma);
 
@@ -62,7 +63,9 @@ private:
 
     GLuint _vao;
     BufferObject _pointBuffer;
+    BufferObject _weightsBuffer;
     const std::vector<Vector2f>* _points;
+    const std::vector<float>* _weights;
 
     QOpenGLContext* _ctx;
     QOffscreenSurface _offscreenSurface;


### PR DESCRIPTION
This PR adds an option to weight points in the density renderer.

Given some 2D like this:
<p align="middle">
  <img src="https://github.com/ManiVaultStudio/core/assets/58806453/733f6502-4f74-40e9-ad7a-a64c9d6d7fc2" align="middle" width="50%" />
</p>

The standard behavior of the density renderer when introducing some point sizes looks the same:
<p align="middle">
  <img src="https://github.com/ManiVaultStudio/core/assets/58806453/3c9f6991-b4df-48b0-8920-b877af61cb4a" align="middle" width="50%" />
</p>

With this PR those size weights can be taken into account in the density renderer:
<p align="middle">
  <img src="https://github.com/ManiVaultStudio/core/assets/58806453/9c681bb4-8938-474b-9689-ca2947f917c5" align="middle" width="50%" />
</p>


Also, this PR adds the shader files in Visual Studio