### PR TITLE
Fixes closing crash

### DIFF
--- a/ManiVault/src/actions/IconAction.cpp
+++ b/ManiVault/src/actions/IconAction.cpp
@@ -26,11 +26,15 @@ void IconAction::fromVariantMap(const QVariantMap& variantMap)
 {
     WidgetAction::fromVariantMap(variantMap);
 
-    QPixmap pixmap;
+    if (variantMap.contains("Value"))
+    {
+        QPixmap pixmap;
 
-    pixmap.loadFromData(QByteArray::fromBase64(variantMap["Value"].toByteArray()));
+        pixmap.loadFromData(QByteArray::fromBase64(variantMap["Value"].toByteArray()));
 
-    setIcon(createIcon(pixmap));
+        if (!pixmap.isNull())
+            setIcon(createIcon(pixmap));
+    }
 }
 
 QVariantMap IconAction::toVariantMap() const

--- a/ManiVault/src/actions/StatusBarAction.cpp
+++ b/ManiVault/src/actions/StatusBarAction.cpp
@@ -46,9 +46,15 @@ StatusBarAction::StatusBarAction(QObject* parent, const QString& title, const QS
 
 StatusBarAction::~StatusBarAction()
 {
+    if (!core())
+        return;
+
+    if (!core()->isInitialized())
+        return;
+
     StatusBarAction::statusBarActions.removeOne(this);
 
-    mv::settings().getMiscellaneousSettings().updateStatusBarOptionsAction();
+	mv::settings().getMiscellaneousSettings().updateStatusBarOptionsAction();
 }
 
 WidgetActions StatusBarAction::getStatusBarActions()

--- a/ManiVault/src/actions/WidgetAction.cpp
+++ b/ManiVault/src/actions/WidgetAction.cpp
@@ -68,7 +68,7 @@ WidgetAction::WidgetAction(QObject* parent, const QString& title) :
 
     updateLocation();
 
-    if (core() != nullptr && core()->isInitialized())
+    if (core() && core()->isInitialized())
     {
         actions().addAction(this);
 
@@ -81,7 +81,7 @@ WidgetAction::WidgetAction(QObject* parent, const QString& title) :
 
 WidgetAction::~WidgetAction()
 {
-    if (core() == nullptr || !core()->isInitialized())
+    if (!core() || !core()->isInitialized())
         return;
 
     actions().removeAction(this);

--- a/ManiVault/src/private/DockManager.cpp
+++ b/ManiVault/src/private/DockManager.cpp
@@ -105,25 +105,10 @@ void DockManager::reset()
     qDebug() << __FUNCTION__ << objectName();
 #endif
 
-    QListIterator<QPointer<ViewPluginDockWidget>> it(getViewPluginDockWidgets());
-    it.toBack();
-    while (it.hasPrevious())
-    {
-        QPointer<ViewPluginDockWidget> viewPluginDockWidget = it.previous();
+    CDockManager::removeAllDockAreas();
 
-        if (viewPluginDockWidget == nullptr)
-            continue;
-
-        if (viewPluginDockWidget.get() == nullptr)
-            continue;
-
-        auto ttt = viewPluginDockWidget.get();
-
-        qDebug() << ttt->objectName();
-
+    for (auto viewPluginDockWidget : getViewPluginDockWidgets())
         removeViewPluginDockWidget(viewPluginDockWidget.get());
-    }
-
 }
 
 void DockManager::addViewPluginDockWidget(ads::DockWidgetArea area, ads::CDockWidget* Dockwidget, ads::CDockAreaWidget* DockAreaWidget)


### PR DESCRIPTION
## Problem
The problem is somewhere deep inside the Advanced Docking System. It has something to do with the replacement of a splitter widget which appears to be in the incorrect order.

## Solution
A sturdy work-around for now is to first call `CDockManager::removeAllDockAreas();
` before removing the view plugin dock widgets: 
```
for (auto viewPluginDockWidget : getViewPluginDockWidgets())
    removeViewPluginDockWidget(viewPluginDockWidget.get());
````
The order in which the view plugin dock widgets are removed does not seem to make a difference.

We now get the coveted `0` exit code:

![image](https://github.com/user-attachments/assets/f5f68efc-f733-4ed3-b1d1-8da86d919f77)

## Drive-by changes
- [x] The `StatusBarAction` destructor now only removes itself from `StatusBarAction::statusBarActions` when the core is alive and initialized.
- [x] `IconAction::fromVariantMap(...)`  now checks if there is a actual icon data to load, which prevents a console warning that an icon is `null`.


