### PR TITLE
Fix qt6 deprecation warning

### DIFF
--- a/ManiVault/src/actions/GroupsAction.cpp
+++ b/ManiVault/src/actions/GroupsAction.cpp
@@ -346,7 +346,14 @@ void GroupsAction::Widget::createTreeWidget(const std::int32_t& widgetFlags)
     
     // We do all styling here
     updateCustomStyle();
-    connect(qApp, &QApplication::paletteChanged, this, &GroupsAction::Widget::updateCustomStyle);
+}
+
+bool GroupsAction::Widget::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateCustomStyle();
+
+    return QWidget::event(event);
 }
 
 void GroupsAction::Widget::updateToolbar()

--- a/ManiVault/src/actions/GroupsAction.h
+++ b/ManiVault/src/actions/GroupsAction.h
@@ -83,6 +83,13 @@ public:
             return _filteredActionsAction;
         }
 
+    protected:
+        /**
+        * Override QObject's event handling
+        * @return Boolean Wheter the event was recognized and processed
+        */
+        bool event(QEvent* event) override;
+
     protected: // Internals
 
         /**

--- a/ManiVault/src/actions/WidgetAction.cpp
+++ b/ManiVault/src/actions/WidgetAction.cpp
@@ -76,7 +76,6 @@ WidgetAction::WidgetAction(QObject* parent, const QString& title) :
             setStudioMode(projects().getCurrentProject()->getStudioModeAction().isChecked(), false);
     }
 
-    connect(qApp, &QApplication::paletteChanged, this, &WidgetAction::updateCustomStyle);
 }
 
 WidgetAction::~WidgetAction()
@@ -85,6 +84,13 @@ WidgetAction::~WidgetAction()
         return;
 
     actions().removeAction(this);
+}
+bool WidgetAction::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateCustomStyle();
+
+    return QWidgetAction::event(event);
 }
 
 QString WidgetAction::getLocation(bool recompute /*= false*/) const

--- a/ManiVault/src/actions/WidgetAction.h
+++ b/ManiVault/src/actions/WidgetAction.h
@@ -425,6 +425,13 @@ public: // Widgets
      */
     void setWidgetConfigurationFunction(const WidgetConfigurationFunction& widgetConfigurationFunction);
 
