### PR TITLE
Fixes inapropriate widget action badge display

### DIFF
--- a/ManiVault/src/actions/WidgetActionBadgeOverlayWidget.h
+++ b/ManiVault/src/actions/WidgetActionBadgeOverlayWidget.h
@@ -9,6 +9,8 @@
 
 namespace mv::gui {
 
+class WidgetAction;
+
 /**
  * Widget action badge overlay widget class
  *

--- a/ManiVault/src/actions/WidgetActionViewWidget.h
+++ b/ManiVault/src/actions/WidgetActionViewWidget.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ManiVaultGlobals.h"
+#include "WidgetActionBadgeOverlayWidget.h"
 
 #include <QWidget>
 
@@ -12,7 +13,6 @@ namespace mv::gui {
 
 class WidgetAction;
 class WidgetActionHighlightWidget;
-class WidgetActionBadgeOverlayWidget;
 
 /**
  * Widget action view widget class
@@ -60,6 +60,20 @@ public:
      */
     std::int32_t getWidgetFlags() const;
 
+    /**
+     * Get whether the widget is in a popup state
+     * @return Boolean determining whether the widget is in a popup state
+     */
+    virtual bool isPopup() const final;
+
+private: // Badge
+
+    /** Show the widget action badge */
+    void enableBadge();
+    
+    /** Hide the widget action badge */
+    void disableBadge();
+
 protected: // Drag-and-drop events
 
     /**
@@ -81,11 +95,11 @@ protected: // Drag-and-drop events
     void dropEvent(QDropEvent* dropEvent) override;
 
 private:
-    WidgetAction*                       _action;                /** Pointer to action that will be displayed */
-    std::int32_t                        _widgetFlags;           /** Widget creation flags */
-    WidgetActionHighlightWidget*        _highlightWidget;       /** Pointer to highlight widget */
-    WidgetActionBadgeOverlayWidget*     _badgeOverlayWidget;    /** Pointer to badge overlay widget */
-    std::int32_t                        _cachedHighlighting;    /** Cached highlighting */
+    WidgetAction*                                   _action;                /** Pointer to action that will be displayed */
+    std::int32_t                                    _widgetFlags;           /** Widget creation flags */
+    WidgetActionHighlightWidget*                    _highlightWidget;       /** Pointer to highlight widget */
+    std::unique_ptr<WidgetActionBadgeOverlayWidget> _badgeOverlayWidget;    /** Pointer to badge overlay widget */
+    std::int32_t                                    _cachedHighlighting;    /** Cached highlighting */
 };
 
 }

--- a/ManiVault/src/actions/WidgetActionWidget.cpp
+++ b/ManiVault/src/actions/WidgetActionWidget.cpp
@@ -82,9 +82,4 @@ void WidgetActionWidget::setPopupLayout(QLayout* popupLayout)
     }
 }
 
-bool WidgetActionWidget::isPopup() const
-{
-    return getWidgetFlags() & PopupLayout;
-}
-
 }

--- a/ManiVault/src/actions/WidgetActionWidget.h
+++ b/ManiVault/src/actions/WidgetActionWidget.h
@@ -32,12 +32,6 @@ public:
     WidgetActionWidget(QWidget* parent, WidgetAction* action, std::int32_t widgetFlags = 0);
 
 public: // Popup widget related
-    
-    /**
-     * Get whether the widget is in a popup state
-     * @return Boolean determining whether the widget is in a popup state
-     */
-    virtual bool isPopup() const final;
 
     /**
      * Override the size hint to account for popups

--- a/ManiVault/src/util/WidgetOverlayer.cpp
+++ b/ManiVault/src/util/WidgetOverlayer.cpp
@@ -29,6 +29,8 @@ WidgetOverlayer::WidgetOverlayer(QObject* parent, QWidget* sourceWidget, QWidget
 
     _sourceWidget->installEventFilter(this);
     _targetWidget->installEventFilter(this);
+
+    _sourceWidget->resize(_targetWidget->size());
 }
 
 bool WidgetOverlayer::eventFilter(QObject* target, QEvent* event)


### PR DESCRIPTION
- [x] `WidgetActionBadgeOverlayWidget` is not displayed in the popup state anymore
- [x] `WidgetOverlayer` class now resizes the target widget immediately

Suggestions for review:
- Open some projects and establish if the GUI looks as expected (superficial check)
- Check if the unhide datasets action is working properly
- Check other actions that have the badge enabled