### PR TITLE
Unlock/lock workspace layout from status bar for (published) projects

### DIFF
--- a/ManiVault/cmake/CMakeMvSourcesApplication.cmake
+++ b/ManiVault/cmake/CMakeMvSourcesApplication.cmake
@@ -28,6 +28,7 @@ set(PRIVATE_ACTIONS_HEADERS
     src/private/ForegroundTasksStatusBarAction.h
     src/private/FrontPagesStatusBarAction.h
     src/private/SettingsStatusBarAction.h
+    src/private/WorkspaceStatusBarAction.h
 )
 
 set(PRIVATE_ACTIONS_SOURCES
@@ -38,6 +39,7 @@ set(PRIVATE_ACTIONS_SOURCES
     src/private/ForegroundTasksStatusBarAction.cpp
     src/private/FrontPagesStatusBarAction.cpp
     src/private/SettingsStatusBarAction.cpp
+    src/private/WorkspaceStatusBarAction.cpp
 )
 
 set(PRIVATE_ACTIONS_FILES

--- a/ManiVault/src/MiscellaneousSettingsAction.cpp
+++ b/ManiVault/src/MiscellaneousSettingsAction.cpp
@@ -16,7 +16,7 @@ MiscellaneousSettingsAction::MiscellaneousSettingsAction(QObject* parent) :
     _keepDescendantsAfterRemovalAction(this, "Keep descendants after removal", true),
     _showSimplifiedGuidsAction(this, "Show simplified GUID's", true),
     _statusBarVisibleAction(this, "Show status bar", true),
-    _statusBarOptionsAction(this, "Status bar options")
+    _statusBarOptionsAction(this, "Status bar options", {}, { "Example View OpenGL", "Start Page", "Version", "Plugins", "Logging", "Background Tasks", "Foreground Tasks", "Settings", "Workspace" })
 {
     _statusBarOptionsAction.setDefaultWidgetFlag(OptionsAction::WidgetFlag::Selection);
 
@@ -37,6 +37,8 @@ MiscellaneousSettingsAction::MiscellaneousSettingsAction(QObject* parent) :
     addAction(&_keepDescendantsAfterRemovalAction);
     addAction(&_statusBarVisibleAction);
     addAction(&_statusBarOptionsAction);
+
+    qDebug() << _statusBarOptionsAction.getSelectedOptions();
 }
 
 void MiscellaneousSettingsAction::updateStatusBarOptionsAction()

--- a/ManiVault/src/MiscellaneousSettingsAction.cpp
+++ b/ManiVault/src/MiscellaneousSettingsAction.cpp
@@ -37,8 +37,6 @@ MiscellaneousSettingsAction::MiscellaneousSettingsAction(QObject* parent) :
     addAction(&_keepDescendantsAfterRemovalAction);
     addAction(&_statusBarVisibleAction);
     addAction(&_statusBarOptionsAction);
-
-    qDebug() << _statusBarOptionsAction.getSelectedOptions();
 }
 
 void MiscellaneousSettingsAction::updateStatusBarOptionsAction()

--- a/ManiVault/src/Project.cpp
+++ b/ManiVault/src/Project.cpp
@@ -256,6 +256,8 @@ void Project::initialize()
 
     _selectionGroupingAction.setIconByName("object-group");
     _selectionGroupingAction.setToolTip("Enable/disable dataset grouping");
+
+    _statusBarOptionsAction.setDefaultWidgetFlag(OptionsAction::WidgetFlag::Selection);
 }
 
 }

--- a/ManiVault/src/actions/GroupAction.cpp
+++ b/ManiVault/src/actions/GroupAction.cpp
@@ -298,11 +298,16 @@ QVariantMap GroupAction::toVariantMap() const
     return variantMap;
 }
 
-void GroupAction::clear()
+void GroupAction::removeAllActions()
 {
     _actions.clear();
 
     emit actionsChanged(_actions);
+}
+
+void GroupAction::clear()
+{
+    removeAllActions();
 }
 
 mv::gui::StretchAction* GroupAction::addStretch(std::int32_t stretch /*= 1*/)

--- a/ManiVault/src/actions/GroupAction.h
+++ b/ManiVault/src/actions/GroupAction.h
@@ -182,6 +182,9 @@ public: // Actions management
     virtual void removeAction(WidgetAction* action) final;
 
     /** Remove all actions */
+    virtual void removeAllActions() final;
+
+    /** Remove all actions (alias for GroupAction::removeAllActions()) */
     virtual void clear() final;
 
     /**

--- a/ManiVault/src/actions/LockingAction.cpp
+++ b/ManiVault/src/actions/LockingAction.cpp
@@ -24,6 +24,8 @@ LockingAction::LockingAction(QObject* parent, const QString& what /*= ""*/, bool
     updateActionsText();
 
     setConnectionPermissionsToForceNone(true);
+
+    addAction(&_lockedAction);
 }
 
 void LockingAction::initialize(bool locked /*= false*/)

