### PR TITLE
Edit status bar configuration

### DIFF
--- a/ManiVault/src/Application.cpp
+++ b/ManiVault/src/Application.cpp
@@ -6,7 +6,6 @@
 #include "CoreInterface.h"
 #include "BackgroundTask.h"
 #include "ForegroundTask.h"
-#include "AbstractManager.h"
 #include "ManiVaultVersion.h"
 
 #include "util/IconFonts.h"
@@ -14,11 +13,11 @@
 #include "util/Exception.h"
 
 #include "actions/WidgetAction.h"
+#include "actions/StatusBarAction.h"
 
 #include <stdexcept>
 
 #include <QDebug>
-#include <QMessageBox>
 #include <QMainWindow>
 #include <QUuid>
 #include <QDir>

--- a/ManiVault/src/Application.h
+++ b/ManiVault/src/Application.h
@@ -11,6 +11,7 @@
 #include "util/Version.h"
 
 #include "actions/TriggerAction.h"
+#include "actions/OptionsAction.h"
 
 #include "ApplicationStartupTask.h"
 

--- a/ManiVault/src/MiscellaneousSettingsAction.cpp
+++ b/ManiVault/src/MiscellaneousSettingsAction.cpp
@@ -15,23 +15,10 @@ MiscellaneousSettingsAction::MiscellaneousSettingsAction(QObject* parent) :
     _askConfirmationBeforeRemovingDatasetsAction(this, "Ask confirmation before removing datasets", true),
     _keepDescendantsAfterRemovalAction(this, "Keep descendants after removal", true),
     _showSimplifiedGuidsAction(this, "Show simplified GUID's", true),
-    _showStatusBarAction(this, "Show status bar", true),
-    _statusBarOptionsAction(this, "Status bar options"),
-    _statusBarSettingsGroupAction(this, "Status bar settings group")
+    _statusBarVisibleAction(this, "Show status bar", true),
+    _statusBarOptionsAction(this, "Status bar options")
 {
-    setShowLabels(false);
-
-    updateStatusBarOptionsAction();
-
-    _showStatusBarAction.setSettingsPrefix(QString("%1StatusBar/Show").arg(getSettingsPrefix()));
-    _statusBarOptionsAction.setSettingsPrefix(QString("%1StatusBar/Options").arg(getSettingsPrefix()));
-
     _statusBarOptionsAction.setDefaultWidgetFlag(OptionsAction::WidgetFlag::Selection);
-
-    _statusBarSettingsGroupAction.setShowLabels(false);
-
-    _statusBarSettingsGroupAction.addAction(&_showStatusBarAction);
-    _statusBarSettingsGroupAction.addAction(&_statusBarOptionsAction);
 
     _askConfirmationBeforeRemovingDatasetsAction.setToolTip("Ask confirmation prior to removal of datasets");
     _keepDescendantsAfterRemovalAction.setToolTip("If checked, descendants will not be removed and become orphans (placed at the root of the hierarchy)");
@@ -40,21 +27,23 @@ MiscellaneousSettingsAction::MiscellaneousSettingsAction(QObject* parent) :
     addAction(&_ignoreLoadingErrorsAction);
     addAction(&_askConfirmationBeforeRemovingDatasetsAction);
     addAction(&_keepDescendantsAfterRemovalAction);
-    addAction(&_statusBarSettingsGroupAction);
+    addAction(&_statusBarVisibleAction);
+    addAction(&_statusBarOptionsAction);
 }
 
 void MiscellaneousSettingsAction::updateStatusBarOptionsAction()
 {
-    QStringList statusBarOptions, selectedStatusBarOptions;
+    const auto previousStatusBarOptions = _statusBarOptionsAction.getOptions();
 
-    for (const auto statusBarAction : StatusBarAction::getStatusBarActions()) {
+    QStringList statusBarOptions;
+
+    for (const auto statusBarAction : StatusBarAction::getStatusBarActions())
         statusBarOptions << statusBarAction->text();
 
-        if (statusBarAction->isVisible())
-            selectedStatusBarOptions << statusBarAction->text();
-    }
+    for (const auto statusBarAction : StatusBarAction::getStatusBarActions())
+        qDebug() << statusBarAction->text() << statusBarAction->isVisible();
 
     _statusBarOptionsAction.setOptions(statusBarOptions);
-    _statusBarOptionsAction.setSelectedOptions(selectedStatusBarOptions);
 }
+
 }

--- a/ManiVault/src/MiscellaneousSettingsAction.cpp
+++ b/ManiVault/src/MiscellaneousSettingsAction.cpp
@@ -40,9 +40,6 @@ void MiscellaneousSettingsAction::updateStatusBarOptionsAction()
     for (const auto statusBarAction : StatusBarAction::getStatusBarActions())
         statusBarOptions << statusBarAction->text();
 
-    for (const auto statusBarAction : StatusBarAction::getStatusBarActions())
-        qDebug() << statusBarAction->text() << statusBarAction->isVisible();
-
     _statusBarOptionsAction.setOptions(statusBarOptions);
 }
 

