### PR TITLE
Feature/add project icon

### DIFF
--- a/ManiVault/cmake/CMakeMvSourcesPublic.cmake
+++ b/ManiVault/cmake/CMakeMvSourcesPublic.cmake
@@ -339,6 +339,7 @@ set(PUBLIC_ACTIONS_INTERNAL_HEADERS
     src/actions/WidgetActionToolButtonMenu.h
     src/actions/IconAction.h
     src/actions/IconPickerAction.h
+    src/actions/ApplicationIconPickerAction.h
 )
 
 set(PUBLIC_ACTIONS_INTERNAL_SOURCES
@@ -368,6 +369,7 @@ set(PUBLIC_ACTIONS_INTERNAL_SOURCES
     src/actions/WidgetActionToolButtonMenu.cpp
     src/actions/IconAction.cpp
     src/actions/IconPickerAction.cpp
+    src/actions/ApplicationIconPickerAction.cpp
 )
 
 set(PUBLIC_ACTIONS_INTERNAL_FILES

--- a/ManiVault/cmake/CMakeMvSourcesPublic.cmake
+++ b/ManiVault/cmake/CMakeMvSourcesPublic.cmake
@@ -339,7 +339,7 @@ set(PUBLIC_ACTIONS_INTERNAL_HEADERS
     src/actions/WidgetActionToolButtonMenu.h
     src/actions/IconAction.h
     src/actions/IconPickerAction.h
-    src/actions/ApplicationIconPickerAction.h
+    src/actions/ApplicationIconAction.h
 )
 
 set(PUBLIC_ACTIONS_INTERNAL_SOURCES
@@ -369,7 +369,7 @@ set(PUBLIC_ACTIONS_INTERNAL_SOURCES
     src/actions/WidgetActionToolButtonMenu.cpp
     src/actions/IconAction.cpp
     src/actions/IconPickerAction.cpp
-    src/actions/ApplicationIconPickerAction.cpp
+    src/actions/ApplicationIconAction.cpp
 )
 
 set(PUBLIC_ACTIONS_INTERNAL_FILES

--- a/ManiVault/cmake/CMakeMvSourcesPublic.cmake
+++ b/ManiVault/cmake/CMakeMvSourcesPublic.cmake
@@ -337,6 +337,7 @@ set(PUBLIC_ACTIONS_INTERNAL_HEADERS
     src/actions/WidgetActionBadgeOverlayWidget.h
     src/actions/WidgetActionToolButton.h
     src/actions/WidgetActionToolButtonMenu.h
+    src/actions/IconAction.h
 )
 
 set(PUBLIC_ACTIONS_INTERNAL_SOURCES
@@ -364,6 +365,7 @@ set(PUBLIC_ACTIONS_INTERNAL_SOURCES
     src/actions/WidgetActionBadgeOverlayWidget.cpp
     src/actions/WidgetActionToolButton.cpp
     src/actions/WidgetActionToolButtonMenu.cpp
+    src/actions/IconAction.cpp
 )
 
 set(PUBLIC_ACTIONS_INTERNAL_FILES

--- a/ManiVault/cmake/CMakeMvSourcesPublic.cmake
+++ b/ManiVault/cmake/CMakeMvSourcesPublic.cmake
@@ -338,6 +338,7 @@ set(PUBLIC_ACTIONS_INTERNAL_HEADERS
     src/actions/WidgetActionToolButton.h
     src/actions/WidgetActionToolButtonMenu.h
     src/actions/IconAction.h
+    src/actions/IconPickerAction.h
 )
 
 set(PUBLIC_ACTIONS_INTERNAL_SOURCES
@@ -366,6 +367,7 @@ set(PUBLIC_ACTIONS_INTERNAL_SOURCES
     src/actions/WidgetActionToolButton.cpp
     src/actions/WidgetActionToolButtonMenu.cpp
     src/actions/IconAction.cpp
+    src/actions/IconPickerAction.cpp
 )
 
 set(PUBLIC_ACTIONS_INTERNAL_FILES

--- a/ManiVault/src/Main.cpp
+++ b/ManiVault/src/Main.cpp
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
             else {
                 splashScreenAction.addAlert(SplashScreenAction::Alert::warning(QString("\
                     Unable to load <b>%1</b> at startup, the file does not exist. \
-                    Provide an exisiting project file path when using <b>-p</b>/<b>--project</b> ManiVault<sup>&copy;</sup> command line parameters. \
+                    Provide an existing project file path when using <b>-p</b>/<b>--project</b> ManiVault<sup>&copy;</sup> command line parameters. \
                 ").arg(startupProjectFilePath)));
 
                 throw std::runtime_error("Project file not found");
@@ -211,16 +211,10 @@ int main(int argc, char *argv[])
     application.setStyleSheet(styleSheet);
     loadGuiTask.setSubtaskFinished("Apply styles");
 
-    QIcon appIcon;
-
-    appIcon.addFile(":/Icons/AppIcon32");
-    appIcon.addFile(":/Icons/AppIcon64");
-    appIcon.addFile(":/Icons/AppIcon128");
-    appIcon.addFile(":/Icons/AppIcon256");
-    appIcon.addFile(":/Icons/AppIcon512");
-    appIcon.addFile(":/Icons/AppIcon1024");
-
-    application.setWindowIcon(appIcon);
+    if (projects().hasProject() && projects().getCurrentProject()->getReadOnlyAction().isChecked())
+        projects().getCurrentProject()->getApplicationIconAction().overrideMainWindowIcon();
+    else
+        application.setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
 
     MainWindow mainWindow;
 

--- a/ManiVault/src/Main.cpp
+++ b/ManiVault/src/Main.cpp
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
 
     Application application(argc, argv);
 
-    application.setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
+    Application::setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
 
     Core core;
 
@@ -156,7 +156,7 @@ int main(int argc, char *argv[])
 
                     application.setStartupProjectMetaAction(projectMetaAction);
 
-                    if (projectMetaAction->getApplicationIconAction().getOverrideAction().isChecked())
+                    if (projectMetaAction->getReadOnlyAction().isChecked() && projectMetaAction->getApplicationIconAction().getOverrideAction().isChecked())
                         application.setWindowIcon(projectMetaAction->getApplicationIconAction().getIconPickerAction().getIcon());
                 }
                 else {

--- a/ManiVault/src/Main.cpp
+++ b/ManiVault/src/Main.cpp
@@ -120,6 +120,8 @@ int main(int argc, char *argv[])
 
     Application application(argc, argv);
 
+    application.setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
+
     Core core;
 
     application.setCore(&core);
@@ -153,6 +155,9 @@ int main(int argc, char *argv[])
                     splashScreenAction.fromVariantMap(projectMetaAction->getSplashScreenAction().toVariantMap());
 
                     application.setStartupProjectMetaAction(projectMetaAction);
+
+                    if (projectMetaAction->getApplicationIconAction().getOverrideAction().isChecked())
+                        application.setWindowIcon(projectMetaAction->getApplicationIconAction().getIconPickerAction().getIcon());
                 }
                 else {
                     splashScreenAction.addAlert(SplashScreenAction::Alert::info(QString("\
@@ -210,11 +215,6 @@ int main(int argc, char *argv[])
 
     application.setStyleSheet(styleSheet);
     loadGuiTask.setSubtaskFinished("Apply styles");
-
-    if (projects().hasProject() && projects().getCurrentProject()->getReadOnlyAction().isChecked())
-        projects().getCurrentProject()->getApplicationIconAction().overrideMainWindowIcon();
-    else
-        application.setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
 
     MainWindow mainWindow;
 

--- a/ManiVault/src/Project.cpp
+++ b/ManiVault/src/Project.cpp
@@ -9,8 +9,6 @@
 
 #include "util/Serialization.h"
 
-#include <stdlib.h>
-
 using namespace mv::gui;
 using namespace mv::util;
 

--- a/ManiVault/src/Project.cpp
+++ b/ManiVault/src/Project.cpp
@@ -98,6 +98,7 @@ void Project::fromVariantMap(const QVariantMap& variantMap)
     _projectMetaAction.getCompressionAction().fromParentVariantMap(variantMap);
     _projectMetaAction.getSplashScreenAction().fromParentVariantMap(variantMap);
     _projectMetaAction.getStudioModeAction().fromParentVariantMap(variantMap);
+    _projectMetaAction.getApplicationIconAction().fromParentVariantMap(variantMap);
 
     dataHierarchy().fromParentVariantMap(variantMap);
     actions().fromParentVariantMap(variantMap);
@@ -121,6 +122,7 @@ QVariantMap Project::toVariantMap() const
     _projectMetaAction.getCompressionAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getSplashScreenAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getStudioModeAction().insertIntoVariantMap(variantMap);
+    _projectMetaAction.getApplicationIconAction().insertIntoVariantMap(variantMap);
 
     plugins().insertIntoVariantMap(variantMap);
     dataHierarchy().insertIntoVariantMap(variantMap);

--- a/ManiVault/src/Project.h
+++ b/ManiVault/src/Project.h
@@ -129,6 +129,7 @@ public: // Project meta action getters facade
     const ProjectCompressionAction& getCompressionAction() const { return _projectMetaAction.getCompressionAction(); }
     const gui::SplashScreenAction& getSplashScreenAction() const { return _projectMetaAction.getSplashScreenAction(); }
     const gui::ToggleAction& getStudioModeAction() const { return _projectMetaAction.getStudioModeAction(); }
+    const gui::ApplicationIconPickerAction& getIconAction() const { return _projectMetaAction.getIconAction(); }
 
     gui::VersionAction& getApplicationVersionAction() { return _projectMetaAction.getApplicationVersionAction(); }
     gui::VersionAction& getProjectVersionAction() { return _projectMetaAction.getProjectVersionAction(); }
@@ -141,6 +142,7 @@ public: // Project meta action getters facade
     ProjectCompressionAction& getCompressionAction() { return _projectMetaAction.getCompressionAction(); }
     gui::SplashScreenAction& getSplashScreenAction() { return _projectMetaAction.getSplashScreenAction(); }
     gui::ToggleAction& getStudioModeAction() { return _projectMetaAction.getStudioModeAction(); }
+    gui::ApplicationIconPickerAction& getIconAction() { return _projectMetaAction.getIconAction(); }
 
 signals:
 

--- a/ManiVault/src/Project.h
+++ b/ManiVault/src/Project.h
@@ -10,12 +10,8 @@
 
 #include "actions/StringAction.h"
 #include "actions/StringsAction.h"
-#include "actions/IntegralAction.h"
 #include "actions/VersionAction.h"
 
-#include "ModalTask.h"
-
-#include "Application.h"
 #include "ProjectMetaAction.h"
 
 #include <QSharedPointer>
@@ -129,7 +125,7 @@ public: // Project meta action getters facade
     const ProjectCompressionAction& getCompressionAction() const { return _projectMetaAction.getCompressionAction(); }
     const gui::SplashScreenAction& getSplashScreenAction() const { return _projectMetaAction.getSplashScreenAction(); }
     const gui::ToggleAction& getStudioModeAction() const { return _projectMetaAction.getStudioModeAction(); }
-    const gui::ApplicationIconPickerAction& getApplicationIconAction() const { return _projectMetaAction.getApplicationIconAction(); }
+    const gui::ApplicationIconAction& getApplicationIconAction() const { return _projectMetaAction.getApplicationIconAction(); }
 
     gui::VersionAction& getApplicationVersionAction() { return _projectMetaAction.getApplicationVersionAction(); }
     gui::VersionAction& getProjectVersionAction() { return _projectMetaAction.getProjectVersionAction(); }
@@ -142,7 +138,7 @@ public: // Project meta action getters facade
     ProjectCompressionAction& getCompressionAction() { return _projectMetaAction.getCompressionAction(); }
     gui::SplashScreenAction& getSplashScreenAction() { return _projectMetaAction.getSplashScreenAction(); }
     gui::ToggleAction& getStudioModeAction() { return _projectMetaAction.getStudioModeAction(); }
-    gui::ApplicationIconPickerAction& getApplicationIconAction() { return _projectMetaAction.getApplicationIconAction(); }
+    gui::ApplicationIconAction& getApplicationIconAction() { return _projectMetaAction.getApplicationIconAction(); }
 
 signals:
 

--- a/ManiVault/src/Project.h
+++ b/ManiVault/src/Project.h
@@ -129,7 +129,7 @@ public: // Project meta action getters facade
     const ProjectCompressionAction& getCompressionAction() const { return _projectMetaAction.getCompressionAction(); }
     const gui::SplashScreenAction& getSplashScreenAction() const { return _projectMetaAction.getSplashScreenAction(); }
     const gui::ToggleAction& getStudioModeAction() const { return _projectMetaAction.getStudioModeAction(); }
-    const gui::ApplicationIconPickerAction& getIconAction() const { return _projectMetaAction.getIconAction(); }
+    const gui::ApplicationIconPickerAction& getApplicationIconAction() const { return _projectMetaAction.getApplicationIconAction(); }
 
     gui::VersionAction& getApplicationVersionAction() { return _projectMetaAction.getApplicationVersionAction(); }
     gui::VersionAction& getProjectVersionAction() { return _projectMetaAction.getProjectVersionAction(); }
@@ -142,7 +142,7 @@ public: // Project meta action getters facade
     ProjectCompressionAction& getCompressionAction() { return _projectMetaAction.getCompressionAction(); }
     gui::SplashScreenAction& getSplashScreenAction() { return _projectMetaAction.getSplashScreenAction(); }
     gui::ToggleAction& getStudioModeAction() { return _projectMetaAction.getStudioModeAction(); }
-    gui::ApplicationIconPickerAction& getIconAction() { return _projectMetaAction.getIconAction(); }
+    gui::ApplicationIconPickerAction& getApplicationIconAction() { return _projectMetaAction.getApplicationIconAction(); }
 
 signals:
 

--- a/ManiVault/src/ProjectMetaAction.cpp
+++ b/ManiVault/src/ProjectMetaAction.cpp
@@ -25,6 +25,7 @@ ProjectMetaAction::ProjectMetaAction(Project* project, QObject* parent /*= nullp
     _contributorsAction(this, "Contributors"),
     _splashScreenAction(this, true),
     _studioModeAction(this, "Studio Mode"),
+    _iconAction(this, "Icon"),
     _compressionAction(this)
 {
     _splashScreenAction.setProjectMetaAction(this);
@@ -76,6 +77,7 @@ void ProjectMetaAction::fromVariantMap(const QVariantMap& variantMap)
     _contributorsAction.fromParentVariantMap(variantMap);
     _splashScreenAction.fromParentVariantMap(variantMap);
     _studioModeAction.fromParentVariantMap(variantMap);
+    _iconAction.fromParentVariantMap(variantMap);
     _compressionAction.fromParentVariantMap(variantMap);
 }
 
@@ -92,6 +94,7 @@ QVariantMap ProjectMetaAction::toVariantMap() const
     _contributorsAction.insertIntoVariantMap(variantMap);
     _splashScreenAction.insertIntoVariantMap(variantMap);
     _studioModeAction.insertIntoVariantMap(variantMap);
+    _iconAction.insertIntoVariantMap(variantMap);
     _compressionAction.insertIntoVariantMap(variantMap);
 
     return variantMap;

--- a/ManiVault/src/ProjectMetaAction.cpp
+++ b/ManiVault/src/ProjectMetaAction.cpp
@@ -25,7 +25,7 @@ ProjectMetaAction::ProjectMetaAction(Project* project, QObject* parent /*= nullp
     _contributorsAction(this, "Contributors"),
     _splashScreenAction(this, true),
     _studioModeAction(this, "Studio Mode"),
-    _iconAction(this, "Icon"),
+    _applicationIconAction(this, "Application icon"),
     _compressionAction(this)
 {
     _splashScreenAction.setProjectMetaAction(this);
@@ -77,7 +77,7 @@ void ProjectMetaAction::fromVariantMap(const QVariantMap& variantMap)
     _contributorsAction.fromParentVariantMap(variantMap);
     _splashScreenAction.fromParentVariantMap(variantMap);
     _studioModeAction.fromParentVariantMap(variantMap);
-    _iconAction.fromParentVariantMap(variantMap);
+    _applicationIconAction.fromParentVariantMap(variantMap);
     _compressionAction.fromParentVariantMap(variantMap);
 }
 
@@ -94,7 +94,7 @@ QVariantMap ProjectMetaAction::toVariantMap() const
     _contributorsAction.insertIntoVariantMap(variantMap);
     _splashScreenAction.insertIntoVariantMap(variantMap);
     _studioModeAction.insertIntoVariantMap(variantMap);
-    _iconAction.insertIntoVariantMap(variantMap);
+    _applicationIconAction.insertIntoVariantMap(variantMap);
     _compressionAction.insertIntoVariantMap(variantMap);
 
     return variantMap;
@@ -124,6 +124,8 @@ void ProjectMetaAction::initialize()
     _contributorsAction.setEnabled(false);
     _contributorsAction.setStretch(1);
     _contributorsAction.setDefaultWidgetFlags(StringsAction::ListView);
+
+    _applicationIconAction.setToolTip("Application icon settings");
 }
 
 Project* ProjectMetaAction::getProject()

--- a/ManiVault/src/ProjectMetaAction.cpp
+++ b/ManiVault/src/ProjectMetaAction.cpp
@@ -70,6 +70,7 @@ void ProjectMetaAction::fromVariantMap(const QVariantMap& variantMap)
 
     _applicationVersionAction.fromParentVariantMap(variantMap);
     _projectVersionAction.fromParentVariantMap(variantMap);
+    _readOnlyAction.fromParentVariantMap(variantMap);
     _titleAction.fromParentVariantMap(variantMap);
     _descriptionAction.fromParentVariantMap(variantMap);
     _tagsAction.fromParentVariantMap(variantMap);
@@ -87,6 +88,7 @@ QVariantMap ProjectMetaAction::toVariantMap() const
 
     _applicationVersionAction.insertIntoVariantMap(variantMap);
     _projectVersionAction.insertIntoVariantMap(variantMap);
+    _readOnlyAction.insertIntoVariantMap(variantMap);
     _titleAction.insertIntoVariantMap(variantMap);
     _descriptionAction.insertIntoVariantMap(variantMap);
     _tagsAction.insertIntoVariantMap(variantMap);

--- a/ManiVault/src/ProjectMetaAction.h
+++ b/ManiVault/src/ProjectMetaAction.h
@@ -9,6 +9,7 @@
 #include "actions/StringsAction.h"
 #include "actions/VersionAction.h"
 #include "actions/VerticalGroupAction.h"
+#include "actions/ApplicationIconPickerAction.h"
 
 #include "ProjectCompressionAction.h"
 
@@ -80,6 +81,7 @@ public: // Action getters
     const gui::StringsAction& getContributorsAction() const { return _contributorsAction; }
     const gui::SplashScreenAction& getSplashScreenAction() const { return _splashScreenAction; }
     const gui::ToggleAction& getStudioModeAction() const { return _studioModeAction; }
+    const gui::ApplicationIconPickerAction& getIconAction() const { return _iconAction; }
     const ProjectCompressionAction& getCompressionAction() const { return _compressionAction; }
 
     gui::VersionAction& getApplicationVersionAction() { return _applicationVersionAction; }
@@ -92,21 +94,23 @@ public: // Action getters
     gui::StringsAction& getContributorsAction() { return _contributorsAction; }
     gui::SplashScreenAction& getSplashScreenAction() { return _splashScreenAction; }
     gui::ToggleAction& getStudioModeAction() { return _studioModeAction; }
+    gui::ApplicationIconPickerAction& getIconAction() { return _iconAction; }
     ProjectCompressionAction& getCompressionAction() { return _compressionAction; }
 
 private:
-    Project*                    _project;                   /** Pointer to source project to get the meta data from */
-    gui::VersionAction          _applicationVersionAction;  /** Action for storing the application version */
-    gui::VersionAction          _projectVersionAction;      /** Action for storing the project version */
-    gui::ToggleAction           _readOnlyAction;            /** Read-only action */
-    gui::StringAction           _titleAction;               /** Title action */
-    gui::StringAction           _descriptionAction;         /** Description action */
-    gui::StringsAction          _tagsAction;                /** Tags action */
-    gui::StringAction           _commentsAction;            /** Comments action */
-    gui::StringsAction          _contributorsAction;        /** Contributors action */
-    gui::SplashScreenAction     _splashScreenAction;        /** Action for configuring the project splash screen */
-    gui::ToggleAction           _studioModeAction;          /** Toggle between view- and studio mode action */
-    ProjectCompressionAction    _compressionAction;         /** Project compression action */
+    Project*                            _project;                   /** Pointer to source project to get the meta data from */
+    gui::VersionAction                  _applicationVersionAction;  /** Action for storing the application version */
+    gui::VersionAction                  _projectVersionAction;      /** Action for storing the project version */
+    gui::ToggleAction                   _readOnlyAction;            /** Read-only action */
+    gui::StringAction                   _titleAction;               /** Title action */
+    gui::StringAction                   _descriptionAction;         /** Description action */
+    gui::StringsAction                  _tagsAction;                /** Tags action */
+    gui::StringAction                   _commentsAction;            /** Comments action */
+    gui::StringsAction                  _contributorsAction;        /** Contributors action */
+    gui::SplashScreenAction             _splashScreenAction;        /** Action for configuring the project splash screen */
+    gui::ToggleAction                   _studioModeAction;          /** Toggle between view- and studio mode action */
+    gui::ApplicationIconPickerAction    _iconAction;                /** Project icon action (only used in application mode) */
+    ProjectCompressionAction            _compressionAction;         /** Project compression action */
 };
 
 }

--- a/ManiVault/src/ProjectMetaAction.h
+++ b/ManiVault/src/ProjectMetaAction.h
@@ -9,7 +9,7 @@
 #include "actions/StringsAction.h"
 #include "actions/VersionAction.h"
 #include "actions/VerticalGroupAction.h"
-#include "actions/ApplicationIconPickerAction.h"
+#include "actions/ApplicationIconAction.h"
 
 #include "ProjectCompressionAction.h"
 
@@ -81,7 +81,7 @@ public: // Action getters
     const gui::StringsAction& getContributorsAction() const { return _contributorsAction; }
     const gui::SplashScreenAction& getSplashScreenAction() const { return _splashScreenAction; }
     const gui::ToggleAction& getStudioModeAction() const { return _studioModeAction; }
-    const gui::ApplicationIconPickerAction& getApplicationIconAction() const { return _applicationIconAction; }
+    const gui::ApplicationIconAction& getApplicationIconAction() const { return _applicationIconAction; }
     const ProjectCompressionAction& getCompressionAction() const { return _compressionAction; }
 
     gui::VersionAction& getApplicationVersionAction() { return _applicationVersionAction; }
@@ -94,23 +94,23 @@ public: // Action getters
     gui::StringsAction& getContributorsAction() { return _contributorsAction; }
     gui::SplashScreenAction& getSplashScreenAction() { return _splashScreenAction; }
     gui::ToggleAction& getStudioModeAction() { return _studioModeAction; }
-    gui::ApplicationIconPickerAction& getApplicationIconAction() { return _applicationIconAction; }
+    gui::ApplicationIconAction& getApplicationIconAction() { return _applicationIconAction; }
     ProjectCompressionAction& getCompressionAction() { return _compressionAction; }
 
 private:
-    Project*                            _project;                           /** Pointer to source project to get the meta data from */
-    gui::VersionAction                  _applicationVersionAction;          /** Action for storing the application version */
-    gui::VersionAction                  _projectVersionAction;              /** Action for storing the project version */
-    gui::ToggleAction                   _readOnlyAction;                    /** Read-only action */
-    gui::StringAction                   _titleAction;                       /** Title action */
-    gui::StringAction                   _descriptionAction;                 /** Description action */
-    gui::StringsAction                  _tagsAction;                        /** Tags action */
-    gui::StringAction                   _commentsAction;                    /** Comments action */
-    gui::StringsAction                  _contributorsAction;                /** Contributors action */
-    gui::SplashScreenAction             _splashScreenAction;                /** Action for configuring the project splash screen */
-    gui::ToggleAction                   _studioModeAction;                  /** Toggle between view- and studio mode action */
-    gui::ApplicationIconPickerAction    _applicationIconAction;             /** Application icon action (only used in application mode) */
-    ProjectCompressionAction            _compressionAction;                 /** Project compression action */
+    Project*                        _project;                           /** Pointer to source project to get the meta data from */
+    gui::VersionAction              _applicationVersionAction;          /** Action for storing the application version */
+    gui::VersionAction              _projectVersionAction;              /** Action for storing the project version */
+    gui::ToggleAction               _readOnlyAction;                    /** Read-only action */
+    gui::StringAction               _titleAction;                       /** Title action */
+    gui::StringAction               _descriptionAction;                 /** Description action */
+    gui::StringsAction              _tagsAction;                        /** Tags action */
+    gui::StringAction               _commentsAction;                    /** Comments action */
+    gui::StringsAction              _contributorsAction;                /** Contributors action */
+    gui::SplashScreenAction         _splashScreenAction;                /** Action for configuring the project splash screen */
+    gui::ToggleAction               _studioModeAction;                  /** Toggle between view- and studio mode action */
+    gui::ApplicationIconAction      _applicationIconAction;             /** Application icon action (only used in application mode) */
+    ProjectCompressionAction        _compressionAction;                 /** Project compression action */
 };
 
 }

--- a/ManiVault/src/ProjectMetaAction.h
+++ b/ManiVault/src/ProjectMetaAction.h
@@ -81,7 +81,7 @@ public: // Action getters
     const gui::StringsAction& getContributorsAction() const { return _contributorsAction; }
     const gui::SplashScreenAction& getSplashScreenAction() const { return _splashScreenAction; }
     const gui::ToggleAction& getStudioModeAction() const { return _studioModeAction; }
-    const gui::ApplicationIconPickerAction& getIconAction() const { return _iconAction; }
+    const gui::ApplicationIconPickerAction& getApplicationIconAction() const { return _applicationIconAction; }
     const ProjectCompressionAction& getCompressionAction() const { return _compressionAction; }
 
     gui::VersionAction& getApplicationVersionAction() { return _applicationVersionAction; }
@@ -94,23 +94,23 @@ public: // Action getters
     gui::StringsAction& getContributorsAction() { return _contributorsAction; }
     gui::SplashScreenAction& getSplashScreenAction() { return _splashScreenAction; }
     gui::ToggleAction& getStudioModeAction() { return _studioModeAction; }
-    gui::ApplicationIconPickerAction& getIconAction() { return _iconAction; }
+    gui::ApplicationIconPickerAction& getApplicationIconAction() { return _applicationIconAction; }
     ProjectCompressionAction& getCompressionAction() { return _compressionAction; }
 
 private:
-    Project*                            _project;                   /** Pointer to source project to get the meta data from */
-    gui::VersionAction                  _applicationVersionAction;  /** Action for storing the application version */
-    gui::VersionAction                  _projectVersionAction;      /** Action for storing the project version */
-    gui::ToggleAction                   _readOnlyAction;            /** Read-only action */
-    gui::StringAction                   _titleAction;               /** Title action */
-    gui::StringAction                   _descriptionAction;         /** Description action */
-    gui::StringsAction                  _tagsAction;                /** Tags action */
-    gui::StringAction                   _commentsAction;            /** Comments action */
-    gui::StringsAction                  _contributorsAction;        /** Contributors action */
-    gui::SplashScreenAction             _splashScreenAction;        /** Action for configuring the project splash screen */
-    gui::ToggleAction                   _studioModeAction;          /** Toggle between view- and studio mode action */
-    gui::ApplicationIconPickerAction    _iconAction;                /** Project icon action (only used in application mode) */
-    ProjectCompressionAction            _compressionAction;         /** Project compression action */
+    Project*                            _project;                           /** Pointer to source project to get the meta data from */
+    gui::VersionAction                  _applicationVersionAction;          /** Action for storing the application version */
+    gui::VersionAction                  _projectVersionAction;              /** Action for storing the project version */
+    gui::ToggleAction                   _readOnlyAction;                    /** Read-only action */
+    gui::StringAction                   _titleAction;                       /** Title action */
+    gui::StringAction                   _descriptionAction;                 /** Description action */
+    gui::StringsAction                  _tagsAction;                        /** Tags action */
+    gui::StringAction                   _commentsAction;                    /** Comments action */
+    gui::StringsAction                  _contributorsAction;                /** Contributors action */
+    gui::SplashScreenAction             _splashScreenAction;                /** Action for configuring the project splash screen */
+    gui::ToggleAction                   _studioModeAction;                  /** Toggle between view- and studio mode action */
+    gui::ApplicationIconPickerAction    _applicationIconAction;             /** Application icon action (only used in application mode) */
+    ProjectCompressionAction            _compressionAction;                 /** Project compression action */
 };
 
 }

--- a/ManiVault/src/actions/ApplicationIconAction.h
+++ b/ManiVault/src/actions/ApplicationIconAction.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "actions/HorizontalGroupAction.h"
 #include "actions/IconPickerAction.h"
 
 #include <QTimer>
@@ -11,15 +12,13 @@
 namespace mv::gui {
 
 /**
- * Application icon picker action class
- *
- * Extends the IconPickerAction class with testing functionality
+ * Application icon action class
  *
  * Note: This action is developed for internal use only
  *
  * @author Thomas Kroes
  */
-class CORE_EXPORT ApplicationIconPickerAction : public IconPickerAction
+class CORE_EXPORT ApplicationIconAction : public HorizontalGroupAction
 {
 public:
 
@@ -28,12 +27,7 @@ public:
      * @param parent Pointer to parent object
      * @param title Title of the action
      */
-    Q_INVOKABLE ApplicationIconPickerAction(QObject* parent, const QString& title);
-
-    /** Use IconPickerAction basic functions */
-    using IconPickerAction::getIcon;
-    using IconPickerAction::setIcon;
-    using IconPickerAction::setIconFromImage;
+    Q_INVOKABLE ApplicationIconAction(QObject* parent, const QString& title);
 
     /** Set the main window icon to the override application icon */
     void overrideMainWindowIcon() const;
@@ -57,6 +51,8 @@ public: // Serialization
 
 public: // Action getters
 
+    ToggleAction& getOverrideAction() { return _overrideAction; }
+    IconPickerAction& getIconPickerAction() { return _iconPickerAction; }
     TriggerAction& getTestAction() { return _testAction; }
 
 signals:
@@ -68,13 +64,14 @@ signals:
     void iconChanged(const QIcon& icon);
 
 private:
-    gui::ToggleAction   _overrideAction;     /** Toggles override application icon action when loading a published project at ManiVault startup */
-    TriggerAction       _testAction;                        /** Trigger an icon test */
-    QTimer              _testTimer;                         /** Interval in which to set the application icon */
+    ToggleAction        _overrideAction;    /** Toggles override application icon action when loading a published project at ManiVault startup */
+    IconPickerAction    _iconPickerAction;  /** Application icon picker action */
+    TriggerAction       _testAction;        /** Trigger an icon test */
+    QTimer              _testTimer;         /** Interval in which to set the application icon */
 };
 
 }
 
-Q_DECLARE_METATYPE(mv::gui::ApplicationIconPickerAction)
+Q_DECLARE_METATYPE(mv::gui::ApplicationIconAction)
 
-inline const auto applicationIconPickerActionMetaTypeId = qRegisterMetaType<mv::gui::ApplicationIconPickerAction*>("mv::gui::ApplicationIconPickerAction");
+inline const auto applicationIconActionMetaTypeId = qRegisterMetaType<mv::gui::ApplicationIconAction*>("mv::gui::ApplicationIconAction");

--- a/ManiVault/src/actions/ApplicationIconPickerAction.cpp
+++ b/ManiVault/src/actions/ApplicationIconPickerAction.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#include "ApplicationIconPickerAction.h"
+
+#include <QMainWindow>
+#include <QImage>
+
+#include "Application.h"
+
+namespace mv::gui {
+
+ApplicationIconPickerAction::ApplicationIconPickerAction(QObject* parent, const QString& title) :
+    IconPickerAction(parent, title),
+    _testAction(this, "Test"),
+    _testTimer(this)
+{
+    addAction(&_testAction);
+
+    const auto testIconName = "play";
+
+    _testAction.setDefaultWidgetFlags(TriggerAction::WidgetFlag::Icon);
+    _testAction.setToolTip("Briefly (5s) shows the icon in the main window");
+    _testAction.setIconByName(testIconName);
+
+    _testTimer.setSingleShot(true);
+    _testTimer.setInterval(2000);
+
+    connect(&_testAction, &TriggerAction::triggered, this, [this]() -> void {
+        Application::getMainWindow()->setWindowIcon(getIcon());
+
+        _testAction.setIconByName("stopwatch");
+        _testTimer.start();
+    });
+
+    connect(&_testTimer, &QTimer::timeout, this, [this, testIconName]() -> void {
+        _testAction.setIconByName(testIconName);
+
+        Application::getMainWindow()->setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
+
+        _testAction.setIconByName(testIconName);
+    });
+}
+
+void ApplicationIconPickerAction::fromVariantMap(const QVariantMap& variantMap)
+{
+    IconPickerAction::fromVariantMap(variantMap);
+
+    _testAction.fromParentVariantMap(variantMap);
+}
+
+QVariantMap ApplicationIconPickerAction::toVariantMap() const
+{
+    auto variantMap = IconPickerAction::toVariantMap();
+
+    _testAction.insertIntoVariantMap(variantMap);
+
+    return variantMap;
+}
+
+}

--- a/ManiVault/src/actions/ApplicationIconPickerAction.cpp
+++ b/ManiVault/src/actions/ApplicationIconPickerAction.cpp
@@ -5,7 +5,6 @@
 #include "ApplicationIconPickerAction.h"
 
 #include <QMainWindow>
-#include <QImage>
 
 #include "Application.h"
 
@@ -13,40 +12,77 @@ namespace mv::gui {
 
 ApplicationIconPickerAction::ApplicationIconPickerAction(QObject* parent, const QString& title) :
     IconPickerAction(parent, title),
+    _overrideAction(this, "Override application icon"),
     _testAction(this, "Test"),
     _testTimer(this)
 {
+    addAction(&_overrideAction);
     addAction(&_testAction);
 
     const auto testIconName = "play";
 
     _testAction.setDefaultWidgetFlags(TriggerAction::WidgetFlag::Icon);
-    _testAction.setToolTip("Briefly (5s) shows the icon in the main window");
+    _testAction.setToolTip("Briefly (2s) shows the icon in the main window");
     _testAction.setIconByName(testIconName);
 
     _testTimer.setSingleShot(true);
     _testTimer.setInterval(2000);
 
     connect(&_testAction, &TriggerAction::triggered, this, [this]() -> void {
-        Application::getMainWindow()->setWindowIcon(getIcon());
+        overrideMainWindowIcon();
 
         _testAction.setIconByName("stopwatch");
         _testTimer.start();
     });
 
     connect(&_testTimer, &QTimer::timeout, this, [this, testIconName]() -> void {
-        _testAction.setIconByName(testIconName);
-
-        Application::getMainWindow()->setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
+        ApplicationIconPickerAction::resetApplicationIcon();
 
         _testAction.setIconByName(testIconName);
     });
+
+    const auto updateApplicationIconActionReadOnly = [this]() -> void {
+        const auto overrideApplicationIcon = _overrideAction.isChecked();
+
+        getInputFilePathPickerAction().setEnabled(overrideApplicationIcon);
+        getIconAction().setEnabled(overrideApplicationIcon);
+        getTestAction().setEnabled(overrideApplicationIcon);
+    };
+
+    updateApplicationIconActionReadOnly();
+
+    connect(&_overrideAction, &ToggleAction::toggled, this, updateApplicationIconActionReadOnly);
+
+    _overrideAction.setSortIndex(0);
+    _overrideAction.setToolTip("Whether to override the default ManiVault application icon when the project is in published mode");
+
+    const auto updateTestActionReadOnly = [this]() -> void {
+        _testAction.setEnabled(!getIcon().isNull());
+    };
+
+    updateTestActionReadOnly();
+
+    connect(this, &IconPickerAction::iconChanged, this, updateTestActionReadOnly);
+}
+
+void ApplicationIconPickerAction::overrideMainWindowIcon() const
+{
+    if (getIcon().isNull())
+        return;
+
+    Application::getMainWindow()->setWindowIcon(getIcon());
+}
+
+void ApplicationIconPickerAction::resetApplicationIcon()
+{
+    Application::getMainWindow()->setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
 }
 
 void ApplicationIconPickerAction::fromVariantMap(const QVariantMap& variantMap)
 {
     IconPickerAction::fromVariantMap(variantMap);
 
+    _overrideAction.fromParentVariantMap(variantMap);
     _testAction.fromParentVariantMap(variantMap);
 }
 
@@ -54,6 +90,7 @@ QVariantMap ApplicationIconPickerAction::toVariantMap() const
 {
     auto variantMap = IconPickerAction::toVariantMap();
 
+    _overrideAction.insertIntoVariantMap(variantMap);
     _testAction.insertIntoVariantMap(variantMap);
 
     return variantMap;

--- a/ManiVault/src/actions/ApplicationIconPickerAction.h
+++ b/ManiVault/src/actions/ApplicationIconPickerAction.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#pragma once
+
+#include "actions/IconPickerAction.h"
+
+#include <QTimer>
+
+namespace mv::gui {
+
+/**
+ * Application icon picker action class
+ *
+ * Extends the IconPickerAction class with testing functionality
+ *
+ * Note: This action is developed for internal use only
+ *
+ * @author Thomas Kroes
+ */
+class CORE_EXPORT ApplicationIconPickerAction : public IconPickerAction
+{
+public:
+
+    /**
+     * Construct with pointer to \p parent object
+     * @param parent Pointer to parent object
+     * @param title Title of the action
+     */
+    Q_INVOKABLE ApplicationIconPickerAction(QObject* parent, const QString& title);
+
+    /** Use IconPickerAction basic functions */
+    using IconPickerAction::getIcon;
+    using IconPickerAction::setIcon;
+    using IconPickerAction::setIconFromImage;
+
+public: // Serialization
+
+    /**
+     * Load image action from variant
+     * @param Variant representation of the image action
+     */
+    void fromVariantMap(const QVariantMap& variantMap) override;
+
+    /**
+     * Save image action to variant
+     * @return Variant representation of the image action
+     */
+    QVariantMap toVariantMap() const override;
+
+public: // Action getters
+
+    TriggerAction& getTestAction() { return _testAction; }
+
+signals:
+
+    /**
+     * Signals that the current icon changed to \p icon
+     * @param icon Current icon that changed
+     */
+    void iconChanged(const QIcon& icon);
+
+private:
+    TriggerAction   _testAction;    /** Trigger an icon test */
+    QTimer          _testTimer;     /** Interval in which to set the application icon */
+};
+
+}
+
+Q_DECLARE_METATYPE(mv::gui::ApplicationIconPickerAction)
+
+inline const auto applicationIconPickerActionMetaTypeId = qRegisterMetaType<mv::gui::ApplicationIconPickerAction*>("mv::gui::ApplicationIconPickerAction");

--- a/ManiVault/src/actions/ApplicationIconPickerAction.h
+++ b/ManiVault/src/actions/ApplicationIconPickerAction.h
@@ -35,6 +35,12 @@ public:
     using IconPickerAction::setIcon;
     using IconPickerAction::setIconFromImage;
 
+    /** Set the main window icon to the override application icon */
+    void overrideMainWindowIcon() const;
+
+    /** Set the application icon to the default */
+    static void resetApplicationIcon();
+
 public: // Serialization
 
     /**
@@ -62,8 +68,9 @@ signals:
     void iconChanged(const QIcon& icon);
 
 private:
-    TriggerAction   _testAction;    /** Trigger an icon test */
-    QTimer          _testTimer;     /** Interval in which to set the application icon */
+    gui::ToggleAction   _overrideAction;     /** Toggles override application icon action when loading a published project at ManiVault startup */
+    TriggerAction       _testAction;                        /** Trigger an icon test */
+    QTimer              _testTimer;                         /** Interval in which to set the application icon */
 };
 
 }

--- a/ManiVault/src/actions/FilePickerAction.cpp
+++ b/ManiVault/src/actions/FilePickerAction.cpp
@@ -21,7 +21,7 @@ FilePickerAction::FilePickerAction(QObject* parent, const QString& title, const 
     _dirModel(nullptr),
     _completer(nullptr),
     _filePathAction(this, "File path"),
-    _pickAction(this, ""),
+    _pickAction(this, "Pick"),
     _nameFilters(),
     _defaultSuffix(),
     _fileType("File")

--- a/ManiVault/src/actions/FilePickerAction.cpp
+++ b/ManiVault/src/actions/FilePickerAction.cpp
@@ -29,6 +29,7 @@ FilePickerAction::FilePickerAction(QObject* parent, const QString& title, const 
     setDefaultWidgetFlags(WidgetFlag::Default);
     setFilePath(filePath);
 
+    _filePathAction.setStretch(1);
     _filePathAction.getTrailingAction().setVisible(true);
 
     if (populateCompleter)
@@ -39,6 +40,7 @@ FilePickerAction::FilePickerAction(QObject* parent, const QString& title, const 
         _filePathAction.setCompleter(_completer.get());
     }
 
+    _pickAction.setStretch(0);
     _pickAction.setDefaultWidgetFlags(TriggerAction::Icon);
     _pickAction.setIconByName("folder-open");
     

--- a/ManiVault/src/actions/FilePickerAction.cpp
+++ b/ManiVault/src/actions/FilePickerAction.cpp
@@ -6,9 +6,10 @@
 
 #include <Application.h>
 
+#include <actions/HorizontalGroupAction.h>
+
 #include <QDir>
 #include <QFileDialog>
-#include <QHBoxLayout>
 #include <QStandardPaths>
 
 using namespace mv::util;
@@ -20,7 +21,7 @@ FilePickerAction::FilePickerAction(QObject* parent, const QString& title, const 
     _dirModel(nullptr),
     _completer(nullptr),
     _filePathAction(this, "File path"),
-    _pickAction(this, "Pick"),
+    _pickAction(this, ""),
     _nameFilters(),
     _defaultSuffix(),
     _fileType("File")
@@ -40,7 +41,6 @@ FilePickerAction::FilePickerAction(QObject* parent, const QString& title, const 
         _filePathAction.setCompleter(_completer.get());
     }
 
-    _pickAction.setStretch(0);
     _pickAction.setDefaultWidgetFlags(TriggerAction::Icon);
     _pickAction.setIconByName("folder-open");
     
@@ -173,20 +173,15 @@ bool FilePickerAction::isValid() const
 
 QWidget* FilePickerAction::getWidget(QWidget* parent, const std::int32_t& widgetFlags)
 {
-    auto widget = new WidgetActionWidget(parent, this);
-    auto layout = new QHBoxLayout();
-
-    layout->setContentsMargins(0, 0, 0, 0);
+    auto groupAction = new HorizontalGroupAction(this, "Group");
 
     if (widgetFlags & WidgetFlag::LineEdit)
-        layout->addWidget(_filePathAction.createWidget(parent));
+        groupAction->addAction(&_filePathAction);
 
     if (widgetFlags & WidgetFlag::PushButton)
-        layout->addWidget(_pickAction.createWidget(parent));
+        groupAction->addAction(&_pickAction);
 
-    widget->setLayout(layout);
-
-    return widget;
+    return groupAction->createWidget(parent);
 }
 
 void FilePickerAction::fromVariantMap(const QVariantMap& variantMap)

--- a/ManiVault/src/actions/GroupAction.cpp
+++ b/ManiVault/src/actions/GroupAction.cpp
@@ -238,8 +238,11 @@ void GroupAction::setLabelWidthFixed(std::uint32_t labelWidthFixed)
 void GroupAction::sortActions()
 {
     std::sort(_actions.begin(), _actions.end(), [](const WidgetAction* lhs, const WidgetAction* rhs) {
+        if (lhs->getSortIndex() < 0 || rhs->getSortIndex() < 0)
+            return false;
+
         return rhs->getSortIndex() > lhs->getSortIndex();
-        });
+    });
 }
 
 QWidget* GroupAction::getWidget(QWidget* parent, const std::int32_t& widgetFlags)

--- a/ManiVault/src/actions/IconAction.cpp
+++ b/ManiVault/src/actions/IconAction.cpp
@@ -4,13 +4,17 @@
 
 #include "IconAction.h"
 
+#include <QBuffer>
+
 using namespace mv::util;
 
 namespace mv::gui {
 
 IconAction::IconAction(QObject* parent, const QString& title) :
-    WidgetAction(parent, title)
+    TriggerAction(parent, title)
 {
+    setDefaultWidgetFlags(TriggerAction::WidgetFlag::Icon);
+    setIconByName("exclamation-circle");
 }
 
 void IconAction::setIconFromImage(const QImage& image)
@@ -22,59 +26,27 @@ void IconAction::fromVariantMap(const QVariantMap& variantMap)
 {
     WidgetAction::fromVariantMap(variantMap);
 
-    const auto rawDataMap = variantMap["RawData"].toMap();
+    QPixmap pixmap;
 
-    variantMapMustContain(rawDataMap, "RawData");
+    pixmap.loadFromData(QByteArray::fromBase64(variantMap["Value"].toByteArray()));
 
-    QByteArray iconByteArray;
-
-    QDataStream iconDataStream(&iconByteArray, QIODevice::ReadOnly);
-
-    const auto clustersRawDataSize = rawDataMap["ClustersRawDataSize"].toInt();
-
-    iconByteArray.resize(clustersRawDataSize);
-
-    populateDataBufferFromVariantMap(rawDataMap["ClustersRawData"].toMap(), (char*)iconByteArray.data());
-
-    //QImage image;
-
-    //image.loadFromData(QByteArray::fromBase64(variantMap["Value"].toByteArray()));
-
-    //setImage(image);
-
-    //_filePathAction.fromParentVariantMap(variantMap);
-    //_fileNameAction.fromParentVariantMap(variantMap);
+    setIcon(createIcon(pixmap));
 }
 
 QVariantMap IconAction::toVariantMap() const
 {
     auto variantMap = WidgetAction::toVariantMap();
 
-    /*QByteArray previewImageByteArray;
+    QByteArray previewImageByteArray;
     QBuffer previewImageBuffer(&previewImageByteArray);
 
-    _image.save(&previewImageBuffer, "PNG");
+    icon().pixmap(QSize(32, 32)).save(&previewImageBuffer, "PNG");
 
     variantMap.insert({
-        { "Value", QVariant::fromValue(previewImageByteArray.toBase64()) }
-        });
-
-    _filePathAction.insertIntoVariantMap(variantMap);
-    _fileNameAction.insertIntoVariantMap(variantMap);*/
+    { "Value", QVariant::fromValue(previewImageByteArray.toBase64()) }
+    });
 
     return variantMap;
-}
-
-IconAction::Widget::Widget(QWidget* parent, IconAction* iconAction, const std::int32_t& widgetFlags) :
-    WidgetActionWidget(parent, iconAction, widgetFlags)
-{
-    auto layout = new QVBoxLayout();
-
-    layout->addWidget(&_iconLabel);
-
-    setLayout(layout);
-
-    _iconLabel.setPixmap(iconAction->icon().pixmap(12, 12));
 }
 
 }

--- a/ManiVault/src/actions/IconAction.cpp
+++ b/ManiVault/src/actions/IconAction.cpp
@@ -14,7 +14,7 @@ IconAction::IconAction(QObject* parent, const QString& title) :
 {
 }
 
-const QIcon IconAction::getIcon() const
+QIcon IconAction::getIcon() const
 {
     return _icon;
 }

--- a/ManiVault/src/actions/IconAction.cpp
+++ b/ManiVault/src/actions/IconAction.cpp
@@ -9,21 +9,8 @@ using namespace mv::util;
 namespace mv::gui {
 
 IconAction::IconAction(QObject* parent, const QString& title) :
-    WidgetAction(parent, title),
-    _icon()
+    WidgetAction(parent, title)
 {
-}
-
-QIcon IconAction::getIcon() const
-{
-    return _icon;
-}
-
-void IconAction::setIcon(const QIcon& icon)
-{
-    _icon = icon;
-
-    emit iconChanged(_icon);
 }
 
 void IconAction::setIconFromImage(const QImage& image)
@@ -87,7 +74,7 @@ IconAction::Widget::Widget(QWidget* parent, IconAction* iconAction, const std::i
 
     setLayout(layout);
 
-    _iconLabel.setPixmap(iconAction->getIcon().pixmap(12, 12));
+    _iconLabel.setPixmap(iconAction->icon().pixmap(12, 12));
 }
 
 }

--- a/ManiVault/src/actions/IconAction.cpp
+++ b/ManiVault/src/actions/IconAction.cpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#include "IconAction.h"
+
+using namespace mv::util;
+
+namespace mv::gui {
+
+IconAction::IconAction(QObject* parent, const QString& title) :
+    WidgetAction(parent, title),
+    _icon()
+{
+}
+
+const QIcon IconAction::getIcon() const
+{
+    return _icon;
+}
+
+void IconAction::setIcon(const QIcon& icon)
+{
+    _icon = icon;
+
+    emit iconChanged(_icon);
+}
+
+void IconAction::setIconFromImage(const QImage& image)
+{
+    setIcon(createIcon(QPixmap::fromImage(image)));
+}
+
+void IconAction::fromVariantMap(const QVariantMap& variantMap)
+{
+    WidgetAction::fromVariantMap(variantMap);
+
+    const auto rawDataMap = variantMap["RawData"].toMap();
+
+    variantMapMustContain(rawDataMap, "RawData");
+
+    QByteArray iconByteArray;
+
+    QDataStream iconDataStream(&iconByteArray, QIODevice::ReadOnly);
+
+    const auto clustersRawDataSize = rawDataMap["ClustersRawDataSize"].toInt();
+
+    iconByteArray.resize(clustersRawDataSize);
+
+    populateDataBufferFromVariantMap(rawDataMap["ClustersRawData"].toMap(), (char*)iconByteArray.data());
+
+    //QImage image;
+
+    //image.loadFromData(QByteArray::fromBase64(variantMap["Value"].toByteArray()));
+
+    //setImage(image);
+
+    //_filePathAction.fromParentVariantMap(variantMap);
+    //_fileNameAction.fromParentVariantMap(variantMap);
+}
+
+QVariantMap IconAction::toVariantMap() const
+{
+    auto variantMap = WidgetAction::toVariantMap();
+
+    /*QByteArray previewImageByteArray;
+    QBuffer previewImageBuffer(&previewImageByteArray);
+
+    _image.save(&previewImageBuffer, "PNG");
+
+    variantMap.insert({
+        { "Value", QVariant::fromValue(previewImageByteArray.toBase64()) }
+        });
+
+    _filePathAction.insertIntoVariantMap(variantMap);
+    _fileNameAction.insertIntoVariantMap(variantMap);*/
+
+    return variantMap;
+}
+
+IconAction::Widget::Widget(QWidget* parent, IconAction* iconAction, const std::int32_t& widgetFlags) :
+    WidgetActionWidget(parent, iconAction, widgetFlags)
+{
+    auto layout = new QVBoxLayout();
+
+    layout->addWidget(&_iconLabel);
+
+    setLayout(layout);
+
+    _iconLabel.setPixmap(iconAction->getIcon().pixmap(12, 12));
+}
+
+}

--- a/ManiVault/src/actions/IconAction.h
+++ b/ManiVault/src/actions/IconAction.h
@@ -16,6 +16,8 @@ namespace mv::gui {
  *
  * For icon storage
  *
+ * Note: This action is developed for internal use only
+ *
  * @author Thomas Kroes
  */
 class CORE_EXPORT IconAction : public WidgetAction
@@ -68,7 +70,7 @@ public:
      * Get the current icon
      * @return Icon
      */
-    const QIcon getIcon() const;
+    QIcon getIcon() const;
 
     /**
      * Set the current icon to \p icon

--- a/ManiVault/src/actions/IconAction.h
+++ b/ManiVault/src/actions/IconAction.h
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#pragma once
+
+#include "WidgetAction.h"
+#include "WidgetActionWidget.h"
+
+#include <QIcon>
+
+namespace mv::gui {
+
+/**
+ * Icon action class (WIP)
+ *
+ * For icon storage
+ *
+ * @author Thomas Kroes
+ */
+class CORE_EXPORT IconAction : public WidgetAction
+{
+    Q_OBJECT
+
+public:
+
+    /** Label widget class for icon action */
+    class CORE_EXPORT Widget : public WidgetActionWidget {
+    protected:
+
+        /**
+         * Construct with pointer to \p parent widget, pointer to \p iconAction and \p widgetFlags
+         * @param parent Pointer to parent widget
+         * @param iconAction Pointer to icon action
+         * @param widgetFlags Widget flags
+         */
+        Widget(QWidget* parent, IconAction* iconAction, const std::int32_t& widgetFlags);
+
+    protected:
+        IconAction*     _iconAction;    /** Pointer to icon action */
+        QLabel          _iconLabel;     /** Label which will display the icon */
+
+        friend class IconAction;
+    };
+
+protected:
+
+    /**
+     * Get widget representation of the icon action
+     * @param parent Pointer to parent widget
+     * @param widgetFlags Widget flags for the configuration of the widget (type)
+     */
+    QWidget* getWidget(QWidget* parent, const std::int32_t& widgetFlags) override
+    {
+        return new Widget(parent, this, widgetFlags);
+    }
+
+public:
+
+    /**
+     * Constructor
+     * @param parent Pointer to parent object
+     * @param title Title of the action
+     */
+    Q_INVOKABLE IconAction(QObject* parent, const QString& title);
+
+    /**
+     * Get the current icon
+     * @return Icon
+     */
+    const QIcon getIcon() const;
+
+    /**
+     * Set the current icon to \p icon
+     * @param icon Current icon
+     */
+    void setIcon(const QIcon& icon);
+
+    /**
+     * Set the current icon from \p image
+     * @param image Image to convert to icon
+     */
+    void setIconFromImage(const QImage& image);
+
+public: // Serialization
+
+    /**
+     * Load image action from variant
+     * @param Variant representation of the image action
+     */
+    void fromVariantMap(const QVariantMap& variantMap) override;
+
+    /**
+     * Save image action to variant
+     * @return Variant representation of the image action
+     */
+    QVariantMap toVariantMap() const override;
+
+public: // Action getters
+
+    //StringAction& getFilePathAction() { return _filePathAction; }
+    //StringAction& getFileNameAction() { return _fileNameAction; }
+    //FilePickerAction& getFilePickerAction() { return _filePickerAction; }
+    //TriggerAction& getPreviewAction() { return _previewAction; }
+
+signals:
+
+    /**
+     * Signals that the current icon changed
+     * @param icon Current icon that changed
+     */
+    void iconChanged(const QIcon& icon);
+
+protected:
+    QIcon              _icon;             /** Current icon */
+    //StringAction        _filePathAction;    /** String action which contains the last loaded file path */
+    //StringAction        _fileNameAction;    /** String action which contains the last loaded file name */
+    //FilePickerAction    _filePickerAction;  /** Action for loading the image from disk */
+    //TriggerAction       _previewAction;     /** Action for previewing the image (via tooltip) */
+};
+
+}
+
+Q_DECLARE_METATYPE(mv::gui::IconAction)
+
+inline const auto iconActionMetaTypeId = qRegisterMetaType<mv::gui::IconAction*>("mv::gui::IconAction");

--- a/ManiVault/src/actions/IconAction.h
+++ b/ManiVault/src/actions/IconAction.h
@@ -7,8 +7,6 @@
 #include "WidgetAction.h"
 #include "WidgetActionWidget.h"
 
-#include <QIcon>
-
 namespace mv::gui {
 
 /**
@@ -22,8 +20,6 @@ namespace mv::gui {
  */
 class CORE_EXPORT IconAction : public WidgetAction
 {
-    Q_OBJECT
-
 public:
 
     /** Label widget class for icon action */
@@ -73,12 +69,6 @@ public:
     QIcon getIcon() const;
 
     /**
-     * Set the current icon to \p icon
-     * @param icon Current icon
-     */
-    void setIcon(const QIcon& icon);
-
-    /**
      * Set the current icon from \p image
      * @param image Image to convert to icon
      */
@@ -97,28 +87,6 @@ public: // Serialization
      * @return Variant representation of the image action
      */
     QVariantMap toVariantMap() const override;
-
-public: // Action getters
-
-    //StringAction& getFilePathAction() { return _filePathAction; }
-    //StringAction& getFileNameAction() { return _fileNameAction; }
-    //FilePickerAction& getFilePickerAction() { return _filePickerAction; }
-    //TriggerAction& getPreviewAction() { return _previewAction; }
-
-signals:
-
-    /**
-     * Signals that the current icon changed
-     * @param icon Current icon that changed
-     */
-    void iconChanged(const QIcon& icon);
-
-protected:
-    QIcon              _icon;             /** Current icon */
-    //StringAction        _filePathAction;    /** String action which contains the last loaded file path */
-    //StringAction        _fileNameAction;    /** String action which contains the last loaded file name */
-    //FilePickerAction    _filePickerAction;  /** Action for loading the image from disk */
-    //TriggerAction       _previewAction;     /** Action for previewing the image (via tooltip) */
 };
 
 }

--- a/ManiVault/src/actions/IconAction.h
+++ b/ManiVault/src/actions/IconAction.h
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include "WidgetAction.h"
-#include "WidgetActionWidget.h"
+#include "TriggerAction.h"
 
 namespace mv::gui {
 
@@ -18,41 +17,8 @@ namespace mv::gui {
  *
  * @author Thomas Kroes
  */
-class CORE_EXPORT IconAction : public WidgetAction
+class CORE_EXPORT IconAction : public TriggerAction
 {
-public:
-
-    /** Label widget class for icon action */
-    class CORE_EXPORT Widget : public WidgetActionWidget {
-    protected:
-
-        /**
-         * Construct with pointer to \p parent widget, pointer to \p iconAction and \p widgetFlags
-         * @param parent Pointer to parent widget
-         * @param iconAction Pointer to icon action
-         * @param widgetFlags Widget flags
-         */
-        Widget(QWidget* parent, IconAction* iconAction, const std::int32_t& widgetFlags);
-
-    protected:
-        IconAction*     _iconAction;    /** Pointer to icon action */
-        QLabel          _iconLabel;     /** Label which will display the icon */
-
-        friend class IconAction;
-    };
-
-protected:
-
-    /**
-     * Get widget representation of the icon action
-     * @param parent Pointer to parent widget
-     * @param widgetFlags Widget flags for the configuration of the widget (type)
-     */
-    QWidget* getWidget(QWidget* parent, const std::int32_t& widgetFlags) override
-    {
-        return new Widget(parent, this, widgetFlags);
-    }
-
 public:
 
     /**

--- a/ManiVault/src/actions/IconPickerAction.cpp
+++ b/ManiVault/src/actions/IconPickerAction.cpp
@@ -11,8 +11,7 @@ namespace mv::gui {
 IconPickerAction::IconPickerAction(QObject* parent, const QString& title) :
     HorizontalGroupAction(parent, title),
     _inputFilePathPickerAction(this, "FilePicker"),
-    _iconAction(this, "Icon"),
-    _testAction(this, "Test")
+    _iconAction(this, "Icon")
 {
     setShowLabels(false);
 
@@ -38,9 +37,10 @@ IconPickerAction::IconPickerAction(QObject* parent, const QString& title) :
 
     _inputFilePathPickerAction.setStretch(1);
     _inputFilePathPickerAction.setNameFilters({ "*.png" });
+    _inputFilePathPickerAction.setDefaultWidgetFlags(FilePickerAction::WidgetFlag::PushButton);
 }
 
-const QIcon IconPickerAction::getIcon() const
+QIcon IconPickerAction::getIcon() const
 {
     return _iconAction.icon();
 }

--- a/ManiVault/src/actions/IconPickerAction.cpp
+++ b/ManiVault/src/actions/IconPickerAction.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#include "IconPickerAction.h"
+
+namespace mv::gui {
+
+IconPickerAction::IconPickerAction(QObject* parent, const QString& title) :
+    HorizontalGroupAction(parent, title),
+    _filePickerAction(this, "FilePicker"),
+    _iconAction(this, "Icon")
+{
+    addAction(&_filePickerAction);
+    addAction(&_iconAction);
+
+    connect(&_iconAction, &IconAction::iconChanged, this, &IconPickerAction::iconChanged);
+}
+
+const QIcon IconPickerAction::getIcon() const
+{
+    return _iconAction.getIcon();
+}
+
+void IconPickerAction::setIcon(const QIcon& icon)
+{
+    _iconAction.setIcon(icon);
+}
+
+void IconPickerAction::setIconFromImage(const QImage& image)
+{
+    setIcon(createIcon(QPixmap::fromImage(image)));
+}
+
+void IconPickerAction::fromVariantMap(const QVariantMap& variantMap)
+{
+    HorizontalGroupAction::fromVariantMap(variantMap);
+
+    _filePickerAction.fromParentVariantMap(variantMap);
+    _iconAction.fromParentVariantMap(variantMap);
+}
+
+QVariantMap IconPickerAction::toVariantMap() const
+{
+    auto variantMap = HorizontalGroupAction::toVariantMap();
+
+    _filePickerAction.insertIntoVariantMap(variantMap);
+    _iconAction.insertIntoVariantMap(variantMap);
+
+    return variantMap;
+}
+
+}

--- a/ManiVault/src/actions/IconPickerAction.h
+++ b/ManiVault/src/actions/IconPickerAction.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include "actions/HorizontalGroupAction.h"
+#include "actions/FilePickerAction.h"
 #include "actions/IconAction.h"
+#include "actions/TriggerAction.h"
 
 namespace mv::gui {
 
@@ -68,22 +70,21 @@ public: // Serialization
 
 public: // Action getters
 
-    //StringAction& getFilePathAction() { return _filePathAction; }
-    //StringAction& getFileNameAction() { return _fileNameAction; }
-    //FilePickerAction& getFilePickerAction() { return _filePickerAction; }
-    //TriggerAction& getPreviewAction() { return _previewAction; }
+    FilePickerAction& getImageFilePathPickerAction() { return _inputFilePathPickerAction; }
+    IconAction& getIconAction() { return _iconAction; }
 
 signals:
 
     /**
-     * Signals that the current icon changed
+     * Signals that the current icon changed to \p icon
      * @param icon Current icon that changed
      */
     void iconChanged(const QIcon& icon);
 
 private:
-    FilePickerAction    _filePickerAction;  /** Action picking a PNG image which will be transformed into an icon */
-    IconAction          _iconAction;        /** Action which holds the current icon */
+    FilePickerAction    _inputFilePathPickerAction;     /** Action for picking an input (.ico, .png or .icns) file which serve as input for the internal icon (QIcon) */
+    IconAction          _iconAction;                    /** Action which holds the current icon */
+    TriggerAction       _testAction;                    /** Trigger an icon test */
 };
 
 }

--- a/ManiVault/src/actions/IconPickerAction.h
+++ b/ManiVault/src/actions/IconPickerAction.h
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#pragma once
+
+#include "actions/HorizontalGroupAction.h"
+#include "actions/IconAction.h"
+
+namespace mv::gui {
+
+/**
+ * Icon picker action class (WIP)
+ *
+ * For picking and displaying an icon
+ *
+ * Note: This action is developed for internal use only
+ *
+ * @author Thomas Kroes
+ */
+class CORE_EXPORT IconPickerAction : public HorizontalGroupAction
+{
+    Q_OBJECT
+
+public:
+
+    /**
+     * Construct with pointer to \p parent object
+     * @param parent Pointer to parent object
+     * @param title Title of the action
+     */
+    Q_INVOKABLE IconPickerAction(QObject* parent, const QString& title);
+
+    /**
+     * Get the current icon
+     * Facade for IconAction::getIcon()
+     * @return Icon
+     */
+    const QIcon getIcon() const;
+
+    /**
+     * Set the current icon to \p icon
+     * Facade for IconAction::setIcon(...)
+     * @param icon Current icon
+     */
+    void setIcon(const QIcon& icon);
+
+    /**
+     * Set the current icon from \p image
+     * Facade for IconAction::setIconFromImage(...)
+     * @param image Image to convert to icon
+     */
+    void setIconFromImage(const QImage& image);
+
+public: // Serialization
+
+    /**
+     * Load image action from variant
+     * @param Variant representation of the image action
+     */
+    void fromVariantMap(const QVariantMap& variantMap) override;
+
+    /**
+     * Save image action to variant
+     * @return Variant representation of the image action
+     */
+    QVariantMap toVariantMap() const override;
+
+public: // Action getters
+
+    //StringAction& getFilePathAction() { return _filePathAction; }
+    //StringAction& getFileNameAction() { return _fileNameAction; }
+    //FilePickerAction& getFilePickerAction() { return _filePickerAction; }
+    //TriggerAction& getPreviewAction() { return _previewAction; }
+
+signals:
+
+    /**
+     * Signals that the current icon changed
+     * @param icon Current icon that changed
+     */
+    void iconChanged(const QIcon& icon);
+
+private:
+    FilePickerAction    _filePickerAction;  /** Action picking a PNG image which will be transformed into an icon */
+    IconAction          _iconAction;        /** Action which holds the current icon */
+};
+
+}
+
+Q_DECLARE_METATYPE(mv::gui::IconPickerAction)
+
+inline const auto iconPickerActionMetaTypeId = qRegisterMetaType<mv::gui::IconPickerAction*>("mv::gui::IconPickerAction");

--- a/ManiVault/src/actions/IconPickerAction.h
+++ b/ManiVault/src/actions/IconPickerAction.h
@@ -38,7 +38,7 @@ public:
      * Facade for IconAction::getIcon()
      * @return Icon
      */
-    const QIcon getIcon() const;
+    QIcon getIcon() const;
 
     /**
      * Set the current icon to \p icon
@@ -70,7 +70,7 @@ public: // Serialization
 
 public: // Action getters
 
-    FilePickerAction& getImageFilePathPickerAction() { return _inputFilePathPickerAction; }
+    FilePickerAction& getInputFilePathPickerAction() { return _inputFilePathPickerAction; }
     IconAction& getIconAction() { return _iconAction; }
 
 signals:
@@ -82,9 +82,8 @@ signals:
     void iconChanged(const QIcon& icon);
 
 private:
-    FilePickerAction    _inputFilePathPickerAction;     /** Action for picking an input (.ico, .png or .icns) file which serve as input for the internal icon (QIcon) */
+    FilePickerAction    _inputFilePathPickerAction;     /** Action for picking an input PNG file which serve as input for the internal icon (QIcon) */
     IconAction          _iconAction;                    /** Action which holds the current icon */
-    TriggerAction       _testAction;                    /** Trigger an icon test */
 };
 
 }

--- a/ManiVault/src/actions/TriggerAction.cpp
+++ b/ManiVault/src/actions/TriggerAction.cpp
@@ -32,7 +32,7 @@ void TriggerAction::selfTriggered()
 
 TriggerAction::PushButtonWidget::PushButtonWidget(QWidget* parent, TriggerAction* triggerAction, const std::int32_t& widgetFlags) :
     QPushButton(parent),
-    _triggersAction(triggerAction)
+    _triggerAction(triggerAction)
 {
     connect(this, &QPushButton::clicked, this, [this, triggerAction]() {
         triggerAction->trigger();

--- a/ManiVault/src/actions/TriggerAction.h
+++ b/ManiVault/src/actions/TriggerAction.h
@@ -49,7 +49,7 @@ public:
         PushButtonWidget(QWidget* parent, TriggerAction* triggerAction, const std::int32_t& widgetFlags);
 
     protected:
-        TriggerAction*   _triggersAction;      /** Pointer to trigger action */
+        TriggerAction*   _triggerAction;      /** Pointer to trigger action */
 
         friend class TriggerAction;
     };

--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -14,9 +14,6 @@
 #include <Application.h>
 #include <CoreInterface.h>
 
-#include <ForegroundTask.h>
-#include <ForegroundTaskHandler.h>
-#include <BackgroundTask.h>
 #include <BackgroundTaskHandler.h>
 
 #include <actions/ToggleAction.h>
@@ -36,10 +33,8 @@
 #include <QMenuBar>
 #include <QOpenGLFunctions>
 #include <QOffscreenSurface>
-#include <QMessageBox>
 #include <QStackedWidget>
 #include <QStatusBar>
-#include <QListView>
 #include <QRandomGenerator>
 
 #ifdef _DEBUG
@@ -145,12 +140,16 @@ void MainWindow::showEvent(QShowEvent* showEvent)
                 setWindowTitle("ManiVault");
             }
             else {
-                const auto projectFilePath = projects().getCurrentProject()->getFilePath();
+                if (projects().getCurrentProject()->getReadOnlyAction().isChecked()) {
+                    setWindowTitle(projects().getCurrentProject()->getTitleAction().getString());
+                } else {
+                    const auto projectFilePath = projects().getCurrentProject()->getFilePath();
 
-                if (projectFilePath.isEmpty())
-                    setWindowTitle("Unsaved - ManiVault");
-                else
-                    setWindowTitle(QString("%1 - ManiVault").arg(projectFilePath));
+                    if (projectFilePath.isEmpty())
+                        setWindowTitle("Unsaved - ManiVault");
+                    else
+                        setWindowTitle(QString("%1 - ManiVault").arg(projectFilePath));
+                }
             }
 
             statusBar()->setVisible(projects().hasProject());

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -429,8 +429,6 @@ void ProjectManager::openProject(QString filePath /*= ""*/, bool importDataOnly 
 
             _project->setFilePath(filePath);
 
-            ProjectMetaAction projectMetaAction(extractFileFromManiVaultProject(filePath, temporaryDirectory, "meta.json"));
-
             auto& projectSerializationTask      = projects().getProjectSerializationTask();
             auto& compressionTask               = projectSerializationTask.getCompressionTask();
 
@@ -481,7 +479,7 @@ void ProjectManager::openProject(QString filePath /*= ""*/, bool importDataOnly 
             _project->updateContributors();
 
             if (disableReadOnlyAction.isEnabled() && disableReadOnlyAction.isChecked())
-                _project->getReadOnlyAction().setChecked(disableReadOnlyAction.isChecked());
+                _project->getReadOnlyAction().setChecked(false);
 
             if (_project->isStartupProject())
                 ModalTask::getGlobalHandler()->setEnabled(true);

--- a/ManiVault/src/private/ProjectSettingsDialog.cpp
+++ b/ManiVault/src/private/ProjectSettingsDialog.cpp
@@ -34,7 +34,7 @@ ProjectSettingsDialog::ProjectSettingsDialog(QWidget* parent /*= nullptr*/) :
 
     _groupAction.addAction(&project->getTitleAction());
     _groupAction.addAction(&project->getDescriptionAction());
-    _groupAction.addAction(&project->getIconAction());
+    _groupAction.addAction(&project->getApplicationIconAction());
     _groupAction.addAction(&project->getProjectVersionAction());
     _groupAction.addAction(&project->getTagsAction());
     _groupAction.addAction(&project->getCommentsAction());

--- a/ManiVault/src/private/ProjectSettingsDialog.cpp
+++ b/ManiVault/src/private/ProjectSettingsDialog.cpp
@@ -34,6 +34,7 @@ ProjectSettingsDialog::ProjectSettingsDialog(QWidget* parent /*= nullptr*/) :
 
     _groupAction.addAction(&project->getTitleAction());
     _groupAction.addAction(&project->getDescriptionAction());
+    _groupAction.addAction(&project->getIconAction());
     _groupAction.addAction(&project->getProjectVersionAction());
     _groupAction.addAction(&project->getTagsAction());
     _groupAction.addAction(&project->getCommentsAction());

--- a/ManiVault/src/widgets/SplashScreenWidget.cpp
+++ b/ManiVault/src/widgets/SplashScreenWidget.cpp
@@ -302,7 +302,7 @@ void SplashScreenWidget::createBody()
         auto comments       = projectMetaAction->getCommentsAction().getString();
 
         if (title.isEmpty())
-            title = QFileInfo(projects().getCurrentProject()->getFilePath()).fileName();
+            title = projects().hasProject() ? QFileInfo(projects().getCurrentProject()->getFilePath()).fileName() : "Untitled";
 
         htmlLabel->setText(QString(" \
             <div style='color: %5;'> \


### PR DESCRIPTION
Features included in this PR:
- [x] Ability to customize the application icon for published projects
- [x] Ability to test this at any time

To this end, the following internal classes have been added:
- [x] `IconAction` (for storage and display of an icon)
- [x] `IconPickerAction` for picking PNG files and converting them to Qt icon (uses the `IconAction`)
- [x] `ApplicationIconAction` for testing the overriding of the application icon and for configuring in the project settings dialog

Bug fixes and some housekeeping along the way:
- [x] Restore the ability to re-edit published projects
- [x] Only show the application name in the main window for published projects (omit the ManiVault name)