+protected:
+    /**
+     * Override QObject's event handling
+     * @return Boolean Wheter the event was recognized and processed
+     */
+    bool event(QEvent* event) override;
+
 public: // Visibility
 
     /**

--- a/ManiVault/src/actions/WidgetActionLabel.cpp
+++ b/ManiVault/src/actions/WidgetActionLabel.cpp
@@ -52,7 +52,6 @@ WidgetActionLabel::WidgetActionLabel(WidgetAction* action, QWidget* parent /*= n
     _nameLabel.installEventFilter(this);
 
     updateCustomStyle();
-    connect(qApp, &QApplication::paletteChanged, this, &WidgetActionLabel::updateCustomStyle);
 }
 
 bool WidgetActionLabel::eventFilter(QObject* target, QEvent* event)
@@ -133,8 +132,16 @@ bool WidgetActionLabel::eventFilter(QObject* target, QEvent* event)
         }
 
         case QEvent::EnabledChange:
+        {
             updateNameLabel();
             break;
+        }
+
+        case QEvent::ApplicationPaletteChange:
+        {
+            updateCustomStyle();
+            break;
+        }
 
         default:
             break;

--- a/ManiVault/src/private/ActionsManager.cpp
+++ b/ManiVault/src/private/ActionsManager.cpp
@@ -13,6 +13,8 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QDialogButtonBox>
+#include <QMetaType>
+#include <QMetaObject>
 
 using namespace mv::gui;
 using namespace mv::util;
@@ -84,22 +86,22 @@ void ActionsManager::fromVariantMap(const QVariantMap& variantMap)
         {
             const auto publicActionMap      = publicActionVariant.toMap();
             const auto publicActionTitle    = publicActionMap["Title"].toString();
-            const auto metaType             = publicActionMap["ActionType"].toString();
+            const auto metaTypeName         = publicActionMap["ActionType"].toString();
 
-            if (metaType.isEmpty())
+            if (metaTypeName.isEmpty())
                 throw std::runtime_error(QString("Action type is not specified for %1").arg(publicActionTitle).toLatin1());
 
-            const auto metaTypeId   = QMetaType::type(metaType.toLatin1());
-            const auto metaObject   = QMetaType::metaObjectForType(metaTypeId);
+            const auto metaType     = QMetaType::fromName(metaTypeName.toLatin1());
+            const auto metaObject   = metaType.metaObject();
                 
             if (!metaObject)
-                throw std::runtime_error(QString("Meta object type '%1' for '%2' is not known. Did you forget to register the action correctly with Qt meta object system? See ToggleAction.h for an example.").arg(metaType, publicActionTitle).toLatin1());
+                throw std::runtime_error(QString("Meta object type '%1' for '%2' is not known. Did you forget to register the action correctly with Qt meta object system? See ToggleAction.h for an example.").arg(metaTypeName, publicActionTitle).toLatin1());
 
             auto metaObjectInstance = metaObject->newInstance(Q_ARG(QObject*, this), Q_ARG(QString, publicActionTitle));
             auto publicAction       = dynamic_cast<WidgetAction*>(metaObjectInstance);
 
             if (!publicAction)
-                throw std::runtime_error(QString("Unable to create a new instance of type '%1'").arg(metaType).toLatin1());
+                throw std::runtime_error(QString("Unable to create a new instance of type '%1'").arg(publicActionTitle).toLatin1());
 
             publicAction->fromVariantMap(publicActionMap);
 

--- a/ManiVault/src/private/DockAreaTitleBar.cpp
+++ b/ManiVault/src/private/DockAreaTitleBar.cpp
@@ -86,10 +86,17 @@ DockAreaTitleBar::DockAreaTitleBar(ads::CDockAreaWidget* dockAreaWidget) :
     updateReadOnly();
 
     updateStyle();
-    connect(qApp, &QApplication::paletteChanged, this, &DockAreaTitleBar::updateStyle);
 }
 
 void DockAreaTitleBar::updateStyle()
 {
     _addViewPluginToolButton->setIcon(Application::getIconFont("FontAwesome").getIcon("plus"));
+}
+
+bool DockAreaTitleBar::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateStyle();
+
+    return ads::CDockAreaTitleBar::event(event);
 }

--- a/ManiVault/src/private/DockAreaTitleBar.h
+++ b/ManiVault/src/private/DockAreaTitleBar.h
@@ -29,6 +29,13 @@ public:
      */
     DockAreaTitleBar(ads::CDockAreaWidget* dockAreaWidget);
     
+protected:
+    /**
+     * Override QObject's event handling
+     * @return Boolean Wheter the event was recognized and processed
+     */
+    bool event(QEvent* event) override;
+
 public: // Themes
     
     /** refresh the widget and its children according to new style */

--- a/ManiVault/src/private/DockWidget.cpp
+++ b/ManiVault/src/private/DockWidget.cpp
@@ -43,7 +43,6 @@ DockWidget::DockWidget(const QString& title, QWidget* parent /*= nullptr*/) :
     _settingsToolButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
     updateStyle();
-    connect(qApp, &QApplication::paletteChanged, this, &DockWidget::updateStyle);
 
     dynamic_cast<QBoxLayout*>(tabWidget()->layout())->insertSpacing(1, 5);
     dynamic_cast<QBoxLayout*>(tabWidget()->layout())->insertWidget(2, _settingsToolButton, Qt::AlignCenter);
@@ -56,6 +55,14 @@ DockWidget::~DockWidget()
 #endif
 
     takeWidget();
+}
+
+bool DockWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateStyle();
+
+    return ads::CDockWidget::event(event);
 }
 
 QString DockWidget::getTypeString() const

--- a/ManiVault/src/private/DockWidget.h
+++ b/ManiVault/src/private/DockWidget.h
@@ -65,6 +65,13 @@ public:
      */
     void setWidget(QWidget* widget, eInsertMode insertMode = AutoScrollArea);
 