--- a/ManiVault/src/MiscellaneousSettingsAction.cpp
+++ b/ManiVault/src/MiscellaneousSettingsAction.cpp
@@ -1,9 +1,10 @@
+
 // SPDX-License-Identifier: LGPL-3.0-or-later 
 // A corresponding LICENSE file is located in the root directory of this source tree 
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "MiscellaneousSettingsAction.h"
-#include "Application.h"
+#include "actions/StatusBarAction.h"
 
 namespace mv::gui
 {
@@ -13,18 +14,47 @@ MiscellaneousSettingsAction::MiscellaneousSettingsAction(QObject* parent) :
     _ignoreLoadingErrorsAction(this, "Ignore loading errors", true),
     _askConfirmationBeforeRemovingDatasetsAction(this, "Ask confirmation before removing datasets", true),
     _keepDescendantsAfterRemovalAction(this, "Keep descendants after removal", true),
-    _showSimplifiedGuidsAction(this, "Show simplified GUID's", true)
+    _showSimplifiedGuidsAction(this, "Show simplified GUID's", true),
+    _showStatusBarAction(this, "Show status bar", true),
+    _statusBarOptionsAction(this, "Status bar options"),
+    _statusBarSettingsGroupAction(this, "Status bar settings group")
 {
     setShowLabels(false);
 
-    addAction(&_ignoreLoadingErrorsAction);
-    addAction(&_askConfirmationBeforeRemovingDatasetsAction);
-    addAction(&_keepDescendantsAfterRemovalAction);
-    addAction(&_showSimplifiedGuidsAction);
+    updateStatusBarOptionsAction();
+
+    _showStatusBarAction.setSettingsPrefix(QString("%1StatusBar/Show").arg(getSettingsPrefix()));
+    _statusBarOptionsAction.setSettingsPrefix(QString("%1StatusBar/Options").arg(getSettingsPrefix()));
+
+    _statusBarOptionsAction.setDefaultWidgetFlag(OptionsAction::WidgetFlag::Selection);
+
+    _statusBarSettingsGroupAction.setShowLabels(false);
+
+    _statusBarSettingsGroupAction.addAction(&_showStatusBarAction);
+    _statusBarSettingsGroupAction.addAction(&_statusBarOptionsAction);
 
     _askConfirmationBeforeRemovingDatasetsAction.setToolTip("Ask confirmation prior to removal of datasets");
     _keepDescendantsAfterRemovalAction.setToolTip("If checked, descendants will not be removed and become orphans (placed at the root of the hierarchy)");
     _showSimplifiedGuidsAction.setToolTip("If checked, views will show a truncated version of a globally unique identifier");
+
+    addAction(&_ignoreLoadingErrorsAction);
+    addAction(&_askConfirmationBeforeRemovingDatasetsAction);
+    addAction(&_keepDescendantsAfterRemovalAction);
+    addAction(&_statusBarSettingsGroupAction);
 }
 
+void MiscellaneousSettingsAction::updateStatusBarOptionsAction()
+{
+    QStringList statusBarOptions, selectedStatusBarOptions;
+
+    for (const auto statusBarAction : StatusBarAction::getStatusBarActions()) {
+        statusBarOptions << statusBarAction->text();
+
+        if (statusBarAction->isVisible())
+            selectedStatusBarOptions << statusBarAction->text();
+    }
+
+    _statusBarOptionsAction.setOptions(statusBarOptions);
+    _statusBarOptionsAction.setSelectedOptions(selectedStatusBarOptions);
+}
 }

--- a/ManiVault/src/MiscellaneousSettingsAction.cpp
+++ b/ManiVault/src/MiscellaneousSettingsAction.cpp
@@ -24,6 +24,14 @@ MiscellaneousSettingsAction::MiscellaneousSettingsAction(QObject* parent) :
     _keepDescendantsAfterRemovalAction.setToolTip("If checked, descendants will not be removed and become orphans (placed at the root of the hierarchy)");
     _showSimplifiedGuidsAction.setToolTip("If checked, views will show a truncated version of a globally unique identifier");
 
+    const auto updateStatusBarOptionsActionReadOnly = [this]() -> void {
+        _statusBarOptionsAction.setEnabled(_statusBarVisibleAction.isChecked());
+    };
+
+    updateStatusBarOptionsActionReadOnly();
+
+    connect(&_statusBarVisibleAction, &ToggleAction::toggled, updateStatusBarOptionsActionReadOnly);
+
     addAction(&_ignoreLoadingErrorsAction);
     addAction(&_askConfirmationBeforeRemovingDatasetsAction);
     addAction(&_keepDescendantsAfterRemovalAction);

--- a/ManiVault/src/MiscellaneousSettingsAction.h
+++ b/ManiVault/src/MiscellaneousSettingsAction.h
@@ -7,7 +7,7 @@
 #include "GlobalSettingsGroupAction.h"
 
 #include "actions/ToggleAction.h"
-#include "actions/OptionAction.h"
+#include "actions/HorizontalGroupAction.h"
 
 namespace mv::gui
 {
@@ -29,18 +29,27 @@ public:
      */
     MiscellaneousSettingsAction(QObject* parent);
 
+    /** Update status bar options action to reflect the current status bar items */
+    void updateStatusBarOptionsAction();
+
 public: // Action getters
 
     ToggleAction& getIgnoreLoadingErrorsAction() { return _ignoreLoadingErrorsAction; }
     ToggleAction& getAskConfirmationBeforeRemovingDatasetsAction() { return _askConfirmationBeforeRemovingDatasetsAction; }
     ToggleAction& getKeepDescendantsAfterRemovalAction() { return _keepDescendantsAfterRemovalAction; }
     ToggleAction& getShowSimplifiedGuidsAction() { return _showSimplifiedGuidsAction; }
+    ToggleAction& getShowStatusBarAction() { return _showStatusBarAction; }
+    OptionsAction& getStatusBarOptionsAction() { return _statusBarOptionsAction; }
+    HorizontalGroupAction& getStatusBarSettingsGroupAction() { return _statusBarSettingsGroupAction; }
 
 private:
-    ToggleAction   _ignoreLoadingErrorsAction;                     /** Toggle between asking for ignoring loading errors or not */
-    ToggleAction   _askConfirmationBeforeRemovingDatasetsAction;   /** Toggle between asking permission before removing datasets or not */
-    ToggleAction   _keepDescendantsAfterRemovalAction;             /** Toggle between asking permission before removing datasets or not */
-    ToggleAction   _showSimplifiedGuidsAction;                      /** Toggle between asking permission before removing datasets or not */
+    ToggleAction            _ignoreLoadingErrorsAction;                     /** Toggle between asking for ignoring loading errors or not */
+    ToggleAction            _askConfirmationBeforeRemovingDatasetsAction;   /** Toggle between asking permission before removing datasets or not */
+    ToggleAction            _keepDescendantsAfterRemovalAction;             /** Toggle between asking permission before removing datasets or not */
+    ToggleAction            _showSimplifiedGuidsAction;                     /** Toggle between asking permission before removing datasets or not */
+    ToggleAction            _showStatusBarAction;                           /** Action for toggling the status bar visibility */
+    OptionsAction           _statusBarOptionsAction;                        /** Options action for toggling status bar items on/off */
+    HorizontalGroupAction   _statusBarSettingsGroupAction;                  /** For grouping together the former two actions */
 };
 
 }

