### PR TITLE
Improve startup project GUI

### DIFF
--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -8,7 +8,7 @@ set(MV_CORE "mv-core")
 set(MV_VERSION_MAJOR 1)
 set(MV_VERSION_MINOR 0)
 set(MV_VERSION_PATCH 0)
-set(MV_VERSION_SUFFIX "rc") # e.g. for release candidates rc1
+set(MV_VERSION_SUFFIX "") # e.g. for release candidates rc1
 
 include(cmake/Utils.cmake)
 mv_set_version()

--- a/ManiVault/src/Main.cpp
+++ b/ManiVault/src/Main.cpp
@@ -142,7 +142,9 @@ int main(int argc, char *argv[])
         if (startupProjectsMetaActionsCandidates.count() >= 2) {
             StartupProjectSelectorDialog startupProjectSelectorDialog(startupProjectsMetaActionsCandidates);
 
-            if (startupProjectSelectorDialog.exec() == QDialog::Accepted) {
+            const auto dialogResult = startupProjectSelectorDialog.exec();
+
+            if (dialogResult == QDialog::Accepted) {
                 const auto selectedStartupProjectIndex = startupProjectSelectorDialog.getSelectedStartupProjectIndex();
 
                 if (selectedStartupProjectIndex >= 0) {
@@ -151,7 +153,7 @@ int main(int argc, char *argv[])
                 }
             }
 
-            if (startupProjectSelectorDialog.exec() == QDialog::Rejected)
+            if (dialogResult == QDialog::Rejected)
                 return 0;
 
         } else {

--- a/ManiVault/src/Main.cpp
+++ b/ManiVault/src/Main.cpp
@@ -150,6 +150,10 @@ int main(int argc, char *argv[])
                     startupProjectFilePath      = startupProjectsMetaActionsCandidates[selectedStartupProjectIndex].second;
                 }
             }
+
+            if (startupProjectSelectorDialog.exec() == QDialog::Rejected)
+                return 0;
+
         } else {
             if (startupProjectsMetaActionsCandidates.count() == 1) {
                 startupProjectMetaAction    = startupProjectsMetaActionsCandidates.first().first;

--- a/ManiVault/src/private/StartupProjectSelectorDialog.cpp
+++ b/ManiVault/src/private/StartupProjectSelectorDialog.cpp
@@ -46,7 +46,6 @@ StartupProjectSelectorDialog::StartupProjectSelectorDialog(const QVector<QPair<Q
 
     setLayout(layout);
 
-    _loadAction.setToolTip("Load the selected project");
     _quitAction.setToolTip("Do not load a project");
 
     _hierarchyWidget.setWindowIcon(windowIcon);
@@ -59,6 +58,7 @@ StartupProjectSelectorDialog::StartupProjectSelectorDialog(const QVector<QPair<Q
 
     const auto updateLoadAction = [this, &treeView]() -> void {
         _loadAction.setText(treeView.selectionModel()->selectedRows().isEmpty() ? "Start ManiVault" : "Load Project");
+        _loadAction.setToolTip(treeView.selectionModel()->selectedRows().isEmpty() ? "Start ManiVault" : "Load the selected project");
     };
 
     updateLoadAction();

--- a/ManiVault/src/private/StartupProjectSelectorDialog.cpp
+++ b/ManiVault/src/private/StartupProjectSelectorDialog.cpp
@@ -22,7 +22,7 @@ StartupProjectSelectorDialog::StartupProjectSelectorDialog(const QVector<QPair<Q
     _filterModel(this),
     _hierarchyWidget(this, "Startup project", _model, &_filterModel, false),
     _loadAction(this, "Load"),
-    _cancelAction(this, "Cancel")
+    _quitAction(this, "Quit")
 {
     _model.initialize(startupProjectsMetaActions);
 
@@ -38,16 +38,16 @@ StartupProjectSelectorDialog::StartupProjectSelectorDialog(const QVector<QPair<Q
 
     auto bottomLayout = new QHBoxLayout();
 
-    bottomLayout->addStretch(1);
     bottomLayout->addWidget(_loadAction.createWidget(this));
-    bottomLayout->addWidget(_cancelAction.createWidget(this));
+    bottomLayout->addStretch(1);
+    bottomLayout->addWidget(_quitAction.createWidget(this));
 
     layout->addLayout(bottomLayout);
 
     setLayout(layout);
 
     _loadAction.setToolTip("Load the selected project");
-    _cancelAction.setToolTip("Do not load a project");
+    _quitAction.setToolTip("Do not load a project");
 
     _hierarchyWidget.setWindowIcon(windowIcon);
     _hierarchyWidget.getTreeView().setRootIsDecorated(false);
@@ -58,7 +58,7 @@ StartupProjectSelectorDialog::StartupProjectSelectorDialog(const QVector<QPair<Q
     treeView.setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
 
     const auto updateLoadAction = [this, &treeView]() -> void {
-        _loadAction.setEnabled(!treeView.selectionModel()->selectedRows().isEmpty());
+        _loadAction.setText(treeView.selectionModel()->selectedRows().isEmpty() ? "Start ManiVault" : "Load Project");
     };
 
     updateLoadAction();
@@ -87,7 +87,7 @@ StartupProjectSelectorDialog::StartupProjectSelectorDialog(const QVector<QPair<Q
     treeViewHeader->setStretchLastSection(false);
 
     connect(&_loadAction, &TriggerAction::triggered, this, &StartupProjectSelectorDialog::accept);
-    connect(&_cancelAction, &TriggerAction::triggered, this, &StartupProjectSelectorDialog::reject);
+    connect(&_quitAction, &TriggerAction::triggered, this, &StartupProjectSelectorDialog::reject);
 }
 
 std::int32_t StartupProjectSelectorDialog::getSelectedStartupProjectIndex()

--- a/ManiVault/src/private/StartupProjectSelectorDialog.h
+++ b/ManiVault/src/private/StartupProjectSelectorDialog.h
@@ -35,7 +35,7 @@ public:
 
     /** Get preferred size */
     QSize sizeHint() const override {
-        return QSize(400, 150);
+        return QSize(500, 150);
     }
 
     /** Get minimum size hint*/
@@ -54,5 +54,5 @@ private:
     StartupProjectsFilterModel  _filterModel;           /** Sorting and filtering model for the plugin manager model */
     mv::gui::HierarchyWidget    _hierarchyWidget;       /** Widget for displaying the loaded plugins */
     mv::gui::TriggerAction      _loadAction;            /** Load the selected project */
-    mv::gui::TriggerAction      _cancelAction;          /** Exit the dialog and don't load a project */
+    mv::gui::TriggerAction      _quitAction;          /** Exit the dialog and don't load a project */
 };


### PR DESCRIPTION
- [x] Allow to exit project selection and quit the application
- [x] The load button text depends on whether there is a project selection or not (`StartManiVault` when there is no project selection and `Load Project` otherwise)
- [x] Remove the `rc` ManiVault version suffix