+protected:
+    /**
+     * Override QObject's event handling
+     * @return Boolean Wheter the event was recognized and processed
+     */
+    bool event(QEvent* event) override;
+
 public: // Serialization
 
     /**

--- a/ManiVault/src/private/LearningPagePluginAction.cpp
+++ b/ManiVault/src/private/LearningPagePluginAction.cpp
@@ -59,8 +59,6 @@ LearningPagePluginActionsWidget::LearningPagePluginActionsWidget(const mv::plugi
 
     _actionsOverlayWidget.hide();
 
-    connect(qApp, &QApplication::paletteChanged, this, &LearningPagePluginActionsWidget::updateStyle);
-
     updateStyle();
 }
 
@@ -93,6 +91,14 @@ void LearningPagePluginActionsWidget::leaveEvent(QEvent* leaveEvent)
     _actionsOverlayWidget.setAttribute(Qt::WA_TransparentForMouseEvents, true);
 
     updateStyle();
+}
+
+bool LearningPagePluginActionsWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateStyle();
+
+    return QWidget::event(event);
 }
 
 bool LearningPagePluginActionsWidget::hasOverlay() const

--- a/ManiVault/src/private/LearningPagePluginAction.h
+++ b/ManiVault/src/private/LearningPagePluginAction.h
@@ -96,6 +96,12 @@ protected:
      */
     void leaveEvent(QEvent* leaveEvent) override;
 
+    /**
+     * Override QObject's event handling
+     * @return Boolean Wheter the event was recognized and processed
+     */
+    bool event(QEvent* event) override;
+
 private:
 
     /**

--- a/ManiVault/src/private/LearningPageTutorialsWidget.cpp
+++ b/ManiVault/src/private/LearningPageTutorialsWidget.cpp
@@ -20,9 +20,15 @@ LearningPageTutorialsWidget::LearningPageTutorialsWidget(LearningPageContentWidg
 
     setLayout(&_mainLayout);
 
-    connect(qApp, &QApplication::paletteChanged, this, &LearningPageTutorialsWidget::updateCustomStyle);
-
     updateCustomStyle();
+}
+
+bool LearningPageTutorialsWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateCustomStyle();
+
+    return QWidget::event(event);
 }
 
 void LearningPageTutorialsWidget::updateCustomStyle()

--- a/ManiVault/src/private/LearningPageTutorialsWidget.h
+++ b/ManiVault/src/private/LearningPageTutorialsWidget.h
@@ -25,6 +25,13 @@ protected:
      */
     LearningPageTutorialsWidget(LearningPageContentWidget* learningPageContentWidget);
 
+protected:
+    /**
+     * Override QObject's event handling
+     * @return Boolean Wheter the event was recognized and processed
+     */
+    bool event(QEvent* event) override;
+
 private:
 
     /** Update all custom style elements */

--- a/ManiVault/src/private/LearningPageVideosWidget.cpp
+++ b/ManiVault/src/private/LearningPageVideosWidget.cpp
@@ -65,14 +65,20 @@ LearningPageVideosWidget::LearningPageVideosWidget(QWidget* parent /*= nullptr*/
             _videosListView.closePersistentEditor(_filterModel.index(rowIndex, static_cast<int>(LearningPageVideosModel::Column::Delegate)));
     });
 
-    connect(qApp, &QApplication::paletteChanged, this, &LearningPageVideosWidget::updateCustomStyle);
-
     updateCustomStyle();
 }
 
 void LearningPageVideosWidget::showEvent(QShowEvent* showEvent)
 {
     _model.populateFromServer();
+}
+
+bool LearningPageVideosWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateCustomStyle();
+
+    return QWidget::event(event);
 }
 
 void LearningPageVideosWidget::updateCustomStyle()

--- a/ManiVault/src/private/LearningPageVideosWidget.h
+++ b/ManiVault/src/private/LearningPageVideosWidget.h
@@ -40,6 +40,12 @@ protected:
      */
     void showEvent(QShowEvent* showEvent);
 
+    /**
+     * Override QObject's event handling
+     * @return Boolean Wheter the event was recognized and processed
+     */
+    bool event(QEvent* event) override;
+
 private:
 
     /** Update all custom style elements */

--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -221,6 +221,14 @@ void MainWindow::resizeEvent(QResizeEvent* resizeEvent)
     QWidget::resizeEvent(resizeEvent);
 }
 