--- a/ManiVault/src/MiscellaneousSettingsAction.h
+++ b/ManiVault/src/MiscellaneousSettingsAction.h
@@ -7,7 +7,6 @@
 #include "GlobalSettingsGroupAction.h"
 
 #include "actions/ToggleAction.h"
-#include "actions/HorizontalGroupAction.h"
 
 namespace mv::gui
 {
@@ -38,18 +37,16 @@ public: // Action getters
     ToggleAction& getAskConfirmationBeforeRemovingDatasetsAction() { return _askConfirmationBeforeRemovingDatasetsAction; }
     ToggleAction& getKeepDescendantsAfterRemovalAction() { return _keepDescendantsAfterRemovalAction; }
     ToggleAction& getShowSimplifiedGuidsAction() { return _showSimplifiedGuidsAction; }
-    ToggleAction& getShowStatusBarAction() { return _showStatusBarAction; }
+    ToggleAction& getStatusBarVisibleAction() { return _statusBarVisibleAction; }
     OptionsAction& getStatusBarOptionsAction() { return _statusBarOptionsAction; }
-    HorizontalGroupAction& getStatusBarSettingsGroupAction() { return _statusBarSettingsGroupAction; }
 
 private:
     ToggleAction            _ignoreLoadingErrorsAction;                     /** Toggle between asking for ignoring loading errors or not */
     ToggleAction            _askConfirmationBeforeRemovingDatasetsAction;   /** Toggle between asking permission before removing datasets or not */
-    ToggleAction            _keepDescendantsAfterRemovalAction;             /** Toggle between asking permission before removing datasets or not */
-    ToggleAction            _showSimplifiedGuidsAction;                     /** Toggle between asking permission before removing datasets or not */
-    ToggleAction            _showStatusBarAction;                           /** Action for toggling the status bar visibility */
+    ToggleAction            _keepDescendantsAfterRemovalAction;             /** Toggle keep descendants when removing parent dataset or not */
+    ToggleAction            _showSimplifiedGuidsAction;                     /** Toggle between showing long or short GUIDS */
+    ToggleAction            _statusBarVisibleAction;                        /** Action for toggling the status bar visibility */
     OptionsAction           _statusBarOptionsAction;                        /** Options action for toggling status bar items on/off */
-    HorizontalGroupAction   _statusBarSettingsGroupAction;                  /** For grouping together the former two actions */
 };
 
 }

--- a/ManiVault/src/Project.cpp
+++ b/ManiVault/src/Project.cpp
@@ -22,7 +22,7 @@ Project::Project(QObject* parent /*= nullptr*/) :
     _applicationVersion(Application::current()->getVersion()),
     _projectMetaAction(this),
     _selectionGroupingAction(this, "Selection grouping"),
