### PR TITLE
Fix non pch build

### DIFF
--- a/ManiVault/src/AbstractProjectManager.h
+++ b/ManiVault/src/AbstractProjectManager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "AbstractManager.h"
+#include "Application.h"
 #include "Project.h"
 #include "ProjectSerializationTask.h"
 

--- a/ManiVault/src/Main.cpp
+++ b/ManiVault/src/Main.cpp
@@ -11,6 +11,8 @@
 #include <ProjectMetaAction.h>
 #include <ManiVaultVersion.h>
 
+#include <util/Icon.h>
+
 #include <QSurfaceFormat>
 #include <QStyleFactory>
 #include <QProxyStyle>

--- a/ManiVault/src/MiscellaneousSettingsAction.h
+++ b/ManiVault/src/MiscellaneousSettingsAction.h
@@ -6,6 +6,7 @@
 
 #include "GlobalSettingsGroupAction.h"
 
+#include "actions/OptionsAction.h"
 #include "actions/ToggleAction.h"
 
 namespace mv::gui

--- a/ManiVault/src/ProjectMetaAction.cpp
+++ b/ManiVault/src/ProjectMetaAction.cpp
@@ -3,8 +3,9 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "ProjectMetaAction.h"
-#include "Project.h"
 
+#include "Application.h"
+#include "Project.h"
 #include "util/Serialization.h"
 
 using namespace mv::gui;

--- a/ManiVault/src/actions/ApplicationIconAction.cpp
+++ b/ManiVault/src/actions/ApplicationIconAction.cpp
@@ -7,6 +7,7 @@
 #include <QMainWindow>
 
 #include "Application.h"
