### PR TITLE
Fix misleading warning

### DIFF
--- a/ManiVault/src/private/PluginManager.cpp
+++ b/ManiVault/src/private/PluginManager.cpp
@@ -167,6 +167,9 @@ void PluginManager::loadPluginFactories()
                 }
             }
 
+            if (dynamicLibsToLoad.isEmpty())
+                break;
+
             if (++currentTry >= maxTries)
             {
                 qWarning() << "Could not load all dependencies for " << pluginName << ". Missing: " << dynamicLibsToLoad;


### PR DESCRIPTION
Break when all dependencies are loaded, no need to print a warning when everything went well.