### PR TITLE
Remove linked data

### DIFF
--- a/ManiVault/src/LinkedData.cpp
+++ b/ManiVault/src/LinkedData.cpp
@@ -194,6 +194,11 @@ void LinkedData::setMapping(SelectionMap& mapping)
     _mapping = mapping;
 }
 
+void LinkedData::setMapping(SelectionMap&& mapping)
+{
+    _mapping = std::move(mapping);
+}
+
 void LinkedData::fromVariantMap(const QVariantMap& variantMap)
 {
     Serializable::fromVariantMap(variantMap);

--- a/ManiVault/src/LinkedData.h
+++ b/ManiVault/src/LinkedData.h
@@ -95,7 +95,9 @@ public:
     const Dataset<DatasetImpl> getTargetDataset() const { return _targetDataSet; }
 
     const SelectionMap& getMapping() const;
+
     void setMapping(SelectionMap& map);
+    void setMapping(SelectionMap&& map);
 
     /**
      * Load from variant map

--- a/ManiVault/src/Set.cpp
+++ b/ManiVault/src/Set.cpp
@@ -14,6 +14,8 @@
 
 #include "Application.h"
 
+#include <algorithm>
+
 using namespace mv::gui;
 using namespace mv::util;
 
@@ -334,6 +336,31 @@ void DatasetImpl::addLinkedData(const mv::Dataset<DatasetImpl>& targetDataSet, m
 {
     _linkedData.emplace_back(toSmartPointer(), targetDataSet);
     _linkedData.back().setMapping(mapping);
+}
+
+void DatasetImpl::removeAllLinkedData()
+{
+    _linkedData.clear();
+}
+
+void DatasetImpl::removeLinkedDataset(const mv::Dataset<DatasetImpl>& targetDataSet)
+{
+    // erase-remove idiom (https://en.wikibooks.org/wiki/More_C++_Idioms/Erase-Remove) 
+    // removes all mappings to targetDataSet from _linkedData
+    _linkedData.erase(std::remove_if(_linkedData.begin(),
+        _linkedData.end(),
+        [targetDataSet](const mv::LinkedData& linkedSel) {return linkedSel.getTargetDataset() == targetDataSet; }),
+        _linkedData.end());
+}
+
+void DatasetImpl::removeLinkedDataMapping(const QString& mappingID)
+{
+    // removes specific mapping from _linkedData
+    _linkedData.erase(std::remove_if(_linkedData.begin(),
+        _linkedData.end(),
+        [mappingID](const mv::LinkedData& linkedSel) {return linkedSel.getId() == mappingID; }),
+        _linkedData.end());
+
 }
 
 DatasetImpl::DatasetImpl(const QString& rawDataName, bool mayUnderive /*= true*/, const QString& id /*= ""*/) :

--- a/ManiVault/src/Set.cpp
+++ b/ManiVault/src/Set.cpp
@@ -172,7 +172,7 @@ void DatasetImpl::fromVariantMap(const QVariantMap& variantMap)
         assert(_sourceDataset.isValid());
     }
 
-    // For backwards compatability, check PluginVersion
+    // For backwards compatibility, check PluginVersion
     if (!(variantMap["PluginVersion"] == "No Version") && !variantMap["Full"].toBool())
     {        
         if (variantMap.contains("FullDatasetID"))

--- a/ManiVault/src/Set.cpp
+++ b/ManiVault/src/Set.cpp
@@ -338,6 +338,12 @@ void DatasetImpl::addLinkedData(const mv::Dataset<DatasetImpl>& targetDataSet, m
     _linkedData.back().setMapping(mapping);
 }
 
+void DatasetImpl::addLinkedData(const mv::Dataset<DatasetImpl>& targetDataSet, mv::SelectionMap&& mapping)
+{
+    _linkedData.emplace_back(toSmartPointer(), targetDataSet);
+    _linkedData.back().setMapping(std::move(mapping));
+}
+
 void DatasetImpl::removeAllLinkedData()
 {
     _linkedData.clear();

--- a/ManiVault/src/Set.h
+++ b/ManiVault/src/Set.h
@@ -484,6 +484,23 @@ public: // Linked data
 
     void addLinkedData(const mv::Dataset<DatasetImpl>& targetDataSet, mv::SelectionMap& mapping);
 
+    /**
+     * Removes all mappings of global selection indices from this dataset
+     */
+    void removeAllLinkedData();
+
+    /**
+     * Removes mappings of global selection indices from this dataset to a target dataset
+     * @param targetDataSet The target dataset
+     */
+    void removeLinkedDataset(const mv::Dataset<DatasetImpl>& targetDataSet);
+
+    /**
+     * Removes a mapping from this dataset
+     * @param mappingID unique identifier (as obtained with getId()) of to-be-removed mapping
+     */
+    void removeLinkedDataMapping(const QString& mappingID);
+
     const std::vector<mv::LinkedData>& getLinkedData() const;
 
     std::vector<mv::LinkedData>& getLinkedData();

--- a/ManiVault/src/Set.h
+++ b/ManiVault/src/Set.h
@@ -484,6 +484,8 @@ public: // Linked data
 
     void addLinkedData(const mv::Dataset<DatasetImpl>& targetDataSet, mv::SelectionMap& mapping);
 
+    void addLinkedData(const mv::Dataset<DatasetImpl>& targetDataSet, mv::SelectionMap&& mapping);
+
     /**
      * Removes all mappings of global selection indices from this dataset
      */


### PR DESCRIPTION
Utility functions to remove linked data added with `addLinkedData`.

Also added `LinkedData::setMapping(SelectionMap&& mapping)` as a typical use case of selection map will be to first construct them in a plugin, set them in the core and then not use them in the plugin anymore.