--- a/ManiVault/src/actions/OptionsAction.cpp
+++ b/ManiVault/src/actions/OptionsAction.cpp
@@ -124,8 +124,8 @@ void OptionsAction::selectOption(const QString& option, bool unselect /*= false*
 
 void OptionsAction::toggleOption(const QString& option)
 {
-    if (!hasOption(option))
-        return;
+    //if (!hasOption(option))
+    //    return;
 
     selectOption(option, isOptionSelected(option));
 }

--- a/ManiVault/src/private/DockAreaTitleBar.cpp
+++ b/ManiVault/src/private/DockAreaTitleBar.cpp
@@ -78,7 +78,9 @@ DockAreaTitleBar::DockAreaTitleBar(ads::CDockAreaWidget* dockAreaWidget) :
     insertWidget(indexOf(button(ads::TitleBarButtonTabsMenu)) - 1, _addViewPluginToolButton);
 
     const auto updateReadOnly = [this]() -> void {
-        _addViewPluginToolButton->setVisible(!workspaces().getLockingAction().isLocked());
+        const auto projectIsReadOnly = mv::projects().hasProject() && mv::projects().getCurrentProject()->getReadOnlyAction().isChecked();
+
+        _addViewPluginToolButton->setVisible(!workspaces().getLockingAction().isLocked() && !projectIsReadOnly);
     };
 
     connect(&workspaces().getLockingAction().getLockedAction(), &ToggleAction::toggled, this, updateReadOnly);

--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -26,6 +26,7 @@
 #include "BackgroundTasksStatusBarAction.h"
 #include "ForegroundTasksStatusBarAction.h"
 #include "SettingsStatusBarAction.h"
+#include "WorkspaceStatusBarAction.h"
 
 #include <QDebug>
 #include <QMessageBox>
@@ -107,14 +108,16 @@ void MainWindow::showEvent(QShowEvent* showEvent)
         auto backgroundTasksStatusBarAction = new BackgroundTasksStatusBarAction(this, "Background Tasks");
         auto foregroundTasksStatusBarAction = new ForegroundTasksStatusBarAction(this, "Foreground Tasks");
         auto settingsTasksStatusBarAction   = new SettingsStatusBarAction(this, "Settings");
+        auto workspaceStatusBarAction       = new WorkspaceStatusBarAction(this, "Workspace");
 
         statusBar()->insertPermanentWidget(0, startPageStatusBarAction->createWidget(this));
         statusBar()->insertPermanentWidget(1, versionStatusBarAction->createWidget(this));
         statusBar()->insertPermanentWidget(2, pluginsStatusBarAction->createWidget(this));
-        statusBar()->insertPermanentWidget(3, loggingStatusBarAction->createWidget(this), 4);
-        statusBar()->insertPermanentWidget(4, backgroundTasksStatusBarAction->createWidget(this), 1);
-        statusBar()->insertPermanentWidget(5, foregroundTasksStatusBarAction->createWidget(this));
-        statusBar()->insertPermanentWidget(6, settingsTasksStatusBarAction->createWidget(this));
+        statusBar()->insertPermanentWidget(3, workspaceStatusBarAction->createWidget(this));
+        statusBar()->insertPermanentWidget(4, loggingStatusBarAction->createWidget(this), 4);
+        statusBar()->insertPermanentWidget(5, backgroundTasksStatusBarAction->createWidget(this), 1);
+        statusBar()->insertPermanentWidget(6, foregroundTasksStatusBarAction->createWidget(this));
+        statusBar()->insertPermanentWidget(7, settingsTasksStatusBarAction->createWidget(this));
 
         const auto updateStatusBarVisibility = [this]() -> void {
             statusBar()->setVisible(mv::projects().hasProject() && mv::settings().getMiscellaneousSettings().getStatusBarVisibleAction().isChecked());

--- a/ManiVault/src/private/WorkspaceStatusBarAction.cpp
+++ b/ManiVault/src/private/WorkspaceStatusBarAction.cpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#include "WorkspaceStatusBarAction.h"
+
+#include <actions/LockingAction.h>
+
+#ifdef _DEBUG
+    #define WORKSPACE_STATUS_BAR_ACTION_VERBOSE
+#endif
+
+using namespace mv;
+using namespace mv::gui;
+
+WorkspaceStatusBarAction::WorkspaceStatusBarAction(QObject* parent, const QString& title) :
+    StatusBarAction(parent, title, "table"),
+    _loadPluginBrowserAction(this, "Plugin"),
+    _settingsAction(this, "Settings")
+{
+    setPopupAction(&_settingsAction);
+    setToolTip("Explore workspace settings");
+
+    connect(&mv::workspaces(), &AbstractWorkspaceManager::workspaceCreated, this, [this](const mv::Workspace& workspace) -> void {
+        _settingsAction.removeAllActions();
+        _settingsAction.addAction(const_cast<LockingAction*>(&workspace.getLockingAction()));
+    });
+
+    //_pluginsAction.setConfigurationFlag(WidgetAction::ConfigurationFlag::NoGroupBoxInPopupLayout);
+    _settingsAction.setPopupSizeHint(QSize(300, 200));
+
+    /*
+    _settingsAction.setWidgetConfigurationFunction([this](WidgetAction* action, QWidget* widget) -> void {
+        auto hierarchyWidget = widget->findChild<HierarchyWidget*>("HierarchyWidget");
+
+        Q_ASSERT(hierarchyWidget != nullptr);
+
+        if (hierarchyWidget == nullptr)
+            return;
+
+        hierarchyWidget->setHeaderHidden(true);
+        hierarchyWidget->setWindowIcon(Application::getIconFont("FontAwesome").getIcon("plug"));
+        
+        hierarchyWidget->getFilterGroupAction().setVisible(false);
+        hierarchyWidget->getColumnsGroupAction().setVisible(false);
+
+        auto& toolbarAction = hierarchyWidget->getToolbarAction();
+
+        toolbarAction.addAction(&_loadPluginBrowserAction);
+
+        auto treeView = widget->findChild<QTreeView*>("TreeView");
+
+        Q_ASSERT(treeView != nullptr);
+
+        if (treeView == nullptr)
+            return;
+
+        treeView->setColumnHidden(static_cast<int>(AbstractPluginFactoriesModel::Column::NumberOfInstances), true);
+
+        auto treeViewHeader = treeView->header();
+
+        treeViewHeader->setStretchLastSection(false);
+
+        treeViewHeader->setSectionResizeMode(static_cast<int>(AbstractPluginFactoriesModel::Column::Name), QHeaderView::Stretch);
+        treeViewHeader->setSectionResizeMode(static_cast<int>(AbstractPluginFactoriesModel::Column::Version), QHeaderView::ResizeToContents);
+
+        treeViewHeader->resizeSections(QHeaderView::ResizeToContents);
+    });
+    
+
+    _loadPluginBrowserAction.setIconByName("window-maximize");
+    _loadPluginBrowserAction.setDefaultWidgetFlags(TriggerAction::WidgetFlag::Icon);
+    _loadPluginBrowserAction.setToolTip("Load plugin browser");
+
+    connect(&_loadPluginBrowserAction, &TriggerAction::triggered, this, [this]() -> void {
+        projects().getPluginManagerAction().trigger();
+    });
+
+    auto& badge = getBarIconStringAction().getBadge();
+
+    badge.setScale(0.55f);
+    badge.setBackgroundColor(qApp->palette().highlight().color());
+
+    const auto updateBadge = [this, &badge]() -> void {
+        const auto numberPluginsLoaded = _listModel.rowCount();
+
+        badge.setEnabled(numberPluginsLoaded > 0);
+        badge.setNumber(numberPluginsLoaded);
+    };
+
+    updateBadge();
+
+    connect(&_listModel, &QSortFilterProxyModel::rowsInserted, this, updateBadge);
+    connect(&_listModel, &QSortFilterProxyModel::rowsRemoved, this, updateBadge);
+    */
+}