-    _overrideApplicationStatusBarAction(this, "Override application status bar"),
+    _overrideApplicationStatusBarAction(this, "Override studio status bar"),
     _statusBarVisibleAction(this, "Show status bar"),
     _statusBarOptionsAction(this, "Status bar items")
 {

--- a/ManiVault/src/Project.cpp
+++ b/ManiVault/src/Project.cpp
@@ -23,17 +23,45 @@ Project::Project(QObject* parent /*= nullptr*/) :
     _projectMetaAction(this),
     _selectionGroupingAction(this, "Selection grouping"),
     _overrideApplicationStatusBarAction(this, "Override application status bar"),
-    _statusBarOptionsAction(this, "Status bar items"),
-    _statusBarSettingsGroupAction(this, "Status bar settings group")
+    _statusBarVisibleAction(this, "Show status bar"),
+    _statusBarOptionsAction(this, "Status bar items")
 {
     initialize();
 
-    _statusBarSettingsGroupAction.addAction(&_overrideApplicationStatusBarAction);
-    _statusBarSettingsGroupAction.addAction(&_statusBarOptionsAction);
+    const auto initStatusBarOptionsAction = [this]() -> void {
+        const auto& appStatusBarOptionsAction = mv::settings().getMiscellaneousSettings().getStatusBarOptionsAction();
 
-    //connect(&Application::current()->getStatusBarOptionsAction(), &OptionsAction::optionsChanged, [this](const QStringList& options) -> void {
-    //    _statusBarOptionsAction.setOptions(options);
-    //    });
+        _statusBarOptionsAction.setOptions(mv::settings().getMiscellaneousSettings().getStatusBarOptionsAction().getOptions());
+    };
+
+    initStatusBarOptionsAction();
+
+    connect(&mv::settings().getMiscellaneousSettings().getStatusBarOptionsAction(), &OptionsAction::optionsChanged, initStatusBarOptionsAction);
+
+    /*
+    const auto updateStatusBarActionsReadOnly = [this]() -> void {
+        const auto overrideApplicationStatusBar = _overrideApplicationStatusBarAction.isChecked();
+
+        _statusBarVisibleAction.setEnabled(overrideApplicationStatusBar);
+        _statusBarOptionsAction.setEnabled(overrideApplicationStatusBar);
+    };
+
+    updateStatusBarActionsReadOnly();
+
+    connect(&_overrideApplicationStatusBarAction, &ToggleAction::toggled, updateStatusBarActionsReadOnly);
+
+    
+
+    connect(&_statusBarOptionsAction, &OptionsAction::selectedOptionsChanged, [this](const QStringList& selectedOptions) -> void {
+        if (_overrideApplicationStatusBarAction.isChecked())
+            mv::settings().getMiscellaneousSettings().getStatusBarOptionsAction().setSelectedOptions(selectedOptions);
+    });
+
+    connect(&_statusBarVisibleAction, &ToggleAction::toggled, [this](bool toggled) -> void {
+        if (_overrideApplicationStatusBarAction.isChecked())
+            mv::settings().getMiscellaneousSettings().getStatusBarVisibleAction().setChecked(toggled);
+    });
+    */
 }
 
 Project::Project(const QString& filePath, QObject* parent /*= nullptr*/) :
@@ -114,6 +142,10 @@ void Project::fromVariantMap(const QVariantMap& variantMap)
     else
         _selectionGroupingAction.setChecked(true);
 
+    _overrideApplicationStatusBarAction.fromParentVariantMap(variantMap);
+    _statusBarVisibleAction.fromParentVariantMap(variantMap);
+    _statusBarOptionsAction.fromParentVariantMap(variantMap);
+
     dataHierarchy().fromParentVariantMap(variantMap);
     actions().fromParentVariantMap(variantMap);
     plugins().fromParentVariantMap(variantMap);
@@ -139,6 +171,10 @@ QVariantMap Project::toVariantMap() const
     _projectMetaAction.getApplicationIconAction().insertIntoVariantMap(variantMap);
 
     _selectionGroupingAction.insertIntoVariantMap(variantMap);
+
+    _overrideApplicationStatusBarAction.insertIntoVariantMap(variantMap);
+    _statusBarVisibleAction.insertIntoVariantMap(variantMap);
+    _statusBarOptionsAction.insertIntoVariantMap(variantMap);
 
     plugins().insertIntoVariantMap(variantMap);
     dataHierarchy().insertIntoVariantMap(variantMap);

--- a/ManiVault/src/Project.cpp
+++ b/ManiVault/src/Project.cpp
@@ -38,30 +38,16 @@ Project::Project(QObject* parent /*= nullptr*/) :
 
     connect(&mv::settings().getMiscellaneousSettings().getStatusBarOptionsAction(), &OptionsAction::optionsChanged, initStatusBarOptionsAction);
 
-    /*
-    const auto updateStatusBarActionsReadOnly = [this]() -> void {
+    const auto updateStatusBarActions = [this]() -> void {
         const auto overrideApplicationStatusBar = _overrideApplicationStatusBarAction.isChecked();
 
         _statusBarVisibleAction.setEnabled(overrideApplicationStatusBar);
         _statusBarOptionsAction.setEnabled(overrideApplicationStatusBar);
     };
 
-    updateStatusBarActionsReadOnly();
+    updateStatusBarActions();
 
-    connect(&_overrideApplicationStatusBarAction, &ToggleAction::toggled, updateStatusBarActionsReadOnly);
-
-    
-
-    connect(&_statusBarOptionsAction, &OptionsAction::selectedOptionsChanged, [this](const QStringList& selectedOptions) -> void {
-        if (_overrideApplicationStatusBarAction.isChecked())
-            mv::settings().getMiscellaneousSettings().getStatusBarOptionsAction().setSelectedOptions(selectedOptions);
-    });
-
-    connect(&_statusBarVisibleAction, &ToggleAction::toggled, [this](bool toggled) -> void {
-        if (_overrideApplicationStatusBarAction.isChecked())
-            mv::settings().getMiscellaneousSettings().getStatusBarVisibleAction().setChecked(toggled);
-    });
-    */
+    connect(&_overrideApplicationStatusBarAction, &ToggleAction::toggled, updateStatusBarActions);
 }
 
 Project::Project(const QString& filePath, QObject* parent /*= nullptr*/) :

--- a/ManiVault/src/Project.cpp
+++ b/ManiVault/src/Project.cpp
@@ -21,9 +21,19 @@ Project::Project(QObject* parent /*= nullptr*/) :
     _startupProject(false),
     _applicationVersion(Application::current()->getVersion()),
     _projectMetaAction(this),
-    _selectionGroupingAction(this, "Selection grouping")
+    _selectionGroupingAction(this, "Selection grouping"),
+    _overrideApplicationStatusBarAction(this, "Override application status bar"),
+    _statusBarOptionsAction(this, "Status bar items"),
+    _statusBarSettingsGroupAction(this, "Status bar settings group")
 {
     initialize();
+
+    _statusBarSettingsGroupAction.addAction(&_overrideApplicationStatusBarAction);
+    _statusBarSettingsGroupAction.addAction(&_statusBarOptionsAction);
+
+    //connect(&Application::current()->getStatusBarOptionsAction(), &OptionsAction::optionsChanged, [this](const QStringList& options) -> void {
+    //    _statusBarOptionsAction.setOptions(options);
+    //    });
 }
 
 Project::Project(const QString& filePath, QObject* parent /*= nullptr*/) :

