### PR TITLE
Option to use native or Qt file dialog, default to native

### DIFF
--- a/ManiVault/src/actions/FilePickerAction.cpp
+++ b/ManiVault/src/actions/FilePickerAction.cpp
@@ -24,7 +24,8 @@ FilePickerAction::FilePickerAction(QObject* parent, const QString& title, const 
     _pickAction(this, "Pick"),
     _nameFilters(),
     _defaultSuffix(),
-    _fileType("File")
+    _fileType("File"),
+    _useNativeDialog(true)
 {
     setText(title);
     setDefaultWidgetFlags(WidgetFlag::Default);
@@ -73,7 +74,9 @@ FilePickerAction::FilePickerAction(QObject* parent, const QString& title, const 
         fileDialog->setNameFilters(getNameFilters());
         fileDialog->setDefaultSuffix(getDefaultSuffix());
         fileDialog->setDirectory(Application::current()->getSetting(getSettingsPrefix(), QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation)).toString());
-        fileDialog->setOption(QFileDialog::DontUseNativeDialog, true);
+        
+        if(!_useNativeDialog)
+            fileDialog->setOption(QFileDialog::DontUseNativeDialog, true);
 
 		connect(fileDialog, &QFileDialog::accepted, this, [this, fileDialog]() -> void {
             if (fileDialog->selectedFiles().count() != 1)
@@ -164,6 +167,16 @@ void FilePickerAction::setPlaceHolderString(const QString& placeholderString)
 QString FilePickerAction::getDirectoryName() const
 {
     return QDir(getFilePath()).dirName();
+}
+
+void FilePickerAction::setUseNativeFileDialog(bool useNativeDialog)
+{
+    _useNativeDialog = useNativeDialog;
+}
+
+bool FilePickerAction::getUseNativeFileDialog() const
+{
+    return _useNativeDialog;
 }
 
 bool FilePickerAction::isValid() const

--- a/ManiVault/src/actions/FilePickerAction.h
+++ b/ManiVault/src/actions/FilePickerAction.h
@@ -126,6 +126,18 @@ public:
     QString getDirectoryName() const;
 
     /**
+     * Set whether to use native or Qt file dialog
+     * @param useNativeDialog Whether to use native or Qt file dialog
+     */
+    void setUseNativeFileDialog(bool useNativeDialog);
+
+    /**
+     * Get whether to use native or Qt file dialog
+     * @return Bool whether to use native or Qt file dialog
+     */
+    bool getUseNativeFileDialog() const;
+
+    /**
      * Get whether the directory is valid or not
      * @return Boolean indication whether the directory is valid or not
      */
@@ -178,6 +190,7 @@ private:
     QStringList                 _nameFilters;       /** File type filters */
     QString                     _defaultSuffix;     /** Default suffix */
     QString                     _fileType;          /** File type (e.g. image and project)*/
+    bool                        _useNativeDialog;   /** Whether to use native or Qt file dialog */
 };
 
 }


### PR DESCRIPTION
We use the native file dialog in [LoaderPlugin::AskForFileName](https://github.com/ManiVaultStudio/core/blob/4b0dd0bfb085b88443b2f728dbe9140a03f9a2c8/ManiVault/src/LoaderPlugin.cpp#L19) and should also do so in the `FilePickerAction`.

- Adds option to use native or Qt file dialog
- Defaults to native file dialog (new behavior)