### PR TITLE
Add missing Q_OBJECTs

### DIFF
--- a/ManiVault/src/actions/ApplicationIconAction.h
+++ b/ManiVault/src/actions/ApplicationIconAction.h
@@ -22,6 +22,8 @@ namespace mv::gui {
  */
 class CORE_EXPORT ApplicationIconAction : public HorizontalGroupAction
 {
+    Q_OBJECT
+    
 public:
 
     /**

--- a/ManiVault/src/actions/IconAction.h
+++ b/ManiVault/src/actions/IconAction.h
@@ -19,6 +19,8 @@ namespace mv::gui {
  */
 class CORE_EXPORT IconAction : public TriggerAction
 {
+    Q_OBJECT
+    
 public:
 
     /**


### PR DESCRIPTION
These two files are decorated with [`Q_INVOKABLE`](https://doc.qt.io/qt-6/qobject.html#Q_INVOKABLE) but miss `Q_OBJECT`.

Found with:
```bash
#!/bin/bash

# Search for all .h files in subdirectories
find . -type f -name "*.h" | while read file; do
  # Check if the file contains "Q_INVOKABLE" but not "Q_OBJECT"
  if grep -q "Q_INVOKABLE" "$file" && ! grep -q "Q_OBJECT" "$file"; then
    echo "$file"
  fi
done
```

> ./ManiVault/src/actions/ApplicationIconAction.h
> ./ManiVault/src/actions/IconAction.h