--- a/ManiVault/src/Project.h
+++ b/ManiVault/src/Project.h
@@ -11,6 +11,8 @@
 #include "actions/StringAction.h"
 #include "actions/StringsAction.h"
 #include "actions/VersionAction.h"
+#include "actions/OptionsAction.h"
+#include "actions/HorizontalGroupAction.h"
 
 #include "ProjectMetaAction.h"
 
@@ -127,6 +129,9 @@ public: // Project meta action getters facade
     const gui::ToggleAction& getStudioModeAction() const { return _projectMetaAction.getStudioModeAction(); }
     const gui::ApplicationIconAction& getApplicationIconAction() const { return _projectMetaAction.getApplicationIconAction(); }
     const gui::ToggleAction& getSelectionGroupingAction() const { return _selectionGroupingAction; }
+    const gui::ToggleAction& getOverrideApplicationStatusBarAction() const { return _overrideApplicationStatusBarAction; }
+    const gui::OptionsAction& getStatusBarOptionsAction() const { return _statusBarOptionsAction; }
+    const gui::HorizontalGroupAction& getStatusBarSettingsGroupAction() const { return _statusBarSettingsGroupAction; }
 
     gui::VersionAction& getApplicationVersionAction() { return _projectMetaAction.getApplicationVersionAction(); }
     gui::VersionAction& getProjectVersionAction() { return _projectMetaAction.getProjectVersionAction(); }
@@ -141,6 +146,9 @@ public: // Project meta action getters facade
     gui::ToggleAction& getStudioModeAction() { return _projectMetaAction.getStudioModeAction(); }
     gui::ApplicationIconAction& getApplicationIconAction() { return _projectMetaAction.getApplicationIconAction(); }
     gui::ToggleAction& getSelectionGroupingAction() { return _selectionGroupingAction; }
+    gui::ToggleAction& getOverrideApplicationStatusBarAction() { return _overrideApplicationStatusBarAction; }
+    gui::OptionsAction& getStatusBarOptionsAction() { return _statusBarOptionsAction; }
+    gui::HorizontalGroupAction& getStatusBarSettingsGroupAction() { return _statusBarSettingsGroupAction; }
 
 signals:
 
@@ -151,11 +159,14 @@ signals:
     void filePathChanged(const QString& filePath);
 
 private:
-    QString             _filePath;                  /** Location on disk where the project resides */
-    bool                _startupProject;            /** Boolean determining whether this project is loaded at startup of ManiVault */
-    util::Version       _applicationVersion;        /** Version of the application with which the project is created */
-    ProjectMetaAction   _projectMetaAction;         /** Project meta info action (i.e. title and version) */
-    gui::ToggleAction   _selectionGroupingAction;   /** Action for toggling whether dataset selection grouping is enabled or not */
+    QString                     _filePath;                              /** Location on disk where the project resides */
+    bool                        _startupProject;                        /** Boolean determining whether this project is loaded at startup of ManiVault */
+    util::Version               _applicationVersion;                    /** Version of the application with which the project is created */
+    ProjectMetaAction           _projectMetaAction;                     /** Project meta info action (i.e. title and version) */
+    gui::ToggleAction           _selectionGroupingAction;               /** Action for toggling whether dataset selection grouping is enabled or not */
+    gui::ToggleAction           _overrideApplicationStatusBarAction;    /** Action for toggling whether the project inherits the status bar settings from the application or not */
+    gui::OptionsAction          _statusBarOptionsAction;                /** Options action for toggling status bar items on/off */
+    gui::HorizontalGroupAction  _statusBarSettingsGroupAction;          /** For grouping together the former two actions */
 
 protected:
     static constexpr bool           DEFAULT_ENABLE_COMPRESSION  = false;    /** No compression by default */

--- a/ManiVault/src/Project.h
+++ b/ManiVault/src/Project.h
@@ -130,8 +130,8 @@ public: // Project meta action getters facade
     const gui::ApplicationIconAction& getApplicationIconAction() const { return _projectMetaAction.getApplicationIconAction(); }
     const gui::ToggleAction& getSelectionGroupingAction() const { return _selectionGroupingAction; }
     const gui::ToggleAction& getOverrideApplicationStatusBarAction() const { return _overrideApplicationStatusBarAction; }
+    const gui::ToggleAction& getStatusBarVisibleAction() const { return _statusBarVisibleAction; }
     const gui::OptionsAction& getStatusBarOptionsAction() const { return _statusBarOptionsAction; }
-    const gui::HorizontalGroupAction& getStatusBarSettingsGroupAction() const { return _statusBarSettingsGroupAction; }
 
     gui::VersionAction& getApplicationVersionAction() { return _projectMetaAction.getApplicationVersionAction(); }
     gui::VersionAction& getProjectVersionAction() { return _projectMetaAction.getProjectVersionAction(); }
@@ -147,8 +147,8 @@ public: // Project meta action getters facade
     gui::ApplicationIconAction& getApplicationIconAction() { return _projectMetaAction.getApplicationIconAction(); }
     gui::ToggleAction& getSelectionGroupingAction() { return _selectionGroupingAction; }
     gui::ToggleAction& getOverrideApplicationStatusBarAction() { return _overrideApplicationStatusBarAction; }
+    gui::ToggleAction& getStatusBarVisibleAction() { return _statusBarVisibleAction; }
     gui::OptionsAction& getStatusBarOptionsAction() { return _statusBarOptionsAction; }