+bool MainWindow::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateStyle();
+
+    return QMainWindow::event(event);
+}
+
 void MainWindow::restoreWindowGeometryFromSettings()
 {
     const auto storedMainWindowGeometry = Application::current()->getSetting("MainWindow/Geometry", QVariant());
@@ -284,7 +292,6 @@ void MainWindow::checkGraphicsCapabilities()
 
     ctx.doneCurrent();
     
-    connect(qApp, &QApplication::paletteChanged, this, &MainWindow::updateStyle);
 }
 
 void MainWindow::updateStyle()

--- a/ManiVault/src/private/MainWindow.h
+++ b/ManiVault/src/private/MainWindow.h
@@ -50,6 +50,12 @@ private: // Window geometry persistence
      */
     void setDefaultWindowGeometry(const float& coverage = 0.7f);
     
+    /**
+     * Override QObject's event handling
+     * @return Boolean Wheter the event was recognized and processed
+     */
+    bool event(QEvent* event) override;
+
 public: // Themes
     
     /** refresh the widget and its children according to new style */

--- a/ManiVault/src/private/PageContentWidget.cpp
+++ b/ManiVault/src/private/PageContentWidget.cpp
@@ -34,9 +34,15 @@ PageContentWidget::PageContentWidget(const Qt::Orientation& orientation, QWidget
 
     setLayout(&_mainLayout);
 
-    connect(qApp, &QApplication::paletteChanged, this, &PageContentWidget::updateCustomStyle);
-
     updateCustomStyle();
+}
+
+bool PageContentWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateCustomStyle();
+
+    return QWidget::event(event);
 }
 
 QLabel* PageContentWidget::createHeaderLabel(const QString& title, const QString& tooltip)

--- a/ManiVault/src/private/PageContentWidget.h
+++ b/ManiVault/src/private/PageContentWidget.h
@@ -62,6 +62,12 @@ protected:
         return _rowsLayout;
     };
 
+    /**
+     * Override QObject's event handling
+     * @return Boolean Wheter the event was recognized and processed
+     */
+    bool event(QEvent* event) override;
+
 private:
 
     /** Update custom theme parts not caught by the system itself */

--- a/ManiVault/src/private/PageWidget.cpp
+++ b/ManiVault/src/private/PageWidget.cpp
@@ -41,9 +41,15 @@ PageWidget::PageWidget(const QString& title, QWidget* parent /*= nullptr*/) :
     _layout.addLayout(&_contentLayout, 2);
     _layout.addStretch(1);
 
-    connect(qApp, &QApplication::paletteChanged, this, &PageWidget::updateCustomStyle);
-
     updateCustomStyle();
+}
+
+bool PageWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateCustomStyle();
+
+    return QWidget::event(event);
 }
 
 void PageWidget::paintEvent(QPaintEvent* paintEvent)

--- a/ManiVault/src/private/PageWidget.h
+++ b/ManiVault/src/private/PageWidget.h
@@ -47,6 +47,12 @@ protected:
      */
     QVBoxLayout& getContentLayout();
 
+    /**
+     * Override QObject's event handling
+     * @return Boolean Wheter the event was recognized and processed
+     */
+    bool event(QEvent* event) override;
+
 private:
 
     /** Update custom theme parts not caught by the system itself */

--- a/ManiVault/src/private/StartPageActionDelegateEditorWidget.cpp
+++ b/ManiVault/src/private/StartPageActionDelegateEditorWidget.cpp
@@ -193,7 +193,6 @@ StartPageActionDelegateEditorWidget::StartPageActionDelegateEditorWidget(QWidget
     _metaDataLabel.installEventFilter(this);
     
     updateCustomStyle();
-    connect(qApp, &QApplication::paletteChanged, this, &StartPageActionDelegateEditorWidget::updateCustomStyle);
 
     updateInfoWidgetVisibility();
 }
