### PR TITLE
Fix drag and drop problem and some drive-by changes

### DIFF
--- a/ManiVault/src/actions/WidgetActionMimeData.cpp
+++ b/ManiVault/src/actions/WidgetActionMimeData.cpp
@@ -9,33 +9,34 @@ namespace mv::gui {
 WidgetActionMimeData::WidgetActionMimeData(WidgetAction* action) :
     QMimeData(),
     _action(action),
-    _actionsListModel(this),
-    _actionsFilterModel(this),
     _highlightActions()
 {
-    _actionsFilterModel.setSourceModel(&_actionsListModel);
-    _actionsFilterModel.getScopeFilterAction().setSelectedOptions({ "Private" });
-    _actionsFilterModel.getTypeFilterAction().setString(getAction()->getTypeString());
+    ActionsListModel    actionsListModel;      /** Actions list model */
+    ActionsFilterModel  actionsFilterModel;    /** Filtered actions model */
 
-    for (int rowIndex = 0; rowIndex < _actionsFilterModel.rowCount(); ++rowIndex) {
-        auto action = _actionsFilterModel.getAction(rowIndex);
+    actionsFilterModel.setSourceModel(&actionsListModel);
+    actionsFilterModel.getScopeFilterAction().setSelectedOptions({ "Private" });
+    actionsFilterModel.getTypeFilterAction().setString(getAction()->getTypeString());
 
-        if (action == getAction())
+    for (int rowIndex = 0; rowIndex < actionsFilterModel.rowCount(); ++rowIndex) {
+        auto candidateAction = actionsFilterModel.getAction(rowIndex);
+
+        if (candidateAction == getAction())
             continue;
 
-        if (!action->isEnabled())
+        if (!candidateAction->isEnabled())
             continue;
 
-        if (!action->mayConnect(WidgetAction::Gui))
+        if (!candidateAction->mayConnect(WidgetAction::Gui))
             continue;
 
-        if (action->isHighlighted())
-            action->unHighlight();
+        if (candidateAction->isHighlighted())
+            candidateAction->unHighlight();
 
-        if (action->isConnected() && (action->getPublicAction() == getAction()))
+        if (candidateAction->isConnected() && (candidateAction->getPublicAction() == getAction()))
             continue;
 
-        _highlightActions << action;
+        _highlightActions << candidateAction;
     }
 
     for (auto highlightAction : _highlightActions)

--- a/ManiVault/src/actions/WidgetActionMimeData.h
+++ b/ManiVault/src/actions/WidgetActionMimeData.h
@@ -56,8 +56,6 @@ public:
 
 private:
     WidgetAction*       _action;                /** Pointer to mime data action */
-    ActionsListModel    _actionsListModel;      /** Actions list model */
-    ActionsFilterModel  _actionsFilterModel;    /** Filtered actions model */
     WidgetActions       _highlightActions;      /** Actions to be highlighted/un-highlighted */
 };
 

--- a/ManiVault/src/models/ActionsListModel.cpp
+++ b/ManiVault/src/models/ActionsListModel.cpp
@@ -14,7 +14,7 @@ using namespace mv::gui;
 namespace mv
 {
 
-ActionsListModel::ActionsListModel(QObject* parent, gui::WidgetAction* rootAction /*= nullptr*/) :
+ActionsListModel::ActionsListModel(QObject* parent /*= nullptr*/, gui::WidgetAction* rootAction /*= nullptr*/) :
     AbstractActionsModel(parent),
     _rootAction(rootAction)
 {

--- a/ManiVault/src/models/ActionsListModel.h
+++ b/ManiVault/src/models/ActionsListModel.h
@@ -30,7 +30,7 @@ public:
      * @param parent Pointer to parent object
      * @param rootAction When set, only list the root action and its descendants
      */
-    ActionsListModel(QObject* parent, gui::WidgetAction* rootAction = nullptr);
+    ActionsListModel(QObject* parent = nullptr, gui::WidgetAction* rootAction = nullptr);
 
     /** Initializes the model from the current state of the actions manager */
     void initialize() override;

--- a/ManiVault/src/models/NumberOfRowsAction.cpp
+++ b/ManiVault/src/models/NumberOfRowsAction.cpp
@@ -15,9 +15,16 @@ NumberOfRowsAction::NumberOfRowsAction(QObject* parent, const QString& title) :
     setEnabled(false);
 
     _updateTimer.setSingleShot(true);
-    _updateTimer.setInterval(100);
+    _updateTimer.setInterval(250);
 
     connect(&_updateTimer, &QTimer::timeout, this, &NumberOfRowsAction::updateString);
+}
+
+NumberOfRowsAction::~NumberOfRowsAction()
+{
+    disconnect(_model, &QAbstractItemModel::rowsInserted, this, nullptr);
+    disconnect(_model, &QAbstractItemModel::rowsRemoved, this, nullptr);
+    disconnect(_model, &QAbstractItemModel::layoutChanged, this, nullptr);
 }
 
 void NumberOfRowsAction::initialize(QAbstractItemModel* model)
@@ -37,6 +44,7 @@ void NumberOfRowsAction::initialize(QAbstractItemModel* model)
     }
 
     _model = model;
+
 
     connect(_model, &QAbstractItemModel::rowsInserted, this, &NumberOfRowsAction::numberOfRowsChanged);
     connect(_model, &QAbstractItemModel::rowsRemoved, this, &NumberOfRowsAction::numberOfRowsChanged);

--- a/ManiVault/src/models/NumberOfRowsAction.h
+++ b/ManiVault/src/models/NumberOfRowsAction.h
@@ -33,6 +33,9 @@ public:
      */
     Q_INVOKABLE NumberOfRowsAction(QObject* parent, const QString& title);
 
+    /** Ensure to disconnect from model to avoid receiving signals when the actions is already destructed */
+    ~NumberOfRowsAction() override;
+
     /**
      * Initialize the with a pointer to a \p model
      * @param model Pointer to model to synchronize with

--- a/ManiVault/src/models/StandardItemModel.cpp
+++ b/ManiVault/src/models/StandardItemModel.cpp
@@ -18,7 +18,7 @@ using namespace gui;
 
 StandardItemModel::StandardItemModel(QObject* parent /*= nullptr*/) :
     QStandardItemModel(parent),
-    _numberOfRowsAction(this, "Number of rows")
+    _numberOfRowsAction(nullptr, "Number of rows")
 {
     _numberOfRowsAction.initialize(this);
 }


### PR DESCRIPTION
- [x] Prevent variable shadowing by renaming `action` to `candidateAction`
- [x] Some small code improvements
- [x] Disconnect from model signals in `NumberOfRowsAction` to prevent receiving signals when the model is already destroyed