-    gui::HorizontalGroupAction& getStatusBarSettingsGroupAction() { return _statusBarSettingsGroupAction; }
 
 signals:
 
@@ -165,8 +165,8 @@ private:
     ProjectMetaAction           _projectMetaAction;                     /** Project meta info action (i.e. title and version) */
     gui::ToggleAction           _selectionGroupingAction;               /** Action for toggling whether dataset selection grouping is enabled or not */
     gui::ToggleAction           _overrideApplicationStatusBarAction;    /** Action for toggling whether the project inherits the status bar settings from the application or not */
+    gui::ToggleAction           _statusBarVisibleAction;                /** Action for toggling the status bar visibility */
     gui::OptionsAction          _statusBarOptionsAction;                /** Options action for toggling status bar items on/off */
-    gui::HorizontalGroupAction  _statusBarSettingsGroupAction;          /** For grouping together the former two actions */
 
 protected:
     static constexpr bool           DEFAULT_ENABLE_COMPRESSION  = false;    /** No compression by default */

--- a/ManiVault/src/actions/OptionsAction.cpp
+++ b/ManiVault/src/actions/OptionsAction.cpp
@@ -29,8 +29,11 @@ OptionsAction::OptionsAction(QObject* parent, const QString& title, const QStrin
     setDefaultWidgetFlags(WidgetFlag::Default);
     initialize(options, selectedOptions);
 
-    connect(&_optionsModel, &QAbstractItemModel::dataChanged, this, [this]() -> void {
-        selectedOptionsChanged(getSelectedOptions());
+    connect(&_optionsModel, &QAbstractItemModel::dataChanged, this, [this](const QModelIndex& topLeft, const QModelIndex& bottomRight, const QList<int>& roles) -> void {
+        //if (roles.contains(Qt::CheckStateRole)) {
+            saveToSettings();
+            emit selectedOptionsChanged(getSelectedOptions());
+        //}
     });
 }
 
@@ -72,10 +75,10 @@ bool OptionsAction::hasOptions() const
 
 void OptionsAction::setOptions(const QStringList& options, bool clearSelection /*= false*/)
 {
-    const auto selectedOptions = getSelectedOptions();
-
     _optionsModel.setStrings(options);
-    _optionsModel.setCheckedIndicesFromStrings(selectedOptions);
+
+    if (clearSelection)
+        _optionsModel.setCheckedIndicesFromStrings({});
 
     emit optionsChanged(getOptions());
 }

--- a/ManiVault/src/actions/StatusBarAction.cpp
+++ b/ManiVault/src/actions/StatusBarAction.cpp
@@ -14,6 +14,8 @@
 
 namespace mv::gui {
 
+WidgetActions StatusBarAction::statusBarActions;
+
 StatusBarAction::StatusBarAction(QObject* parent, const QString& title, const QIcon& icon /*= QIcon()*/) :
     WidgetAction(parent, title),
     _barGroupAction(this, "Bar Group"),
@@ -23,11 +25,27 @@ StatusBarAction::StatusBarAction(QObject* parent, const QString& title, const QI
     _index(-1)
 {
     initialize(icon);
+
+    StatusBarAction::statusBarActions << this;
+
+    mv::settings().getMiscellaneousSettings().updateStatusBarOptionsAction();
 }
 
 StatusBarAction::StatusBarAction(QObject* parent, const QString& title, const QString& icon /*= ""*/) :
     StatusBarAction(parent, title, icon.isEmpty() ? QIcon() : Application::getIconFont("FontAwesome").getIcon(icon))
 {
+}
+
+StatusBarAction::~StatusBarAction()
+{
+    StatusBarAction::statusBarActions.removeOne(this);
+
+    mv::settings().getMiscellaneousSettings().updateStatusBarOptionsAction();
+}
+
+WidgetActions StatusBarAction::getStatusBarActions()
+{
+    return statusBarActions;
 }
 
 QWidget* StatusBarAction::getWidget(QWidget* parent, const std::int32_t& widgetFlags)
@@ -168,6 +186,17 @@ void StatusBarAction::initialize(const QIcon& icon)
     tooltipChanged();
 
     connect(this, &WidgetAction::changed, this, tooltipChanged);
+
+    const auto updateStatusBarActionsVisibility = [this]() -> void {
+        const auto selectedOptions = mv::settings().getMiscellaneousSettings().getStatusBarOptionsAction().getSelectedOptions();
+
+        for (auto statusBarAction : StatusBarAction::statusBarActions)
+            statusBarAction->setVisible(selectedOptions.contains(statusBarAction->text()));
+    };
+
+    updateStatusBarActionsVisibility();
+
+    connect(&mv::settings().getMiscellaneousSettings().getStatusBarOptionsAction(), &OptionsAction::selectedOptionsChanged, this, updateStatusBarActionsVisibility);
 }
 
 StatusBarAction::Widget::Widget(QWidget* parent, StatusBarAction* statusBarAction, const std::int32_t& widgetFlags) :

--- a/ManiVault/src/actions/StatusBarAction.cpp
+++ b/ManiVault/src/actions/StatusBarAction.cpp
@@ -28,6 +28,14 @@ StatusBarAction::StatusBarAction(QObject* parent, const QString& title, const QI
 
     StatusBarAction::statusBarActions << this;
 
+    const auto updateVisibility = [this]() -> void {
+        setVisible(mv::settings().getMiscellaneousSettings().getStatusBarOptionsAction().isOptionSelected(text()));
+    };
+
+    updateVisibility();
+
+    connect(&mv::settings().getMiscellaneousSettings().getStatusBarOptionsAction(), &OptionsAction::selectedOptionsChanged, this, updateVisibility);
+
     mv::settings().getMiscellaneousSettings().updateStatusBarOptionsAction();
 }
 

--- a/ManiVault/src/actions/StatusBarAction.h
+++ b/ManiVault/src/actions/StatusBarAction.h
@@ -95,6 +95,15 @@ public:
      */
     StatusBarAction(QObject* parent, const QString& title, const QString& icon = "");
 
+    /** Destructor for removing this action from StatusBarAction#statusBarActions */
+    ~StatusBarAction();
+
+    /**
+     * Get registered status bar action
+     * @return Status bar actions
+     */
+    static WidgetActions getStatusBarActions();
+
 public:
 
     /**
@@ -208,6 +217,8 @@ private:
     WidgetAction*           _popupAction;       /** Pointer to popup action (maybe nullptr) */
     WidgetActions           _menuActions;       /** Menu actions for the popup */
     std::int32_t            _index;             /** Position in the status bar where the action is inserted (zero: append, negative; right-to-left, positive: left-to-right) */
+
+    static WidgetActions statusBarActions;
 
     friend class WidgetActionToolButton;
 };

--- a/ManiVault/src/models/CheckableStringListModel.cpp
+++ b/ManiVault/src/models/CheckableStringListModel.cpp
@@ -52,6 +52,8 @@ void CheckableStringListModel::setStrings(const QStringList& strings)
     _checkStatesList.resize(strings.count());
 
     _strings = strings;
+
+    setCheckedIndicesFromStrings(_checkedStrings);
 }
 
 QStringList CheckableStringListModel::getCheckedStrings() const
@@ -105,7 +107,10 @@ void CheckableStringListModel::setCheckedIndicesSet(const CheckedIndicesSet& che
 
 void CheckableStringListModel::setCheckedIndicesFromStrings(const QStringList& checkedStrings)
 {
+    _checkedStrings = checkedStrings;
+
     const auto checkStatesList = _checkStatesList;
+
     std::fill(_checkStatesList.begin(), _checkStatesList.end(), false);
 
     for (const auto& checkedString : checkedStrings) {
@@ -116,12 +121,9 @@ void CheckableStringListModel::setCheckedIndicesFromStrings(const QStringList& c
 
         _checkStatesList[index] = true;
     }
+
     if (checkStatesList != _checkStatesList)
-    {
         emit dataChanged(index(0, 0), index(rowCount() - 1));
-    }
-
-
 }
 
 void CheckableStringListModel::invertChecks()

--- a/ManiVault/src/models/CheckableStringListModel.h
+++ b/ManiVault/src/models/CheckableStringListModel.h
@@ -27,7 +27,7 @@ public:
 private:
 
     /**
-     * We want to reset our internal CheckableStringListModel#_checkedItems every time the strings are changed.
+     * We want to reset our internal CheckableStringListModel#_checkStatesList every time the strings are changed.
      * We make the CheckableStringListModel::setStringList(...) private and replace it with
      * CheckableStringListModel::setStrings(...) so that we have control over the internals. This also prevents
      * accidental misuse of QStringListModel::setStringList(...), which would lead to problems with checked items.
@@ -104,7 +104,8 @@ public:
     void invertChecks();
 
 private:
-    CheckStatesList _checkStatesList;   /** Keeps track of the selected items */
+    QStringList     _checkedStrings;    /** Keeps track of the selected items by item string */
+    CheckStatesList _checkStatesList;   /** Keeps track of the selected items by item index */
     QStringList     _strings;           /** Model strings */
 };
 

--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -117,7 +117,7 @@ void MainWindow::showEvent(QShowEvent* showEvent)
         statusBar()->insertPermanentWidget(6, settingsTasksStatusBarAction->createWidget(this));
 
         const auto updateStatusBarVisibility = [this]() -> void {
-            statusBar()->setVisible(mv::projects().hasProject() && mv::settings().getMiscellaneousSettings().getShowStatusBarAction().isChecked());
+            statusBar()->setVisible(mv::projects().hasProject() && mv::settings().getMiscellaneousSettings().getStatusBarVisibleAction().isChecked());
         };
 
         const auto getNumberOfPermanentWidgets = [this]() -> std::int32_t {
@@ -203,7 +203,7 @@ void MainWindow::showEvent(QShowEvent* showEvent)
         projectChanged();
         updateStatusBarVisibility();
 
-        connect(&mv::settings().getMiscellaneousSettings().getShowStatusBarAction(), &ToggleAction::toggled, this, updateStatusBarVisibility);
+        connect(&mv::settings().getMiscellaneousSettings().getStatusBarVisibleAction(), &ToggleAction::toggled, this, updateStatusBarVisibility);
     }
 }
 

--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -116,6 +116,10 @@ void MainWindow::showEvent(QShowEvent* showEvent)
         statusBar()->insertPermanentWidget(5, foregroundTasksStatusBarAction->createWidget(this));
         statusBar()->insertPermanentWidget(6, settingsTasksStatusBarAction->createWidget(this));
 
+        const auto updateStatusBarVisibility = [this]() -> void {
+            statusBar()->setVisible(mv::projects().hasProject() && mv::settings().getMiscellaneousSettings().getShowStatusBarAction().isChecked());
+        };
+
         const auto getNumberOfPermanentWidgets = [this]() -> std::int32_t {
             return statusBar()->findChildren<QWidget*>(Qt::FindDirectChildrenOnly).count();
         };
@@ -135,7 +139,7 @@ void MainWindow::showEvent(QShowEvent* showEvent)
             }
         }
 
