### PR TITLE
Add randomized point depth option to point renderer

### DIFF
--- a/ManiVault/res/shaders/PointPlot.vert
+++ b/ManiVault/res/shaders/PointPlot.vert
@@ -12,25 +12,27 @@
 #define EFFECT_COLOR_2D 4
 
 // Point properties
-uniform float pointSize;        				/** Point size */
-uniform float pointSizeScale;   				/** Scale factor in absolute point size mode */
-uniform int   scalarEffect;
-uniform float pointOpacity;     				/** Point opacity */
-uniform mat3 orthoM;            				/** Projection matrix from bounds space to clip space */
-uniform bool hasHighlights;     				/** Whether a highlight buffer is used */
-uniform bool hasScalars;        				/** Whether a scalar buffer is used */
-uniform vec3 colorMapRange;     				/** Color map scalar range */
-uniform bool hasColors;         				/** Whether a color buffer is used */
-uniform bool hasSizes;          				/** Whether a point size buffer is used */
-uniform bool hasOpacities;      				/** Whether an opacity buffer is used */
+uniform float 	pointSize;        		/** Point size */
+uniform float 	pointSizeScale;   		/** Scale factor in absolute point size mode */
+uniform int   	scalarEffect;
+uniform float 	pointOpacity;     		/** Point opacity */
+uniform mat3 	orthoM;            		/** Projection matrix from bounds space to clip space */
+uniform bool 	hasHighlights;     		/** Whether a highlight buffer is used */
+uniform bool 	hasScalars;        		/** Whether a scalar buffer is used */
+uniform vec3 	colorMapRange;     		/** Color map scalar range */
+uniform bool 	hasColors;         		/** Whether a color buffer is used */
+uniform bool 	hasSizes;          		/** Whether a point size buffer is used */
+uniform bool 	hasOpacities;			/** Whether an opacity buffer is used */
 
 // Selection visualization
-uniform int	selectionDisplayMode;				/** Type of selection display (e.g. outline, override) */
-uniform float selectionOutlineScale;     		/** Selection outline scale */
-uniform float selectionOutlineOpacity;     		/** Selection outline opacity */
-uniform vec3  selectionOutlineColor;			/** Selection outline color */
-uniform bool selectionHaloEnabled; 				/** Whether selection halo is enabled */
-uniform float selectionHaloScale;     			/** Selection halo scale */
+uniform int	selectionDisplayMode;		/** Type of selection display (e.g. outline, override) */
+uniform float 	selectionOutlineScale;     	/** Selection outline scale */
+uniform float 	selectionOutlineOpacity;     	/** Selection outline opacity */
+uniform vec3  	selectionOutlineColor;		/** Selection outline color */
+uniform bool 	selectionHaloEnabled; 		/** Whether selection halo is enabled */
+uniform float 	selectionHaloScale;		/** Selection halo scale */
+
+uniform bool 	randomizedDepthEnabled;		/** Whether to randomize the z-order */
 
 layout(location = 0) in vec2    vertex;         /** Vertex input, always a [-1, 1] quad */
 layout(location = 1) in vec2    position;       /** 2-Dimensional positions of points */
@@ -47,6 +49,57 @@ smooth out float vScalar;
 smooth out vec3  vColor;
 smooth out float vOpacity;
 smooth out vec2  vPosOrig;