@@ -217,6 +216,10 @@ bool StartPageActionDelegateEditorWidget::eventFilter(QObject* target, QEvent* e
     {
         case QEvent::Resize:
             updateTextLabels();
+            break;
+
+        case QEvent::ApplicationPaletteChange:
+            updateCustomStyle();
             break;
 
         default:

--- a/ManiVault/src/private/StartPageActionsWidget.cpp
+++ b/ManiVault/src/private/StartPageActionsWidget.cpp
@@ -96,6 +96,14 @@ StartPageActionsWidget::StartPageActionsWidget(QWidget* parent, const QString& t
     connect(qApp, &QApplication::paletteChanged, this, &StartPageActionsWidget::updateCustomStyle);
 }
 
+bool StartPageActionsWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateCustomStyle();
+
+    return QWidget::event(event);
+}
+
 QVBoxLayout& StartPageActionsWidget::getLayout()
 {
     return _layout;

--- a/ManiVault/src/private/StartPageActionsWidget.h
+++ b/ManiVault/src/private/StartPageActionsWidget.h
@@ -54,6 +54,13 @@ public:
      */
     mv::gui::HierarchyWidget& getHierarchyWidget();
 
+protected:
+    /**
+     * Override QObject's event handling
+     * @return Boolean Wheter the event was recognized and processed
+     */
+    bool event(QEvent* event) override;
+
 private:
 
     /**

--- a/ManiVault/src/private/StartPageOpenProjectWidget.cpp
+++ b/ManiVault/src/private/StartPageOpenProjectWidget.cpp
@@ -65,7 +65,14 @@ StartPageOpenProjectWidget::StartPageOpenProjectWidget(StartPageContentWidget* s
 
     toggleViews();
     
-    connect(qApp, &QApplication::paletteChanged, this, &StartPageOpenProjectWidget::updateCustomStyle);
+}
+
+bool StartPageOpenProjectWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateCustomStyle();
+
+    return QWidget::event(event);
 }
 
 void StartPageOpenProjectWidget::updateActions()

--- a/ManiVault/src/private/StartPageOpenProjectWidget.h
+++ b/ManiVault/src/private/StartPageOpenProjectWidget.h
@@ -32,6 +32,12 @@ protected:
     /** Updates the actions to reflect changes */
     void updateActions();
 
+    /**
+     * Override QObject's event handling
+     * @return Boolean Wheter the event was recognized and processed
+     */
+    bool event(QEvent* event) override;
+
 private:
 
     /**

--- a/ManiVault/src/private/ViewPluginDockWidget.cpp
+++ b/ManiVault/src/private/ViewPluginDockWidget.cpp
@@ -543,8 +543,15 @@ ViewPluginDockWidget::ProgressOverlayWidget::ProgressOverlayWidget(QWidget* pare
 
     connect(qApp, &QApplication::paletteChanged, this, &ProgressOverlayWidget::updateCustomStyle);
 
-
     updateCustomStyle();
+}
+
+bool ViewPluginDockWidget::ProgressOverlayWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateCustomStyle();
+
+    return QWidget::event(event);
 }
 
 void ViewPluginDockWidget::ProgressOverlayWidget::setTask(Task* task)

--- a/ManiVault/src/private/ViewPluginDockWidget.h
+++ b/ManiVault/src/private/ViewPluginDockWidget.h
@@ -70,6 +70,13 @@ private:
          */
         void setTask(mv::Task* task);
 
+    protected:
+        /**
+         * Override QObject's event handling
+         * @return Boolean Wheter the event was recognized and processed
+         */
+        bool event(QEvent* event) override;
+
     private:
 
         /** Update the overlay visibility based on whether there is a task and, if yes, whether it is running or not */

--- a/ManiVault/src/util/AbstractItemModelTester.cpp
+++ b/ManiVault/src/util/AbstractItemModelTester.cpp
@@ -4,9 +4,10 @@
 
 #include "AbstractItemModelTester.h"
 
-#include <QStringList>
-#include <QSize>
 #include <QAbstractItemModel>
+#include <QSize>
+#include <QStringList>
+#include <QMetaType>
 
 /*!
     Connect to all of the models signals.  Whenever anything happens
@@ -386,23 +387,23 @@ void AbstractItemModelTester::data()
     // General Purpose roles that should return a QString
     QVariant variant = model->data(model->index(0, 0), Qt::ToolTipRole);
     if (variant.isValid())
-        Q_ASSERT(variant.canConvert(QVariant::String));
+        Q_ASSERT(variant.canConvert(QMetaType(QMetaType::QString)));
     variant = model->data(model->index(0, 0), Qt::StatusTipRole);
     if (variant.isValid())
-        Q_ASSERT(variant.canConvert(QVariant::String));
+        Q_ASSERT(variant.canConvert(QMetaType(QMetaType::QString)));
     variant = model->data(model->index(0, 0), Qt::WhatsThisRole);
     if (variant.isValid())
-        Q_ASSERT(variant.canConvert(QVariant::String));
+        Q_ASSERT(variant.canConvert(QMetaType(QMetaType::QString)));
 
     // General Purpose roles that should return a QSize
     variant = model->data(model->index(0, 0), Qt::SizeHintRole);
     if (variant.isValid())
-        Q_ASSERT(variant.canConvert(QVariant::Size));
+        Q_ASSERT(variant.canConvert(QMetaType(QMetaType::QSize)));
 
     // General Purpose roles that should return a QFont
     QVariant fontVariant = model->data(model->index(0, 0), Qt::FontRole);
     if (fontVariant.isValid())
-        Q_ASSERT(fontVariant.canConvert(QVariant::Font));
+        Q_ASSERT(fontVariant.canConvert(QMetaType(QMetaType::QFont)));
 
     // Check that the alignment is one we know about
     QVariant textAlignmentVariant = model->data(model->index(0, 0), Qt::TextAlignmentRole);
@@ -414,11 +415,11 @@ void AbstractItemModelTester::data()
     // General Purpose roles that should return a QColor
     QVariant colorVariant = model->data(model->index(0, 0), Qt::BackgroundRole);
     if (colorVariant.isValid())
-        Q_ASSERT(colorVariant.canConvert(QVariant::Color));
+        Q_ASSERT(colorVariant.canConvert(QMetaType(QMetaType::QColor)));
 
     colorVariant = model->data(model->index(0, 0), Qt::ForegroundRole);
     if (colorVariant.isValid())
-        Q_ASSERT(colorVariant.canConvert(QVariant::Color));
+        Q_ASSERT(colorVariant.canConvert(QMetaType(QMetaType::QColor)));
 
     // Check that the "check state" is one we know about.
     QVariant checkStateVariant = model->data(model->index(0, 0), Qt::CheckStateRole);

--- a/ManiVault/src/widgets/DropWidget.cpp
+++ b/ManiVault/src/widgets/DropWidget.cpp
@@ -97,7 +97,7 @@ bool DropWidget::eventFilter(QObject* target, QEvent* event)
                     auto dropRegionContainerWidget = dynamic_cast<DropRegionContainerWidget*>(layout()->itemAt(i)->widget());
 
                     if (dropRegionContainerWidget)
-                        dropRegionContainerWidget->setHighLight(dropRegionContainerWidget->geometry().contains(dragMoveEvent->pos()));
+                        dropRegionContainerWidget->setHighLight(dropRegionContainerWidget->geometry().contains(dragMoveEvent->position().toPoint()));
                 }
             }
 
@@ -129,7 +129,7 @@ bool DropWidget::eventFilter(QObject* target, QEvent* event)
                 auto dropRegionContainerWidget = dynamic_cast<DropRegionContainerWidget*>(layout()->itemAt(i)->widget());
 
                 if (dropRegionContainerWidget) {
-                    if (dropRegionContainerWidget->geometry().contains(dropEvent->pos()))
+                    if (dropRegionContainerWidget->geometry().contains(dropEvent->position().toPoint()))
                         dropRegionContainerWidget->getDropRegion()->drop();
                 }
             }


### PR DESCRIPTION
Previously it was specifically specified to only warn about Qt deprecation for Qt5 during compilation. In [this PR](https://github.com/ManiVaultStudio/core/commit/dc75971021b71abac90ed01fcc522124fd7b4bdf#diff-d25a36582785b5d2af7f79817ddb883e76a4d9a87322d53f3043c466907e3183L115) I removed that since we've been using use Qt6 for a while now.

In this PR I fixed the warnings for deprecated functions in Qt6.