-        const auto projectChanged = [this]() -> void {
+        const auto projectChanged = [this, updateStatusBarVisibility]() -> void {
             if (!projects().hasProject()) {
                 setWindowTitle("ManiVault");
             }
@@ -152,7 +156,7 @@ void MainWindow::showEvent(QShowEvent* showEvent)
                 }
             }
 
-            statusBar()->setVisible(projects().hasProject());
+            updateStatusBarVisibility();
         };
 
         connect(&projects(), &AbstractProjectManager::projectCreated, this, projectChanged);
@@ -197,6 +201,9 @@ void MainWindow::showEvent(QShowEvent* showEvent)
             projects().openProject(Application::current()->getStartupProjectFilePath());
 
         projectChanged();
+        updateStatusBarVisibility();
+
+        connect(&mv::settings().getMiscellaneousSettings().getShowStatusBarAction(), &ToggleAction::toggled, this, updateStatusBarVisibility);
     }
 }
 

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -484,6 +484,14 @@ void ProjectManager::openProject(QString filePath /*= ""*/, bool importDataOnly 
             if (_project->isStartupProject())
                 ModalTask::getGlobalHandler()->setEnabled(true);
 
+            if (_project->getOverrideApplicationStatusBarAction().isChecked() && _project->getStatusBarVisibleAction().isChecked())
+            {
+                auto& miscellaneousSettings = mv::settings().getMiscellaneousSettings();
+
+                miscellaneousSettings.getStatusBarVisibleAction().setChecked(_project->getStatusBarVisibleAction().isChecked());
+                miscellaneousSettings.getStatusBarOptionsAction().setSelectedOptions(_project->getStatusBarOptionsAction().getSelectedOptions());
+            }
+
             unsetTemporaryDirPath(TemporaryDirType::Open);
 
             qDebug().noquote() << filePath << "loaded successfully";
@@ -760,6 +768,14 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
 
             auto currentProject = getCurrentProject();
 
+            currentProject->getOverrideApplicationStatusBarAction().cacheState();
+            currentProject->getStatusBarVisibleAction().cacheState();
+            currentProject->getStatusBarOptionsAction().cacheState();
+
+            currentProject->getOverrideApplicationStatusBarAction().setChecked(true);
+            currentProject->getStatusBarVisibleAction().setChecked(true);
+            currentProject->getStatusBarOptionsAction().setSelectedOptions({ "Logging", "Background Tasks", "Foreground Tasks" });
+
             ToggleAction    passwordProtectedAction(this, "Password Protected");
             StringAction    passwordAction(this, "Password");
 
@@ -829,6 +845,9 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
                     settingsGroupAction.addAction(&currentProject->getTagsAction());
                     settingsGroupAction.addAction(&currentProject->getCommentsAction());
                     settingsGroupAction.addAction(&currentProject->getSplashScreenAction());
+                    settingsGroupAction.addAction(&currentProject->getOverrideApplicationStatusBarAction());
+                    settingsGroupAction.addAction(&currentProject->getStatusBarVisibleAction());
+                    settingsGroupAction.addAction(&currentProject->getStatusBarOptionsAction());
 
                     auto titleLayout = new QHBoxLayout();
 
@@ -895,6 +914,10 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
                 splashScreenEnabledAction.restoreState();
             }
             workspaceLockingAction.setLocked(cacheWorkspaceLocked);
