### PR TITLE
Fix Font Awesome icons on Mac OS and Linux

### DIFF
--- a/ManiVault/src/Application.cpp
+++ b/ManiVault/src/Application.cpp
@@ -49,15 +49,15 @@ Application::Application(int& argc, char** argv) :
     qDebug() << "Initializing icon fonts";
 
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(5, 14, { ":/IconFonts/FontAwesomeBrandsRegular-5.14.otf" }, false, "FontAwesomeBrands")));
-    _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(5, 14, { ":/IconFonts/FontAwesomeRegular-5.14.otf" }, false, "FontAwesomeRegular")));
+    //_iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(5, 14, { ":/IconFonts/FontAwesomeRegular-5.14.otf" }, false, "FontAwesomeRegular")));
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(5, 14, { ":/IconFonts/FontAwesomeSolid-5.14.otf" }, true, "FontAwesome")));
 
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 4, { ":/IconFonts/FontAwesomeBrandsRegular-6.4.otf" }, false, "FontAwesomeBrands")));
-    _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 4, { ":/IconFonts/FontAwesomeRegular-6.4.otf" }, false, "FontAwesomeRegular")));
+    //_iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 4, { ":/IconFonts/FontAwesomeRegular-6.4.otf" }, false, "FontAwesomeRegular")));
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 4, { ":/IconFonts/FontAwesomeSolid-6.4.otf" }, false, "FontAwesome")));
 
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 5, { ":/IconFonts/FontAwesomeBrandsRegular-6.5.otf" }, false, "FontAwesomeBrands")));
-    _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 5, { ":/IconFonts/FontAwesomeRegular-6.5.otf" }, false, "FontAwesomeRegular")));
+    //_iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 5, { ":/IconFonts/FontAwesomeRegular-6.5.otf" }, false, "FontAwesomeRegular")));
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 5, { ":/IconFonts/FontAwesomeSolid-6.5.otf" }, false, "FontAwesome")));
 
     connect(Application::current(), &Application::coreManagersCreated, this, [this](CoreInterface* core) {

--- a/ManiVault/src/Application.cpp
+++ b/ManiVault/src/Application.cpp
@@ -49,15 +49,27 @@ Application::Application(int& argc, char** argv) :
     qDebug() << "Initializing icon fonts";
 
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(5, 14, { ":/IconFonts/FontAwesomeBrandsRegular-5.14.otf" }, false, "FontAwesomeBrands")));
-    //_iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(5, 14, { ":/IconFonts/FontAwesomeRegular-5.14.otf" }, false, "FontAwesomeRegular")));
+
+#if defined(_WIN32) || defined(_WIN64)
+    _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(5, 14, { ":/IconFonts/FontAwesomeRegular-5.14.otf" }, false, "FontAwesomeRegular")));
+#endif
+
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(5, 14, { ":/IconFonts/FontAwesomeSolid-5.14.otf" }, true, "FontAwesome")));
 
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 4, { ":/IconFonts/FontAwesomeBrandsRegular-6.4.otf" }, false, "FontAwesomeBrands")));
-    //_iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 4, { ":/IconFonts/FontAwesomeRegular-6.4.otf" }, false, "FontAwesomeRegular")));
+
+#if defined(_WIN32) || defined(_WIN64)
+    _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 4, { ":/IconFonts/FontAwesomeRegular-6.4.otf" }, false, "FontAwesomeRegular")));
+#endif
+
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 4, { ":/IconFonts/FontAwesomeSolid-6.4.otf" }, false, "FontAwesome")));
 
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 5, { ":/IconFonts/FontAwesomeBrandsRegular-6.5.otf" }, false, "FontAwesomeBrands")));
-    //_iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 5, { ":/IconFonts/FontAwesomeRegular-6.5.otf" }, false, "FontAwesomeRegular")));
+
+#if defined(_WIN32) || defined(_WIN64)
+    _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 5, { ":/IconFonts/FontAwesomeRegular-6.5.otf" }, false, "FontAwesomeRegular")));
+#endif
+
     _iconFonts.add(QSharedPointer<IconFont>(new FontAwesome(6, 5, { ":/IconFonts/FontAwesomeSolid-6.5.otf" }, false, "FontAwesome")));
 
     connect(Application::current(), &Application::coreManagersCreated, this, [this](CoreInterface* core) {

--- a/ManiVault/src/util/IconFont.cpp
+++ b/ManiVault/src/util/IconFont.cpp
@@ -31,6 +31,8 @@ IconFont::IconFont(const QString& name, const std::uint32_t& majorVersion, const
 {
     try
     {
+        qDebug() << "### Font resource names: " << fontResourceNames;
+
         for (const auto& fontResourceName : fontResourceNames) {
             const auto result = QFontDatabase::addApplicationFont(fontResourceName);
 
@@ -41,6 +43,8 @@ IconFont::IconFont(const QString& name, const std::uint32_t& majorVersion, const
 #ifdef ICON_FONT_VERBOSE
                 qDebug() << "Loaded" << getFullName() << QFontDatabase::applicationFontFamilies(result);
 #endif
+
+                qDebug() << "### Font families: " << QFontDatabase::applicationFontFamilies(result);
 
                 _fontFamily = QFontDatabase::applicationFontFamilies(result).first();
             }

--- a/ManiVault/src/util/IconFont.cpp
+++ b/ManiVault/src/util/IconFont.cpp
@@ -31,8 +31,6 @@ IconFont::IconFont(const QString& name, const std::uint32_t& majorVersion, const
 {
     try
     {
-        qDebug() << "### Font resource names: " << fontResourceNames;
-
         for (const auto& fontResourceName : fontResourceNames) {
             const auto result = QFontDatabase::addApplicationFont(fontResourceName);
 
@@ -43,8 +41,6 @@ IconFont::IconFont(const QString& name, const std::uint32_t& majorVersion, const
 #ifdef ICON_FONT_VERBOSE
                 qDebug() << "Loaded" << getFullName() << QFontDatabase::applicationFontFamilies(result);
 #endif
-
-                qDebug() << "### Font families: " << QFontDatabase::applicationFontFamilies(result);
 
                 _fontFamily = QFontDatabase::applicationFontFamilies(result).first();
             }


### PR DESCRIPTION
The Mac OS and Linux font family names for regular and solid are the same: Font Awesome X Free. This makes it impossible to select the correct font family and assign the proper icon. At this point, we only use the solid icons, so we will only load the solid icons on Mac OS and Linux.