### PR TITLE
Fix find package definitions again

### DIFF
--- a/ManiVault/cmake/MvCoreConfig.cmake.in
+++ b/ManiVault/cmake/MvCoreConfig.cmake.in
@@ -1,19 +1,20 @@
 @PACKAGE_INIT@
 
-set(ManiVault_INSTALL_DIR "${CMAKE_CURRENT_LIST_DIR}/../../")
-set(ManiVault_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../$<CONFIGURATION>/include/")
-set(ManiVault_LIB_DIR "${CMAKE_CURRENT_LIST_DIR}/../../$<CONFIGURATION>/lib/")
-set(ManiVault_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "")
+# cannot call set_and_check on variables including $<CONFIGURATION>
+set_and_check(ManiVault_INSTALL_DIR "@PACKAGE_MV_INSTALL_DIR@")
+set(ManiVault_INCLUDE_DIR "@PACKAGE_MV_INSTALL_DIR@/$<CONFIGURATION>/include/")
+set(ManiVault_LIB_DIR "@PACKAGE_MV_INSTALL_DIR@/$<CONFIGURATION>/lib/")
+set_and_check(ManiVault_CMAKE_DIR "@PACKAGE_MV_INSTALL_DIR@/cmake/mv" CACHE INTERNAL "")
 
 list(APPEND ManiVault_LINK_LIBS ManiVault::Core ManiVault::PointData ManiVault::ClusterData ManiVault::ImageData ManiVault::ColorData ManiVault::TextData)
 
-include("${CMAKE_CURRENT_LIST_DIR}/ManiVaultTargets.cmake")
+include("${ManiVault_CMAKE_DIR}/ManiVaultTargets.cmake")
 
 check_required_components("@PROJECT_NAME@")
 
 # include some helper functions
-include("${CMAKE_CURRENT_LIST_DIR}/mv_install_dependencies_utils.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/mv_check_and_set_AVX.cmake")
+include("${ManiVault_CMAKE_DIR}/mv_install_dependencies_utils.cmake")
+include("${ManiVault_CMAKE_DIR}/mv_check_and_set_AVX.cmake")
 
 message(STATUS "Found ManiVault version ${ManiVault_VERSION}. Use for example as:")
 message(STATUS "   find_package(ManiVault COMPONENTS Core PointData ClusterData ImageData ColorData TextData CONFIG)")


### PR DESCRIPTION
Follow up to #714.

The previous PR did not solve the problem entirely, in fact in seems to have worsened it a little.

This change should ensure relative paths. See [CMakePackageConfigHelpers](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html) for more info.