+
+/*
+float rand(vec2 co){
+    return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
+}
+*/
+
+uniform float time;
+out vec4 fragment;
+
+
+
+// A single iteration of Bob Jenkins' One-At-A-Time hashing algorithm.
+uint hash( uint x ) {
+    x += ( x << 10u );
+    x ^= ( x >>  6u );
+    x += ( x <<  3u );
+    x ^= ( x >> 11u );
+    x += ( x << 15u );
+    return x;
+}
+
+
+
+// Compound versions of the hashing algorithm I whipped together.
+uint hash( uvec2 v ) { return hash( v.x ^ hash(v.y)                         ); }
+uint hash( uvec3 v ) { return hash( v.x ^ hash(v.y) ^ hash(v.z)             ); }
+uint hash( uvec4 v ) { return hash( v.x ^ hash(v.y) ^ hash(v.z) ^ hash(v.w) ); }
+
+
+
+// Construct a float with half-open range [0:1] using low 23 bits.
+// All zeroes yields 0.0, all ones yields the next smallest representable value below 1.0.
+float floatConstruct( uint m ) {
+    const uint ieeeMantissa = 0x007FFFFFu; // binary32 mantissa bitmask
+    const uint ieeeOne      = 0x3F800000u; // 1.0 in IEEE binary32
+
+    m &= ieeeMantissa;                     // Keep only mantissa bits (fractional part)
+    m |= ieeeOne;                          // Add fractional part to 1.0
+
+    float  f = uintBitsToFloat( m );       // Range [1:2]
+    return f - 1.0;                        // Range [0:1]
+}
+
+
+
+// Pseudo-random value in half-open range [0:1].
+float random( float x ) { return floatConstruct(hash(floatBitsToUint(x))); }
+float random( vec2  v ) { return floatConstruct(hash(floatBitsToUint(v))); }
+float random( vec3  v ) { return floatConstruct(hash(floatBitsToUint(v))); }
+float random( vec4  v ) { return floatConstruct(hash(floatBitsToUint(v))); }
 
 void main()
 {
@@ -77,5 +130,5 @@ void main()
         scaledVertex = vertex * size * pointSizeScale * ((selectionDisplayMode == 0) ? selectionOutlineScale : 1);
     
     // Move quad by position and output
-    gl_Position = vec4(scaledVertex + pos, 0, 1);
+    gl_Position = vec4(scaledVertex + pos, randomizedDepthEnabled ? random(pos) : 0, 1);
 }

--- a/ManiVault/src/renderers/PointRenderer.cpp
+++ b/ManiVault/src/renderers/PointRenderer.cpp
@@ -425,9 +425,19 @@ namespace mv
             return _selectionHaloEnabled;
         }
 
-        void PointRenderer::setSelectionHaloEnabled(float selectionHaloEnabled)
+        void PointRenderer::setSelectionHaloEnabled(bool selectionHaloEnabled)
         {
             _selectionHaloEnabled = selectionHaloEnabled;
+        }
+
+        bool PointRenderer::getRandomizedDepthEnabled() const
+        {
+            return _randomizedDepthEnabled;
+        }
+
+        void PointRenderer::setRandomizedDepthEnabled(bool randomizedDepth)
+        {
+            _randomizedDepthEnabled = randomizedDepth;
         }
 
         void PointRenderer::init()
@@ -482,6 +492,8 @@ namespace mv
             _shader.uniform1i("selectionOutlineOverrideColor", _selectionOutlineOverrideColor);
             _shader.uniform1f("selectionOutlineOpacity", _selectionOutlineOpacity);
             _shader.uniform1i("selectionHaloEnabled", _selectionHaloEnabled);
+
+            _shader.uniform1i("randomizedDepthEnabled", _randomizedDepthEnabled);
 
             _shader.uniform1i("hasHighlights", _gpuPoints.hasHighlights());
             _shader.uniform1i("hasScalars", _gpuPoints.hasColorScalars());

--- a/ManiVault/src/renderers/PointRenderer.h
+++ b/ManiVault/src/renderers/PointRenderer.h
@@ -180,7 +180,10 @@ namespace mv
             void setSelectionOutlineOpacity(float selectionOutlineOpacity);
 
             bool getSelectionHaloEnabled() const;
-            void setSelectionHaloEnabled(float selectionHaloEnabled);
+            void setSelectionHaloEnabled(bool selectionHaloEnabled);
+
+            bool getRandomizedDepthEnabled() const;
+            void setRandomizedDepthEnabled(bool randomizedDepth);
 
             void init() override;
             void resize(QSize renderSize) override;
@@ -201,6 +204,9 @@ namespace mv
             float                       _selectionOutlineScale              = 1.75f;
             float                       _selectionOutlineOpacity            = 0.5f;
             bool                        _selectionHaloEnabled               = false;
+
+            /* Depth control */
+            bool                        _randomizedDepthEnabled             = true;
 
             /* Window properties */
             QSize                       _windowSize;


### PR DESCRIPTION
- [x] Adds the option to randomize the z-order of points
- [x] Toggled in the scatter plot settings  popup

Works in concert with [this](https://github.com/ManiVaultStudio/Scatterplot/tree/feature/point_renderer_randomized_z_ordering) scatterplot branch