+#include "util/Icon.h"
 
 namespace mv::gui {
 

--- a/ManiVault/src/actions/ApplicationIconAction.h
+++ b/ManiVault/src/actions/ApplicationIconAction.h
@@ -6,6 +6,8 @@
 
 #include "actions/HorizontalGroupAction.h"
 #include "actions/IconPickerAction.h"
+#include "actions/ToggleAction.h"
+#include "actions/TriggerAction.h"
 
 #include <QTimer>
 

--- a/ManiVault/src/actions/IconAction.cpp
+++ b/ManiVault/src/actions/IconAction.cpp
@@ -4,6 +4,8 @@
 
 #include "IconAction.h"
 
+#include "util/Icon.h"
+
 #include <QBuffer>
 
 using namespace mv::util;

--- a/ManiVault/src/actions/IconPickerAction.cpp
+++ b/ManiVault/src/actions/IconPickerAction.cpp
@@ -4,6 +4,8 @@
 
 #include "IconPickerAction.h"
 
+#include "util/Icon.h"
+
 #include <QFileInfo>
 
 namespace mv::gui {

--- a/ManiVault/src/actions/ModelSelectionAction.h
+++ b/ManiVault/src/actions/ModelSelectionAction.h
@@ -8,6 +8,7 @@
 #include "TriggerAction.h"
 
 class QItemSelectionModel;
+class QAbstractItemModel;
 
 namespace mv::gui {
 

--- a/ManiVault/src/actions/OptionsAction.cpp
+++ b/ManiVault/src/actions/OptionsAction.cpp
@@ -6,6 +6,7 @@
 #include "ModelSelectionAction.h"
 
 #include "Application.h"
+#include "util/Miscellaneous.h"
 
 #include <QDebug>
 #include <QHeaderView>

--- a/ManiVault/src/actions/StatusBarAction.cpp
+++ b/ManiVault/src/actions/StatusBarAction.cpp
@@ -5,6 +5,7 @@
 #include "StatusBarAction.h"
 
 #include "Application.h"
+#include "CoreInterface.h"
 
 #ifdef _DEBUG
     #define STATUS_BAR_ACTION_VERBOSE

--- a/ManiVault/src/actions/TableAction.h
+++ b/ManiVault/src/actions/TableAction.h
@@ -13,6 +13,8 @@
 #include "ModelSelectionAction.h"
 #include "HorizontalHeaderAction.h"
 
+#include "WidgetActionWidget.h"
+
 #include "widgets/InfoOverlayWidget.h"
 
 #include <QWidget>

--- a/ManiVault/src/actions/ViewPluginSamplerAction.cpp
+++ b/ManiVault/src/actions/ViewPluginSamplerAction.cpp
@@ -4,6 +4,12 @@
 
 #include "ViewPluginSamplerAction.h"
 
+#include "ViewPlugin.h"
+
+#include "util/Exception.h"
+
+#include <QEvent>
+
 using namespace mv::util;
 
 namespace mv::gui {

--- a/ManiVault/src/actions/WidgetActionBadgeOverlayWidget.cpp
+++ b/ManiVault/src/actions/WidgetActionBadgeOverlayWidget.cpp
@@ -4,6 +4,8 @@
 
 #include "WidgetActionBadgeOverlayWidget.h"
 
+#include "WidgetAction.h"
+
 #include "util/Icon.h"
 
 #include <QPainter>

--- a/ManiVault/src/actions/WidgetActionBadgeOverlayWidget.h
+++ b/ManiVault/src/actions/WidgetActionBadgeOverlayWidget.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "actions/WidgetAction.h"
 #include "widgets/OverlayWidget.h"
 
 namespace mv::gui {

--- a/ManiVault/src/actions/WidgetActionCollapsedWidget.h
+++ b/ManiVault/src/actions/WidgetActionCollapsedWidget.h
@@ -13,8 +13,6 @@
 
 namespace mv::gui {
 
-class WidgetAction;
-
 /**
  * Widget action collapsed widget class
  * 

--- a/ManiVault/src/actions/WidgetActionViewWidget.cpp
+++ b/ManiVault/src/actions/WidgetActionViewWidget.cpp
@@ -3,11 +3,12 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "WidgetActionViewWidget.h"
+
+#include "CoreInterface.h"
+#include "WidgetAction.h"
 #include "WidgetActionCollapsedWidget.h"
 #include "WidgetActionHighlightWidget.h"
 #include "WidgetActionMimeData.h"
-#include "WidgetAction.h"
-#include "CoreInterface.h"
 
 #include <QDebug>
 #include <QDragEnterEvent>

--- a/ManiVault/src/actions/WidgetActionViewWidget.h
+++ b/ManiVault/src/actions/WidgetActionViewWidget.h
@@ -9,6 +9,8 @@
 
 #include <QWidget>
 
+#include <cstdint>
+
 namespace mv::gui {
 
 class WidgetAction;

--- a/ManiVault/src/actions/WidgetActionWidget.cpp
+++ b/ManiVault/src/actions/WidgetActionWidget.cpp
@@ -8,6 +8,7 @@
 #include <QDebug>
 #include <QVBoxLayout>
 #include <QGroupBox>
+#include <QLayout>
 
 namespace mv::gui {
 

--- a/ManiVault/src/actions/WidgetActionWidget.h
+++ b/ManiVault/src/actions/WidgetActionWidget.h
@@ -6,6 +6,9 @@
 
 #include "WidgetActionViewWidget.h"
 
+#include <QSize>
+#include <QWidget>
+
 namespace mv::gui {
 
 class WidgetAction;

--- a/ManiVault/src/models/AbstractDatasetsModel.h
+++ b/ManiVault/src/models/AbstractDatasetsModel.h
@@ -6,9 +6,10 @@
 
 #include "ManiVaultGlobals.h"
 
+#include "Dataset.h"
 #include "StandardItemModel.h"
 
-#include "Dataset.h"
+#include "actions/ToggleAction.h"
 
 #include <QList>
 #include <QStandardItem>

--- a/ManiVault/src/private/LearningPageContentWidget.cpp
+++ b/ManiVault/src/private/LearningPageContentWidget.cpp
@@ -4,6 +4,8 @@
 
 #include "LearningPageContentWidget.h"
 
+#include <CoreInterface.h>
+
 #include <QDebug>
 
 using namespace mv::gui;

--- a/ManiVault/src/private/LearningPageExamplesWidget.cpp
+++ b/ManiVault/src/private/LearningPageExamplesWidget.cpp
@@ -3,8 +3,11 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "LearningPageExamplesWidget.h"
-#include "LearningPageContentWidget.h"
 
+#include "LearningPageContentWidget.h"
+#include "PageContentWidget.h"
+
+#include <QApplication>
 #include <QDebug>
 #include <QStyledItemDelegate>
 

--- a/ManiVault/src/private/LearningPageExamplesWidget.h
+++ b/ManiVault/src/private/LearningPageExamplesWidget.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <QWidget>
+#include <QVBoxLayout>
 
 class LearningPageContentWidget;
 

--- a/ManiVault/src/private/LearningPagePluginAction.cpp
+++ b/ManiVault/src/private/LearningPagePluginAction.cpp
@@ -5,8 +5,10 @@
 #include "LearningPagePluginAction.h"
 
 #include <Application.h>
+#include <PluginFactory.h>
 
 #include <QDebug>
+#include <QEnterEvent>
 #include <QEvent>
 
 using namespace mv;

--- a/ManiVault/src/private/LearningPagePluginAction.h
+++ b/ManiVault/src/private/LearningPagePluginAction.h
@@ -6,8 +6,11 @@
 
 #include "util/WidgetOverlayer.h"
 
-#include <QWidget>
+#include <QLabel>
 #include <QHBoxLayout>
+#include <QWidget>
+
+#include <functional>
 
 namespace mv::plugin {
     class PluginFactory;

--- a/ManiVault/src/private/LearningPagePluginResourcesWidget.cpp
+++ b/ManiVault/src/private/LearningPagePluginResourcesWidget.cpp
@@ -8,6 +8,7 @@
 #include "LearningPagePluginAction.h"
 
 #include <Application.h>
+#include <CoreInterface.h>
 
 #include <QDebug>
 

--- a/ManiVault/src/private/LearningPagePluginResourcesWidget.h
+++ b/ManiVault/src/private/LearningPagePluginResourcesWidget.h
@@ -7,6 +7,7 @@
 #include <QWidget>
 #include <QVBoxLayout>
 
+#include <actions/OptionsAction.h> 
 #include <widgets/FlowLayout.h> 
 
 class LearningPageContentWidget;

--- a/ManiVault/src/private/LearningPageTutorialsWidget.cpp
+++ b/ManiVault/src/private/LearningPageTutorialsWidget.cpp
@@ -3,8 +3,11 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "LearningPageTutorialsWidget.h"
-#include "LearningPageContentWidget.h"
 
+#include "LearningPageContentWidget.h"
+#include "PageContentWidget.h"
+
+#include <QApplication>
 #include <QDebug>
 #include <QStyledItemDelegate>
 

--- a/ManiVault/src/private/LearningPageTutorialsWidget.h
+++ b/ManiVault/src/private/LearningPageTutorialsWidget.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <QVBoxLayout>
 #include <QWidget>
 
 class LearningPageContentWidget;

--- a/ManiVault/src/private/LearningPageVideoWidget.cpp
+++ b/ManiVault/src/private/LearningPageVideoWidget.cpp
@@ -11,10 +11,14 @@
 
 #include <widgets/YouTubeVideoDialog.h>
 
-#include <QDebug>
 #include <QAbstractTextDocumentLayout>
-#include <QEvent>
+#include <QDateTime>
+#include <QDebug>
 #include <QDesktopServices>
+#include <QEvent>
+#include <QLocale>
+#include <QModelIndex>
+#include <QString>
 
 //#define USE_YOUTUBE_DIALOG
 

--- a/ManiVault/src/private/LearningPageVideoWidget.h
+++ b/ManiVault/src/private/LearningPageVideoWidget.h
@@ -4,11 +4,15 @@
 
 #pragma once
 
-#include <QWidget>
-#include <QVBoxLayout>
-#include <QTextBrowser>
-
 #include <util/FileDownloader.h>
+#include <util/WidgetOverlayer.h>
+
+#include <QLabel>
+#include <QPersistentModelIndex>
+#include <QPixmap>
+#include <QTextBrowser>
+#include <QVBoxLayout>
+#include <QWidget>
 
 class LearningPageVideosWidget;
 

--- a/ManiVault/src/private/LearningPageVideosModel.cpp
+++ b/ManiVault/src/private/LearningPageVideosModel.cpp
@@ -5,6 +5,7 @@
 #include "LearningPageVideosModel.h"
 
 #include <QJsonArray>
+#include <QJsonDocument>
 
 #ifdef _DEBUG
     //#define LEARNING_PAGE_VIDEOS_MODEL_VERBOSE
@@ -67,7 +68,7 @@ QSet<QString> LearningPageVideosModel::getTagsSet() const
 
 void LearningPageVideosModel::populateFromServer()
 {
-    connect(&_fileDownloader, &FileDownloader::downloaded, this, [this]() -> void {
+    connect(&_fileDownloader, &mv::util::FileDownloader::downloaded, this, [this]() -> void {
         setRowCount(0);
 
         const auto jsonDocument = QJsonDocument::fromJson(_fileDownloader.downloadedData());

--- a/ManiVault/src/private/LearningPageVideosModel.h
+++ b/ManiVault/src/private/LearningPageVideosModel.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "util/FileDownloader.h"
+#include <util/FileDownloader.h>
 
 #include <QMap>
 #include <QStandardItemModel>

--- a/ManiVault/src/private/PageContentWidget.cpp
+++ b/ManiVault/src/private/PageContentWidget.cpp
@@ -5,7 +5,10 @@
 #include "PageContentWidget.h"
 #include "PageWidget.h"
 
+#include <QApplication>
 #include <QDebug>
+#include <QLabel>
+#include <QString>
 
 PageContentWidget::PageContentWidget(const Qt::Orientation& orientation, QWidget* parent /*= nullptr*/) :
     QWidget(parent),

--- a/ManiVault/src/private/PageContentWidget.h
+++ b/ManiVault/src/private/PageContentWidget.h
@@ -4,9 +4,11 @@
 
 #pragma once
 
-#include <QWidget>
-#include <QVBoxLayout>
 #include <QHBoxLayout>
+#include <QLabel>
+#include <QString>
+#include <QVBoxLayout>
+#include <QWidget>
 
 /**
  * Page content widget class

--- a/ManiVault/src/private/PageHeaderWidget.cpp
+++ b/ManiVault/src/private/PageHeaderWidget.cpp
@@ -5,13 +5,11 @@
 #include "PageHeaderWidget.h"
 #include "PageWidget.h"
 
+#include <QApplication>
 #include <QDebug>
 #include <QResizeEvent>
 
 #include <algorithm>
-
-using namespace mv;
-using namespace mv::gui;
 
 PageHeaderWidget::PageHeaderWidget(const QString& title, QWidget* parent /*= nullptr*/) :
     QWidget(parent),

--- a/ManiVault/src/private/PageWidget.cpp
+++ b/ManiVault/src/private/PageWidget.cpp
@@ -4,6 +4,7 @@
 
 #include "PageWidget.h"
 
+#include <QApplication>
 #include <QDebug>
 #include <QPainter>
 

--- a/ManiVault/src/private/StartPageContentWidget.cpp
+++ b/ManiVault/src/private/StartPageContentWidget.cpp
@@ -7,6 +7,8 @@
 #include "StartPageAction.h"
 #include "StartPageWidget.h"
 
+#include <CoreInterface.h>
+
 #include <QDebug>
 
 using namespace mv;

--- a/ManiVault/src/private/StartupProjectsModel.cpp
+++ b/ManiVault/src/private/StartupProjectsModel.cpp
@@ -4,7 +4,10 @@
 
 #include "StartupProjectsModel.h"
 
+#include <ProjectMetaAction.h>
 #include <util/Icon.h>
+
+#include <QString>
 
 #ifdef _DEBUG
     #define STARTUP_PROJECTS_MODEL_VERBOSE

--- a/ManiVault/src/private/StartupProjectsModel.h
+++ b/ManiVault/src/private/StartupProjectsModel.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <models/StandardItemModel.h>
+#include <ProjectMetaAction.h>
 
 #include <QList>
 #include <QStandardItem>

--- a/ManiVault/src/private/WorkspaceStatusBarAction.cpp
+++ b/ManiVault/src/private/WorkspaceStatusBarAction.cpp
@@ -5,6 +5,7 @@
 #include "WorkspaceStatusBarAction.h"
 
 #include <actions/LockingAction.h>
+#include <CoreInterface.h>
 
 #ifdef _DEBUG
     #define WORKSPACE_STATUS_BAR_ACTION_VERBOSE

--- a/ManiVault/src/util/FileDownloader.h
+++ b/ManiVault/src/util/FileDownloader.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "ManiVaultGlobals.h"
+
 #include <QObject>
 #include <QUrl>
 #include <QByteArray>

--- a/ManiVault/src/widgets/MarkdownDocument.cpp
+++ b/ManiVault/src/widgets/MarkdownDocument.cpp
@@ -8,8 +8,6 @@
     #define MARKDOWN_DOCUMENT_VERBOSE
 #endif
 
-using namespace mv::gui;
-
 namespace mv::util {
 
 MarkdownDocument::MarkdownDocument(QObject* parent /*= nullptr*/) :

--- a/ManiVault/src/widgets/YouTubeVideoDialog.h
+++ b/ManiVault/src/widgets/YouTubeVideoDialog.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "ManiVaultGlobals.h"
+
 #include <QDialog>
 
 #include <QWebEngineView>


### PR DESCRIPTION
Currently, there are a bunch of missing includes when `MV_PRECOMPILE_HEADERS` is `OFF`.

This PR adds them such that compiling without pre-compiled headers works again.