### PR TITLE
Fix density weights again

### DIFF
--- a/ManiVault/res/shaders/DensityCompute.vert
+++ b/ManiVault/res/shaders/DensityCompute.vert
@@ -19,10 +19,7 @@ flat out float pass_weight;
 void main() {
     pass_texCoord = texCoord;
 
-    if(hasWeight)
-        pass_weight = weight;
-    else
-        pass_weight = 1;
+    pass_weight = hasWeight ? weight : 1;
 
     vec2 pos = (projMatrix * vec3(position, 1)).xy;
     gl_Position = vec4(vertex * sigma + pos, 0, 1);

--- a/ManiVault/src/util/DensityComputation.cpp
+++ b/ManiVault/src/util/DensityComputation.cpp
@@ -126,6 +126,13 @@ void DensityComputation::init(QOpenGLContext* ctx)
     glVertexAttribDivisor(2, 1);
     glEnableVertexAttribArray(2);
 
+    // Weights of the points
+    _weightsBuffer.create();
+    _weightsBuffer.bind();
+    glVertexAttribPointer(3, 1, GL_FLOAT, GL_FALSE, 0, 0);
+    glVertexAttribDivisor(3, 1);
+    glEnableVertexAttribArray(3);
+
     // Load the density computation shader
     bool loaded = _shaderDensityCompute.loadShaderFromFile(":shaders/DensityCompute.vert", ":shaders/DensityCompute.frag");
     if (!loaded) {
@@ -149,6 +156,9 @@ void DensityComputation::init(QOpenGLContext* ctx)
     // Add the texture to the framebuffer and validate it
     _densityBuffer.addColorTexture(0, &_densityTexture);
     _densityBuffer.validate();
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
 
     _initialized = true;
 }
@@ -182,13 +192,6 @@ void DensityComputation::setData(const std::vector<Vector2f>* points)
 void DensityComputation::setWeights(const std::vector<float>* weights)
 {
     _weights = weights;
-
-    // Weights of the points
-    _weightsBuffer.create();
-    _weightsBuffer.bind();
-    glVertexAttribPointer(3, 1, GL_FLOAT, GL_FALSE, 0, 0);
-    glVertexAttribDivisor(3, 1);
-    glEnableVertexAttribArray(3);
 }
 
 void DensityComputation::setBounds(float left, float right, float bottom, float top)
@@ -218,17 +221,23 @@ void DensityComputation::compute()
     _ctx->makeCurrent(&_offscreenSurface);
 
     _numPoints = static_cast<std::uint32_t>(_points->size());
+    
+    glBindVertexArray(_vao);
 
     // Upload the points to the GPU
     _pointBuffer.bind();
     _pointBuffer.setData(*_points);
 
-    bool hasWeight = (_weights != nullptr) && (_weights->size() == _numPoints);
+    const bool hasWeight = (_weights != nullptr) && (_weights->size() == _numPoints);
+
+    // Upload the weigths to the GPU, if they are any
+    _weightsBuffer.bind();
+    glDisableVertexAttribArray(3);
+
     if (hasWeight)
     {
-        // Upload the weigths to the GPU
-        _weightsBuffer.bind();
         _weightsBuffer.setData(*_weights);
+        glEnableVertexAttribArray(3);
     }
 
     // Bind the off-screen framebuffer
@@ -256,11 +265,12 @@ void DensityComputation::compute()
     Matrix3f ortho = createProjectionMatrix(_bounds);
     _shaderDensityCompute.uniformMatrix3f("projMatrix", ortho);
 
-    _shaderDensityCompute.uniform1f("hasWeight", hasWeight);
+    _shaderDensityCompute.uniform1i("hasWeight", hasWeight);
 
     // Draw the splats
-    glBindVertexArray(_vao);
     glDrawArraysInstanced(GL_TRIANGLES, 0, 6, _numPoints);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindVertexArray(0);
 
     _maxKDE = calculateMaxKDE();

--- a/ManiVault/src/util/DensityComputation.cpp
+++ b/ManiVault/src/util/DensityComputation.cpp
@@ -72,7 +72,6 @@ void GaussianTexture::generate()
 DensityComputation::DensityComputation() :
     QOpenGLFunctions_3_3_Core(),
     _initialized(false),
-    _needsDensityMapUpdate(true),
     _ctx(nullptr),
     _points(nullptr),
     _weights(nullptr),
@@ -276,8 +275,6 @@ void DensityComputation::compute()
     _maxKDE = calculateMaxKDE();
 
     //qDebug() << "	Max KDE Value = " << _maxKDE << ".\n";
-
-    //_needsDensityMapUpdate = false;
 
     //qDebug() << "Done computing density";
 }

--- a/ManiVault/src/util/DensityComputation.cpp
+++ b/ManiVault/src/util/DensityComputation.cpp
@@ -8,6 +8,7 @@
 #include "graphics/Matrix3f.h"
 
 #include <cmath>
+#include <limits>
 
 namespace mv
 {
@@ -274,8 +275,7 @@ void DensityComputation::compute()
 
     _maxKDE = calculateMaxKDE();
 
-    //qDebug() << "	Max KDE Value = " << _maxKDE << ".\n";
-
+    //qDebug() << "Max KDE Value = " << _maxKDE << ".\n";
     //qDebug() << "Done computing density";
 }
 
@@ -293,8 +293,8 @@ float DensityComputation::calculateMaxKDE()
     glReadPixels(0, 0, RESOLUTION, RESOLUTION, GL_RGB, GL_FLOAT, kde.data());
 
     // Calculate max value for normalization
-    float maxKDE = -99999999.9f;
-    for (int i = 0; i < kde.size(); i += 3) // only lookup red channel
+    float maxKDE = std::numeric_limits<float>::lowest();
+    for (size_t i = 0; i < kde.size(); i += 3) // only lookup red channel
     {
         maxKDE = std::max(maxKDE, kde[i]);
     }

--- a/ManiVault/src/util/DensityComputation.h
+++ b/ManiVault/src/util/DensityComputation.h
@@ -71,7 +71,6 @@ private:
     QOffscreenSurface _offscreenSurface;
 
     bool _initialized;
-    bool _needsDensityMapUpdate;
 };
 
 } // namespace mv


### PR DESCRIPTION
The previous "fix" in https://github.com/ManiVaultStudio/core/pull/599 prevented a crash in the MeanShift plugin but inadvertently rendered the density weighting broken.

Now, ti should be sufficiently robust.