### PR TITLE
Send both signals on web bridge ready and page fully loaded

### DIFF
--- a/ManiVault/src/widgets/WebWidget.cpp
+++ b/ManiVault/src/widgets/WebWidget.cpp
@@ -39,6 +39,8 @@ void WebWidget::init(WebCommunicationObject* communicationObject)
 {
     _webCommunicationObject = communicationObject;
     connect(_webCommunicationObject, &WebCommunicationObject::notifyJsBridgeIsAvailable, this, &WebWidget::onJsBridgeIsAvailable);
+    // DEPRECATED, to be removed in any release after 1.0
+    connect(_webCommunicationObject, &WebCommunicationObject::notifyJsBridgeIsAvailable, this, &WebWidget::initWebPage);
 
     _webView = new QWebEngineView();
     _webView->setAcceptDrops(false);

--- a/ManiVault/src/widgets/WebWidget.h
+++ b/ManiVault/src/widgets/WebWidget.h
@@ -55,22 +55,30 @@ public:
     QWebEnginePage* getPage();
     void setPage(QString htmlPath, QString basePath);
 
+signals:
+    void communicationBridgeReady();
+    void webPageFullyLoaded();
+
 protected:
     void registerFunctions();
 
 public slots:
     void js_debug(QString text);
 
-protected slots:
-    virtual void initWebPage() = 0;
+private slots:
+    void onJsBridgeIsAvailable();
+    void onWebPageLoaded(bool ok);
 
 private:
     QWebEngineView* _webView;
     QWebChannel* _communicationChannel;
 
-    WebCommunicationObject* _js;
+    WebCommunicationObject* _webCommunicationObject;
 
     QString _css;
+
+    bool _communicationAvailable;
+    bool _webPageLoaded;
 };
 
 } // namespace gui

--- a/ManiVault/src/widgets/WebWidget.h
+++ b/ManiVault/src/widgets/WebWidget.h
@@ -65,6 +65,10 @@ protected:
 public slots:
     void js_debug(QString text);
 
+protected slots:
+    /** DEPRECATED, please connect to the communicationBridgeReady() signal instead. */
+    virtual void initWebPage() {}
+
 private slots:
     void onJsBridgeIsAvailable();
     void onWebPageLoaded(bool ok);


### PR DESCRIPTION
Right now initWebPage is a slot that is called when the bridge to JS is available. However, this doesn't necessarily mean that the whole web page is loaded. This causes trouble when one tries to call functions from later .js scripts upon the bridge being ready.

The solution implemented here gets rid of the initWebPage virtual slot. Instead a signal is emitted when the bridge is ready, as well as a signal when both the webpage is loaded AND the bridge is available. Users can choose which signal they want to connect to with their own slot function.