### PR TITLE
Add zlib reference to help menu

### DIFF
--- a/ManiVault/src/private/HelpMenu.cpp
+++ b/ManiVault/src/private/HelpMenu.cpp
@@ -118,10 +118,10 @@ void HelpMenu::aboutThirdParties()
 {
     const QString message = QMessageBox::tr(
         "<p>ManiVault uses several third party libraries: </p>"
-        "&bull; Qt-Advanced-Docking-System (LGPL v2.1): <a href=\"http://%1/\">%1</a> <br>"
-        "&bull; Quazip (LGPL v2.1): <a href=\"http://%2/\">%2</a> <br>"
-        "&bull; zlib (zlib license): <a href=\"http://%3/\">%3</a> <br>"
-        "&bull; Qt ((L)GPL): <a href=\"http://%4/\">%4</a> "
+        "&bull; Qt-Advanced-Docking-System (LGPL v2.1): <a href=\"https://%1/\">%1</a> <br>"
+        "&bull; Quazip (LGPL v2.1): <a href=\"https://%2/\">%2</a> <br>"
+        "&bull; zlib (zlib license): <a href=\"https://%3/\">%3</a> <br>"
+        "&bull; Qt ((L)GPL): <a href=\"https://%4/\">%4</a> "
     ).arg(QStringLiteral("github.com/githubuser0xFFFF/Qt-Advanced-Docking-System"),
           QStringLiteral("github.com/stachenov/quazip"),
           QStringLiteral("zlib.net"),

--- a/ManiVault/src/private/HelpMenu.cpp
+++ b/ManiVault/src/private/HelpMenu.cpp
@@ -120,9 +120,11 @@ void HelpMenu::aboutThirdParties()
         "<p>ManiVault uses several third party libraries: </p>"
         "&bull; Qt-Advanced-Docking-System (LGPL v2.1): <a href=\"http://%1/\">%1</a> <br>"
         "&bull; Quazip (LGPL v2.1): <a href=\"http://%2/\">%2</a> <br>"
-        "&bull; Qt ((L)GPL): <a href=\"http://%3/\">%3</a> "
+        "&bull; zlib (zlib license): <a href=\"http://%3/\">%3</a> <br>"
+        "&bull; Qt ((L)GPL): <a href=\"http://%4/\">%4</a> "
     ).arg(QStringLiteral("github.com/githubuser0xFFFF/Qt-Advanced-Docking-System"),
           QStringLiteral("github.com/stachenov/quazip"),
+          QStringLiteral("zlib.net"),
           QStringLiteral("qt.io"));
 
     auto msgBox = new QMessageBox(this->parentWidget());


### PR DESCRIPTION
Since #635 we build zlib as part of the core and should mention it like the other dependencies in the help menu.

Also:
- Use `https` instead of `http`