+
+            currentProject->getOverrideApplicationStatusBarAction().restoreState();
+            currentProject->getStatusBarVisibleAction().restoreState();
+            currentProject->getStatusBarOptionsAction().restoreState();
 
             unsetTemporaryDirPath(TemporaryDirType::Publish);
         }

--- a/ManiVault/src/private/ProjectSettingsDialog.cpp
+++ b/ManiVault/src/private/ProjectSettingsDialog.cpp
@@ -39,6 +39,9 @@ ProjectSettingsDialog::ProjectSettingsDialog(QWidget* parent /*= nullptr*/) :
     _groupAction.addAction(&project->getTagsAction());
     _groupAction.addAction(&project->getCommentsAction());
     _groupAction.addAction(&project->getContributorsAction());
+    //_groupAction.addAction(&project->getOverrideApplicationStatusBarAction());
+    //_groupAction.addAction(&project->getStatusBarVisibleAction());
+    //_groupAction.addAction(&project->getStatusBarOptionsAction());
     _groupAction.addAction(&project->getSplashScreenAction());
     _groupAction.addAction(&project->getStudioModeAction());
     _groupAction.addAction(&workspaces().getLockingAction().getLockedAction());


### PR DESCRIPTION
# Main contribution
The primary contribution of this PR is the customizability of the `ManiVault` status bar at a global `application` level and a `published application` level.

## Application
The global status bar settings can be edited in the `miscellaneous` section of the `settings` window:
![image](https://github.com/user-attachments/assets/8151b833-e031-4d65-a67d-1b1d40175d4b)
The status bar `visibility` and its individual `components` can be toggled.

## Published application
The status bar configuration can be customized for published applications in the `publish` dialog:
![image](https://github.com/user-attachments/assets/7f50d9e2-fe5b-408e-b35e-a53ab97790d2)
First, either the `studio` status bar settings can be used or these can be overridden (`Override studio status bar`). If the `studio` status bar settings are overridden, two other options can be edited:
- The status bar visibility can be toggled on/off
- The visibility of individual status bar items can be toggled on/off (by default, `logging`, `background tasks` and `foreground tasks` items are visible).

## Small technical contributions
- [x] Some minor code tweaks
- [x] Removed some unnecessary includes

## Bug fixes
- [x] `OptionsAction` [selected options were not properly retained with global settings](https://github.com/ManiVaultStudio/core/issues/646), this is fixed now