--- a/ManiVault/src/private/WorkspaceStatusBarAction.h
+++ b/ManiVault/src/private/WorkspaceStatusBarAction.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later 
+// A corresponding LICENSE file is located in the root directory of this source tree 
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+
+#pragma once
+
+#include <actions/StatusBarAction.h>
+#include <actions/TriggerAction.h>
+#include <actions/GroupAction.h>
+
+/**
+ * Workspace status bar action class
+ *
+ * Status bar action class for displaying workspace settings
+ *
+ * @author Thomas Kroes
+ */
+class WorkspaceStatusBarAction : public mv::gui::StatusBarAction
+{
+    Q_OBJECT
+
+public:
+
+    /**
+     * Construct with \p parent object and \p title
+     * @param parent Pointer to parent object
+     * @param title Title of the action
+     */
+    WorkspaceStatusBarAction(QObject* parent, const QString& title);
+
+private:
+    mv::gui::TriggerAction  _loadPluginBrowserAction;   /** Triggers loading the logging plugin */
+    mv::gui::GroupAction    _settingsAction;
+};

--- a/ManiVault/src/private/WorkspaceStatusBarAction.h
+++ b/ManiVault/src/private/WorkspaceStatusBarAction.h
@@ -5,8 +5,9 @@
 #pragma once
 
 #include <actions/StatusBarAction.h>
+#include <actions/ToggleAction.h>
 #include <actions/TriggerAction.h>
-#include <actions/GroupAction.h>
+#include <actions/HorizontalGroupAction.h>
 
 /**
  * Workspace status bar action class
@@ -29,6 +30,7 @@ public:
     WorkspaceStatusBarAction(QObject* parent, const QString& title);
 
 private:
-    mv::gui::TriggerAction  _loadPluginBrowserAction;   /** Triggers loading the logging plugin */
-    mv::gui::GroupAction    _settingsAction;
+    mv::gui::HorizontalGroupAction  _settingsAction;        /** Horizontal group action for settings */
+    mv::gui::ToggleAction           _layoutLockedAction;    /** Toggles layout locked for the current workspace */
+    mv::gui::TriggerAction          _moreSettingsAction;    /** Triggers loading the project settings dialog */
 };


### PR DESCRIPTION
## Main contributions
- [x] Add `workspace` status bar item to unlock/lock the workspace layout

## Drive-by changes
- [x] Allow toggling of non-existent options in `OptionsAction`
- [x] Fixes #658 