### PR TITLE
Fix HTML rendering problems in sample scope plugin

### DIFF
--- a/ManiVault/src/actions/OptionsAction.h
+++ b/ManiVault/src/actions/OptionsAction.h
@@ -187,7 +187,7 @@ public: // Widgets
              * Invoked when the user presses the mouse
              * @param event Pointer to mouse event
              */
-            void mousePressEvent(QMouseEvent* event);
+            void mousePressEvent(QMouseEvent* event) override;
 
             /**
              * Triggered on mouse hover

--- a/ManiVault/src/actions/WidgetAction.h
+++ b/ManiVault/src/actions/WidgetAction.h
@@ -209,7 +209,7 @@ public: // Hierarchy queries
      */
     template<typename WidgetActionType = WidgetAction>
     std::uint32_t getNumberOfChildren(bool recursively = false) const {
-        return getChildren<WidgetActionType>(recursively).count();
+        return static_cast<std::uint32_t>(getChildren<WidgetActionType>(recursively).count());
     }
 
     /**
@@ -227,7 +227,7 @@ public: // Hierarchy queries
      */
     template<typename WidgetActionType = WidgetAction>
     std::int32_t getDepth() const {
-        return getAncestors<WidgetActionType>().count();
+        return static_cast<std::int32_t>(getAncestors<WidgetActionType>().count());
     }
 
     /**

--- a/ManiVault/src/plugins/SampleScopePlugin/src/SampleScopeWidget.cpp
+++ b/ManiVault/src/plugins/SampleScopePlugin/src/SampleScopeWidget.cpp
@@ -17,7 +17,7 @@ using namespace mv::plugin;
 SampleScopeWidget::SampleScopeWidget(SampleScopePlugin* sampleScopePlugin, QWidget* parent /*= nullptr*/) :
     QWidget(parent),
     _sampleScopePlugin(sampleScopePlugin),
-    _noSamplesOverlayWidget(&_textScrollArea, Application::getIconFont("FontAwesome").getIcon("eye-dropper"), "No samples view", "There is currently no samples view available...")
+    _noSamplesOverlayWidget(&_textHtmlView, Application::getIconFont("FontAwesome").getIcon("eye-dropper"), "No samples view", "There is currently no samples view available...")
 {
     setAutoFillBackground(true);
     setLayout(&_layout);
@@ -30,28 +30,14 @@ SampleScopeWidget::SampleScopeWidget(SampleScopePlugin* sampleScopePlugin, QWidg
     widgetFader.setFadeOutDuration(300);
 
     _layout.setContentsMargins(0, 0, 0, 0);
-    _layout.addWidget(&_textScrollArea);
-
-    _textScrollArea.setWidgetResizable(true);
-    _textScrollArea.setWidget(&_textWidget);
-    _textScrollArea.setObjectName("Shortcuts");
-    //_textScrollArea.setStyleSheet("QScrollArea#Shortcuts { border: none; }");
-    _textScrollArea.setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-
-    _textWidgetLayout.setContentsMargins(4, 4, 4, 4);
-    _textWidgetLayout.addWidget(&_textBodyLabel);
-    _textWidgetLayout.setAlignment(Qt::AlignTop);
-
-    _textWidget.setLayout(&_textWidgetLayout);
-    
-    _textBodyLabel.setWordWrap(true);
+    _layout.addWidget(&_textHtmlView);
 
     _noSamplesOverlayWidget.show();
 }
 
 void SampleScopeWidget::setHtmlText(const QString& htmlText)
 {
-    _textBodyLabel.setText(htmlText);
+    _textHtmlView.setHtml(htmlText);
 }
 
 InfoOverlayWidget& SampleScopeWidget::getNoSamplesOverlayWidget()

--- a/ManiVault/src/plugins/SampleScopePlugin/src/SampleScopeWidget.h
+++ b/ManiVault/src/plugins/SampleScopePlugin/src/SampleScopeWidget.h
@@ -6,10 +6,9 @@
 
 #include <widgets/InfoOverlayWidget.h>
 
-#include <QLabel>
-#include <QScrollArea>
 #include <QWidget>
 #include <QVBoxLayout>
+#include <QWebEngineView>
 
 class SampleScopePlugin;
 
@@ -46,9 +45,6 @@ public:
 private:
     SampleScopePlugin*              _sampleScopePlugin;         /** Pointer to parent sample scope plugin */
     QVBoxLayout                     _layout;                    /** Main layout */
-    QScrollArea                     _textScrollArea;            /** Scroll area for the label */
-    QWidget                         _textWidget;                /** Widget with the shortcuts label */
-    QVBoxLayout                     _textWidgetLayout;          /** Layout for the label */
-    QLabel                          _textBodyLabel;             /** Label for the body HTML text */
+    QWebEngineView                  _textHtmlView;              /** Web engine view in which the HTML is displayed */
     mv::gui::InfoOverlayWidget      _noSamplesOverlayWidget;    /** Overlay widget with a message saying there are no samples available */
 };

--- a/ManiVault/src/private/HelpManager.cpp
+++ b/ManiVault/src/private/HelpManager.cpp
@@ -14,13 +14,15 @@
 #include <QDesktopServices>
 #include <QMainWindow>
 
-using namespace mv;
 using namespace mv::gui;
 using namespace mv::util;
 
 #ifdef _DEBUG
     //#define HELP_MANAGER_VERBOSE
 #endif
+
+namespace mv
+{
 
 HelpManager::HelpManager() :
     AbstractHelpManager(),
@@ -126,4 +128,6 @@ Videos HelpManager::getVideos(const QStringList& tags) const
     }
 
     return videos;
+}
+
 }

--- a/ManiVault/src/private/HelpManager.h
+++ b/ManiVault/src/private/HelpManager.h
@@ -7,6 +7,9 @@
 #include "AbstractHelpManager.h"
 #include "HelpManagerVideosModel.h"
 
+namespace mv
+{
+
 class HelpManager final : public mv::AbstractHelpManager
 {
     Q_OBJECT
@@ -48,3 +51,5 @@ private:
     HelpManagerVideosModel      _videosModel;                   /** Videos model */
     
 };
+
+}

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -30,9 +30,11 @@
     //#define PROJECT_MANAGER_VERBOSE
 #endif
 
-using namespace mv;
 using namespace mv::util;
 using namespace mv::gui;
+
+namespace mv
+{
 
 ProjectManager::ProjectManager(QObject* parent /*= nullptr*/) :
     AbstractProjectManager(parent),
@@ -1064,4 +1066,6 @@ QVariantMap ProjectManager::toVariantMap() const
         return _project->toVariantMap();
 
     return QVariantMap();
+}
+
 }

--- a/ManiVault/src/private/ProjectManager.h
+++ b/ManiVault/src/private/ProjectManager.h
@@ -7,7 +7,9 @@
 #include <AbstractProjectManager.h>
 
 #include <QObject>
-#include <QPointer>
+
+namespace mv
+{
 
 /**
  * Project manager class
@@ -179,3 +181,5 @@ private:
     mv::gui::ToggleAction               _showStartPageAction;               /** Action for toggling the start page */
     mv::gui::TriggerAction              _backToProjectAction;               /** Action for going back to the project */
 };
+
+}


### PR DESCRIPTION
- [x] Switch to `QWebengineView` for HTML rendering
- [x] Enclose managers in `MV_Application` with `mv` namespaces where needed, see issue #707 
- [x] Fix several clang warnings