### PR TITLE
Adds project selector to application startup

### DIFF
--- a/ManiVault/cmake/CMakeMvSourcesApplication.cmake
+++ b/ManiVault/cmake/CMakeMvSourcesApplication.cmake
@@ -248,6 +248,7 @@ set(PRIVATE_APPLICATION_HEADERS
     src/private/LoadSystemViewMenu.h
     src/private/LoadedViewsMenu.h
     src/private/HelpMenu.h
+    src/private/StartupProjectSelectorDialog.h
 )
 
 set(PRIVATE_APPLICATION_SOURCES
@@ -257,11 +258,29 @@ set(PRIVATE_APPLICATION_SOURCES
     src/private/LoadSystemViewMenu.cpp
     src/private/LoadedViewsMenu.cpp
     src/private/HelpMenu.cpp
+    src/private/StartupProjectSelectorDialog.cpp
 )
 
 set(PRIVATE_APPLICATION_FILES
     ${PRIVATE_APPLICATION_HEADERS}
     ${PRIVATE_APPLICATION_SOURCES}
+)
+
+set(PRIVATE_STARTUP_PROJECT_HEADERS
+	src/private/StartupProjectsModel.h
+	src/private/StartupProjectsFilterModel.h
+    src/private/StartupProjectSelectorDialog.h
+)
+
+set(PRIVATE_STARTUP_PROJECT_SOURCES
+src/private/StartupProjectsModel.cpp
+	src/private/StartupProjectsFilterModel.cpp
+    src/private/StartupProjectSelectorDialog.cpp
+)
+
+set(PRIVATE_STARTUP_PROJECT_FILES
+    ${PRIVATE_STARTUP_PROJECT_HEADERS}
+    ${PRIVATE_STARTUP_PROJECT_SOURCES}
 )
 
 set(PRIVATE_PAGES_COMMON_HEADERS
@@ -369,6 +388,7 @@ set(PRIVATE_HEADERS
 	${PRIVATE_LEARNING_PAGE_HEADERS}
     ${PRIVATE_MISCELLANEOUS_HEADERS}
     ${PRIVATE_ACTIONS_HEADERS}
+    ${PRIVATE_STARTUP_PROJECT_HEADERS}
 )
 
 set(PRIVATE_SOURCES
@@ -380,6 +400,7 @@ set(PRIVATE_SOURCES
 	${PRIVATE_LEARNING_PAGE_SOURCES}
     ${PRIVATE_MISCELLANEOUS_SOURCES}
     ${PRIVATE_ACTIONS_SOURCES}
+    ${PRIVATE_STARTUP_PROJECT_SOURCES}
     ${PRIVATE_HEADERS}
 )
 
@@ -389,6 +410,7 @@ list(REMOVE_DUPLICATES PRIVATE_SOURCES)
 source_group(Core FILES ${PRIVATE_CORE_FILES})
 source_group(Actions FILES ${PRIVATE_ACTION_FILES})
 source_group(Application FILES ${PRIVATE_APPLICATION_FILES} ${MAIN_SOURCES})
+source_group(StartupProject FILES ${PRIVATE_STARTUP_PROJECT_FILES})
 source_group(Managers\\Layout FILES ${PRIVATE_LAYOUT_MANAGER_FILES})
 source_group(Managers\\Plugin FILES ${PRIVATE_PLUGIN_MANAGER_FILES})
 source_group(Managers\\Data FILES ${PRIVATE_DATA_MANAGER_FILES})

--- a/ManiVault/src/actions/IconAction.cpp
+++ b/ManiVault/src/actions/IconAction.cpp
@@ -14,7 +14,7 @@ IconAction::IconAction(QObject* parent, const QString& title) :
     TriggerAction(parent, title)
 {
     setDefaultWidgetFlags(TriggerAction::WidgetFlag::Icon);
-    setIconByName("exclamation-circle");
+    //setIconByName("exclamation-circle");
 }
 
 void IconAction::setIconFromImage(const QImage& image)

--- a/ManiVault/src/private/StartupProjectSelectorDialog.cpp
+++ b/ManiVault/src/private/StartupProjectSelectorDialog.cpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#include "StartupProjectSelectorDialog.h"
+
+#include <Application.h>
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+
+using namespace mv;
+using namespace mv::gui;
+
+#ifdef _DEBUG
+    #define STARTUP_PROJECT_SELECTOR_DIALOG_VERBOSE
+#endif
+
+StartupProjectSelectorDialog::StartupProjectSelectorDialog(const QVector<QPair<QSharedPointer<mv::ProjectMetaAction>, QString>>& startupProjectsMetaActions, QWidget* parent /*= nullptr*/) :
+    QDialog(parent),
+    _model(this),
+    _filterModel(this),
+    _hierarchyWidget(this, "Startup project", _model, &_filterModel, false),
+    _loadAction(this, "Load"),
+    _cancelAction(this, "Cancel")
+{
+    _model.initialize(startupProjectsMetaActions);
+
+    const auto windowIcon = Application::getIconFont("FontAwesome").getIcon("file-import");
+
+    setWindowIcon(windowIcon);
+    setModal(true);
+    setWindowTitle("Load project");
+    
+    auto layout = new QVBoxLayout();
+
+    layout->addWidget(&_hierarchyWidget, 1);
+
+    auto bottomLayout = new QHBoxLayout();
+
+    bottomLayout->addStretch(1);
+    bottomLayout->addWidget(_loadAction.createWidget(this));
+    bottomLayout->addWidget(_cancelAction.createWidget(this));
+
+    layout->addLayout(bottomLayout);
+
+    setLayout(layout);
+
+    _loadAction.setToolTip("Load the selected project");
+    _cancelAction.setToolTip("Do not load a project");
+
+    _hierarchyWidget.setWindowIcon(windowIcon);
+    _hierarchyWidget.getTreeView().setRootIsDecorated(false);
+
+    auto& treeView = _hierarchyWidget.getTreeView();
+
+    treeView.setSelectionMode(QAbstractItemView::SelectionMode::SingleSelection);
+    treeView.setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
+
+    const auto updateLoadAction = [this, &treeView]() -> void {
+        _loadAction.setEnabled(!treeView.selectionModel()->selectedRows().isEmpty());
+    };
+
+    updateLoadAction();
+
+    connect(treeView.selectionModel(), &QItemSelectionModel::selectionChanged, this, updateLoadAction);
+
+    auto treeViewHeader = treeView.header();
+
+    treeViewHeader->setStretchLastSection(false);
+
+    //treeViewHeader->resizeSection(static_cast<int>(StartupProjectsModel::Column::FileName), 300);
+    //treeViewHeader->resizeSection(static_cast<int>(StartupProjectsModel::Column::Title), 300);
+    //treeViewHeader->resizeSection(static_cast<int>(StartupProjectsModel::Column::Description), 70);
+
+#ifdef _DEBUG
+    treeViewHeader->setSectionHidden(static_cast<int>(StartupProjectsModel::Column::FileName), false);
+#else
+    treeViewHeader->setSectionHidden(static_cast<int>(StartupProjectsModel::Column::FileName), true);
+#endif
+    
+
+    treeViewHeader->setSectionResizeMode(static_cast<int>(StartupProjectsModel::Column::FileName), QHeaderView::Stretch);
+    treeViewHeader->setSectionResizeMode(static_cast<int>(StartupProjectsModel::Column::Title), QHeaderView::Stretch);
+    treeViewHeader->setSectionResizeMode(static_cast<int>(StartupProjectsModel::Column::Description), QHeaderView::Stretch);
+
+    treeViewHeader->setStretchLastSection(false);
+
+    connect(&_loadAction, &TriggerAction::triggered, this, &StartupProjectSelectorDialog::accept);
+    connect(&_cancelAction, &TriggerAction::triggered, this, &StartupProjectSelectorDialog::reject);
+}
+
+std::int32_t StartupProjectSelectorDialog::getSelectedStartupProjectIndex()
+{
+    auto selectedRows = _hierarchyWidget.getTreeView().selectionModel()->selectedRows();
+
+    if (selectedRows.isEmpty())
+        return -1;
+
+    return selectedRows.first().row();
+}

--- a/ManiVault/src/private/StartupProjectSelectorDialog.h
+++ b/ManiVault/src/private/StartupProjectSelectorDialog.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#pragma once
+
+#include "StartupProjectsModel.h"
+#include "StartupProjectsFilterModel.h"
+
+#include <ProjectMetaAction.h>
+
+#include <widgets/HierarchyWidget.h>
+
+#include <actions/TriggerAction.h>
+
+#include <QDialog>
+
+/**
+ * Startup project selector dialog class
+ * 
+ * Dialog class for selecting a project out of two or more startup projects
+ * 
+ * @author Thomas Kroes
+ */
+class StartupProjectSelectorDialog : public QDialog
+{
+public:
+
+    /**
+     * Construct with \p startupProjectsMetaActions and a pointer to \p parent widget
+     * @param startupProjectsMetaActions Startup projects meta actions
+     * @param parent Pointer to parent widget
+     */
+    StartupProjectSelectorDialog(const QVector<QPair<QSharedPointer<mv::ProjectMetaAction>, QString>>& startupProjectsMetaActions, QWidget* parent = nullptr);
+
+    /** Get preferred size */
+    QSize sizeHint() const override {
+        return QSize(400, 150);
+    }
+
+    /** Get minimum size hint*/
+    QSize minimumSizeHint() const override {
+        return sizeHint();
+    }
+
+    /**
+     * Get index of the selected startup project
+     * @return Index of the selected startup project (-1 if no selection)
+     */
+    std::int32_t getSelectedStartupProjectIndex();
+
+private:
+    StartupProjectsModel        _model;                 /** Plugins tree model (interfaces with a plugin manager) */
+    StartupProjectsFilterModel  _filterModel;           /** Sorting and filtering model for the plugin manager model */
+    mv::gui::HierarchyWidget    _hierarchyWidget;       /** Widget for displaying the loaded plugins */
+    mv::gui::TriggerAction      _loadAction;            /** Load the selected project */
+    mv::gui::TriggerAction      _cancelAction;          /** Exit the dialog and don't load a project */
+};

--- a/ManiVault/src/private/StartupProjectsFilterModel.cpp
+++ b/ManiVault/src/private/StartupProjectsFilterModel.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#include "StartupProjectsFilterModel.h"
+
+#include <QDebug>
+
+#ifdef _DEBUG
+    #define STARTUP_PROJECTS_FILTER_MODEL_VERBOSE
+#endif
+

--- a/ManiVault/src/private/StartupProjectsFilterModel.h
+++ b/ManiVault/src/private/StartupProjectsFilterModel.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#pragma once
+
+#include <models/SortFilterProxyModel.h>
+
+/**
+ * Plugin filter model class
+ *
+ * Sorting and filtering model for plugins models
+ *
+ * @author Thomas Kroes
+ */
+class StartupProjectsFilterModel : public mv::SortFilterProxyModel
+{
+public:
+
+    /** No need for custom constructor (yet) */
+    using mv::SortFilterProxyModel::SortFilterProxyModel;
+};

--- a/ManiVault/src/private/StartupProjectsModel.cpp
+++ b/ManiVault/src/private/StartupProjectsModel.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#include "StartupProjectsModel.h"
+
+#include <util/Icon.h>
+
+#ifdef _DEBUG
+    #define STARTUP_PROJECTS_MODEL_VERBOSE
+#endif
+
+using namespace mv;
+using namespace mv::gui;
+
+StartupProjectsModel::StartupProjectsModel(QObject* parent /*= nullptr*/) :
+    StandardItemModel(parent)
+{
+    setColumnCount(static_cast<int>(Column::Count));
+}
+
+QVariant StartupProjectsModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    switch (static_cast<Column>(section))
+    {
+        case Column::FileName:
+            return FileNameItem::headerData(orientation, role);
+
+        case Column::Title:
+            return TitleItem::headerData(orientation, role);
+
+        case Column::Description:
+            return DescriptionItem::headerData(orientation, role);
+
+        default:
+            break;
+    }
+
+    return {};
+}
+
+void StartupProjectsModel::initialize(const QVector<QPair<QSharedPointer<mv::ProjectMetaAction>, QString>>& startupProjectsMetaActions)
+{
+    for (const auto& startupProjectMetaAction : startupProjectsMetaActions)
+    {
+        auto icon             = startupProjectMetaAction.first->getApplicationIconAction().getIconPickerAction().getIcon();
+        auto fileName  = QFileInfo(startupProjectMetaAction.second).baseName();
+        auto title     = startupProjectMetaAction.first->getTitleAction().getString();
+        auto description= startupProjectMetaAction.first->getDescriptionAction().getString();
+
+        if (title.isEmpty())
+            title = "NA";
+
+        if (description.isEmpty())
+            description = "NA";
+
+        appendRow(Row(icon.isNull() ? createIcon(QPixmap(":/Icons/AppIcon256")) : icon, fileName, title, description));
+    }
+}

--- a/ManiVault/src/private/StartupProjectsModel.h
+++ b/ManiVault/src/private/StartupProjectsModel.h
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#pragma once
+
+#include <models/StandardItemModel.h>
+
+#include <QList>
+#include <QStandardItem>
+
+/**
+ * Startup projects model class
+ *
+ * Standard item model class for storing startup projects
+ *
+ * @author Thomas Kroes
+ */
+class StartupProjectsModel : public mv::StandardItemModel
+{
+public:
+
+    /** Model columns */
+    enum class Column {
+        FileName,       /** File name of the project */
+        Title,          /** Tile of the project */
+        Description,    /** Description of the project */
+
+        Count
+    };
+
+    /** Standard model item class for displaying the startup project file name */
+    class FileNameItem final : public QStandardItem {
+    public:
+
+        /** No need for specialized constructor */
+        using QStandardItem::QStandardItem;
+
+        /**
+         * Get header data for \p orientation and \p role
+         * @param orientation Horizontal/vertical
+         * @param role Data role
+         * @return Header data
+         */
+        static QVariant headerData(Qt::Orientation orientation, int role) {
+            switch (role) {
+                case Qt::DisplayRole:
+                case Qt::EditRole:
+                    return "File name";
+
+                case Qt::ToolTipRole:
+                    return "Startup project file name";
+            }
+
+            return {};
+        }
+    };
+
+    /** Standard model item class for displaying the startup project title */
+    class TitleItem final : public QStandardItem {
+    public:
+
+        /** No need for specialized constructor */
+        using QStandardItem::QStandardItem;
+
+        /**
+         * Get header data for \p orientation and \p role
+         * @param orientation Horizontal/vertical
+         * @param role Data role
+         * @return Header data
+         */
+        static QVariant headerData(Qt::Orientation orientation, int role) {
+            switch (role) {
+                case Qt::DisplayRole:
+                case Qt::EditRole:
+                    return "Title";
+
+                case Qt::ToolTipRole:
+                    return "Startup project title";
+            }
+
+            return {};
+        }
+    };
+
+    /** Standard model item class for displaying the startup project description */
+    class DescriptionItem final : public QStandardItem {
+    public:
+
+        /** No need for specialized constructor */
+        using QStandardItem::QStandardItem;
+
+        /**
+         * Get header data for \p orientation and \p role
+         * @param orientation Horizontal/vertical
+         * @param role Data role
+         * @return Header data
+         */
+        static QVariant headerData(Qt::Orientation orientation, int role) {
+            switch (role) {
+                case Qt::DisplayRole:
+                case Qt::EditRole:
+                    return "Description";
+
+                case Qt::ToolTipRole:
+                    return "Startup project description";
+            }
+
+            return {};
+        }
+    };
+
+protected:
+
+    /** Convenience class for combining items in a row */
+    class Row final : public QList<QStandardItem*>
+    {
+    public:
+
+        /**
+         * Construct with \p icon, \p title and \p description
+         * @param icon Project icon
+         * @param fileName Project file name
+         * @param title Project title
+         * @param description Project description
+         */
+        Row(const QIcon icon, const QString& fileName, const QString& title, const QString& description) : QList<QStandardItem*>()
+        {
+            auto fileNameItem       = new FileNameItem(fileName);
+            auto titleItem          = new TitleItem(title);
+            auto descriptionItem    = new DescriptionItem(description);
+
+#ifdef _DEBUG
+            fileNameItem->setIcon(icon);
+#else
+            titleItem->setIcon(icon);
+#endif
+
+            append(fileNameItem);
+            append(titleItem);
+            append(descriptionItem);
+        }
+    };
+
+public:
+
+    /**
+     * Construct startup projects model with pointer to \p parent object
+     * @param parent Pointer to parent object
+     */
+    StartupProjectsModel(QObject* parent = nullptr);
+
+    /**
+     * Get header data for \p section, \p orientation and display \p role
+     * @param section Section
+     * @param orientation Orientation
+     * @param role Data role
+     * @return Header
+     */
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+
+    /**
+     * Initialize the model from \p startupProjectsMetaActions
+     * @param startupProjectsMetaActions Startup projects meta actions
+     */
+    void initialize(const QVector<QPair<QSharedPointer<mv::ProjectMetaAction>, QString>>& startupProjectsMetaActions);
+};


### PR DESCRIPTION
- [X] Extends the `ManiVaultStudio.exe -p` option also to accept more than one project file path ("file_path_a, file_path_b")
- [x] When the number of valid startup projects exceeds one, a project selector interface is shown from which the user can select the desired project
- [x] Behavior is unmodified for single startup projects

![image](https://github.com/user-attachments/assets/9625ae43-44cb-4768-93e2-bcf1e9b0f162)