### PR TITLE
Add image mask functions

### DIFF
--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -356,6 +356,15 @@ void Images::getMaskData(std::vector<std::uint8_t>& maskData)
 
     maskData = _maskData;
 }
+
+void Images::setMaskData(const std::vector<std::uint8_t>& maskData)
+{
+    _maskData = maskData;
+}
+
+void Images::setMaskData(std::vector<std::uint8_t>&& maskData)
+{
+    _maskData = std::move(maskData);
 }
 
 void Images::getSelectionData(std::vector<std::uint8_t>& selectionImageData, std::vector<std::uint32_t>& selectedIndices, QRect& selectionBoundaries)

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -692,6 +692,9 @@ void Images::computeMaskData()
         // Get global indices from points
         points->getGlobalIndices(globalIndices);
 
+        // All masked by default
+        std::fill(_maskData.begin(), _maskData.end(), 0);
+
         // Loop over all point indices and unmask them
         points->visitData([this, &points, &globalIndices](auto pointData) {
             for (std::int32_t localPointIndex = 0; localPointIndex < globalIndices.size(); localPointIndex++) {
@@ -727,6 +730,9 @@ void Images::computeMaskData()
 
         // Obtain reference to the clusters dataset
         auto clusters = Dataset<Clusters>(inputDataset);
+
+        // Mask out all points
+        std::fill(_maskData.begin(), _maskData.end(), 0);
 
         // Get clusters input points dataset
         auto points = clusters->getParent()->getSourceDataset<Points>();

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -12,9 +12,16 @@
 
 #include <DataHierarchyItem.h>
 #include <Dataset.h>
+#include <LinkedData.h>
 
 #include <ClusterData/ClusterData.h>
 #include <PointData/PointData.h>
+
+#include <cmath>
+#include <exception>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
 
 #include <QDebug>
 

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -821,6 +821,19 @@ void Images::fromVariantMap(const QVariantMap& variantMap)
     if (variantMap.contains("ImageFilePaths"))
         setImageFilePaths(variantMap["ImageFilePaths"].toStringList());
 
+    if (variantMap.contains("MaskData"))
+    {
+        auto size = _imageData->getImageSize();
+        _maskData.resize(static_cast<size_t>(size.width()) * size.height());
+        populateDataBufferFromVariantMap(variantMap["MaskData"].toMap(), (char*)_maskData.data());
+    }
+
+    if (variantMap.contains("VisibleRectangle"))
+    {
+        const auto visibleRectangle = variantMap["VisibleRectangle"].toMap();
+        _visibleRectangle = QRect(visibleRectangle["X"].toInt(), visibleRectangle["Y"].toInt(), visibleRectangle["Width"].toInt(), visibleRectangle["Height"].toInt());
+    }
+
     events().notifyDatasetDataChanged(this);
 }
 
@@ -834,6 +847,8 @@ QVariantMap Images::toVariantMap() const
     variantMap["ImageSize"]                     = QVariantMap({ { "Width", getImageSize().width() }, { "Height", getImageSize().height() } });
     variantMap["NumberOfComponentsPerPixel"]    = getNumberOfComponentsPerPixel();
     variantMap["ImageFilePaths"]                = getImageFilePaths();
+    variantMap["MaskData"]                      = rawDataToVariantMap((char*)_maskData.data(), _maskData.size() * sizeof(std::uint8_t), true);
+    variantMap["VisibleRectangle"]              = QVariantMap({ { "X", _visibleRectangle.x() }, { "Y", _visibleRectangle.y() },{ "Width", _visibleRectangle.width() }, { "Height", _visibleRectangle.height() } });
 
     return variantMap;
 }

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -379,6 +379,13 @@ void Images::setMaskData(std::vector<std::uint8_t>&& maskData)
     updateVisibleRectangle();
 }
 
+void Images::resetMaskData()
+{
+    _maskData.clear();
+    _maskDataGiven = false;
+    updateVisibleRectangle();
+}
+
 void Images::getSelectionData(std::vector<std::uint8_t>& selectionImageData, std::vector<std::uint32_t>& selectedIndices, QRect& selectionBoundaries)
 {
     try

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -273,7 +273,7 @@ void Images::getScalarData(const std::vector<std::uint32_t>& dimensionIndices, Q
                     getScalarDataForImageSequence(dimensionIndex, tempScalarData, tempScalarDataRange);
 
                     for (std::int32_t pixelIndex = 0; pixelIndex < numberOfPixels; pixelIndex++)
-                        scalarData[(pixelIndex * numberOfComponentsPerPixel) + componentIndex] = tempScalarData[pixelIndex];
+                        scalarData[static_cast<size_t>(pixelIndex * numberOfComponentsPerPixel) + componentIndex] = tempScalarData[pixelIndex];
 
                     componentIndex++;
                 }
@@ -289,7 +289,7 @@ void Images::getScalarData(const std::vector<std::uint32_t>& dimensionIndices, Q
                     getScalarDataForImageStack(dimensionIndex, tempScalarData, tempScalarDataRange);
 
                     for (std::int32_t pixelIndex = 0; pixelIndex < numberOfPixels; pixelIndex++)
-                        scalarData[(pixelIndex * numberOfComponentsPerPixel) + componentIndex] = tempScalarData[pixelIndex];
+                        scalarData[static_cast<size_t>(pixelIndex * numberOfComponentsPerPixel) + componentIndex] = tempScalarData[pixelIndex];
 
                     componentIndex++;
                 }

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -396,8 +396,6 @@ void Images::getSelectionData(std::vector<std::uint8_t>& selectionImageData, std
             selectedIndices.clear();
             selectedIndices.reserve(getNumberOfPixels());
 
-            const auto imageWidth = getImageSize().width();
-
             // Fill selection data with non-selected
             std::fill(selectionImageData.begin(), selectionImageData.end(), 0);
 
@@ -437,8 +435,6 @@ void Images::getSelectionData(std::vector<std::uint8_t>& selectionImageData, std
             // Clear the selected indices
             selectedIndices.clear();
             selectedIndices.reserve(getNumberOfPixels());
-
-            const auto imageWidth = getImageSize().width();
 
             // Fill selection data with non-selected
             std::fill(selectionImageData.begin(), selectionImageData.end(), 0);

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -360,11 +360,13 @@ void Images::getMaskData(std::vector<std::uint8_t>& maskData)
 void Images::setMaskData(const std::vector<std::uint8_t>& maskData)
 {
     _maskData = maskData;
+    updateVisibleRectangle();
 }
 
 void Images::setMaskData(std::vector<std::uint8_t>&& maskData)
 {
     _maskData = std::move(maskData);
+    updateVisibleRectangle();
 }
 
 void Images::getSelectionData(std::vector<std::uint8_t>& selectionImageData, std::vector<std::uint32_t>& selectedIndices, QRect& selectionBoundaries)
@@ -757,6 +759,11 @@ void Images::computeMaskData()
         }
     }
 
+    updateVisibleRectangle();
+}
+
+void Images::updateVisibleRectangle()
+{
     // Initialize visible rectangle with numeric extremes
     _visibleRectangle.setTop(std::numeric_limits<int>::max());
     _visibleRectangle.setBottom(std::numeric_limits<int>::lowest());
@@ -779,7 +786,6 @@ void Images::computeMaskData()
         _visibleRectangle.setTop(std::min(_visibleRectangle.top(), pixelCoordinate.y()));
         _visibleRectangle.setBottom(std::max(_visibleRectangle.bottom(), pixelCoordinate.y()));
     }
-    
 }
 
 QPoint Images::getPixelCoordinateFromPixelIndex(const std::int32_t& pixelIndex) const

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -351,7 +351,7 @@ void Images::getImageScalarData(std::uint32_t imageIndex, QVector<float>& scalar
 
 void Images::getMaskData(std::vector<std::uint8_t>& maskData)
 {
-    if (!_maskData.empty())
+    if (_maskData.empty())
         computeMaskData();
 
     maskData = _maskData;

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -677,6 +677,9 @@ void Images::computeMaskData()
     if (_maskData.size() != getNumberOfPixels())
         _maskData.resize(getNumberOfPixels());
 
+    // All masked by default
+    std::fill(_maskData.begin(), _maskData.end(), 0);
+
     // Get reference to input dataset
     auto inputDataset = getParent();
 
@@ -691,9 +694,6 @@ void Images::computeMaskData()
 
         // Get global indices from points
         points->getGlobalIndices(globalIndices);
-
-        // All masked by default
-        std::fill(_maskData.begin(), _maskData.end(), 0);
 
         // Loop over all point indices and unmask them
         points->visitData([this, &points, &globalIndices](auto pointData) {
@@ -730,9 +730,6 @@ void Images::computeMaskData()
 
         // Obtain reference to the clusters dataset
         auto clusters = Dataset<Clusters>(inputDataset);
-
-        // Mask out all points
-        std::fill(_maskData.begin(), _maskData.end(), 0);
 
         // Get clusters input points dataset
         auto points = clusters->getParent()->getSourceDataset<Points>();

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -656,21 +656,20 @@ void Images::computeMaskData()
 {
     //Timer timer(__FUNCTION__);
 
+    // Only compute if necessary
+    if (_maskData.size() == getNumberOfPixels())
+        return;
+    else
+        _maskData.resize(getNumberOfPixels(), 0);
+
     // Get reference to input dataset
     auto inputDataset = getParent();
-
-    // Allocate mask data
-    if (_maskData.size() != getNumberOfPixels())
-        _maskData.resize(getNumberOfPixels());
 
     // Generate mask data for points
     if (inputDataset->getDataType() == PointType) {
 
         // Obtain reference to the points dataset
         auto points = Dataset<Points>(inputDataset);
-
-        // All masked by default
-        std::fill(_maskData.begin(), _maskData.end(), 0);
 
         // Global indices into data
         std::vector<std::uint32_t> globalIndices;
@@ -713,9 +712,6 @@ void Images::computeMaskData()
 
         // Obtain reference to the clusters dataset
         auto clusters = Dataset<Clusters>(inputDataset);
-
-        // Mask out all points
-        std::fill(_maskData.begin(), _maskData.end(), 0);
 
         // Get clusters input points dataset
         auto points = clusters->getParent()->getSourceDataset<Points>();

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -352,9 +352,10 @@ void Images::getImageScalarData(std::uint32_t imageIndex, QVector<float>& scalar
 void Images::getMaskData(std::vector<std::uint8_t>& maskData)
 {
     if (!_maskData.empty())
-        maskData = _maskData;
-    else
         computeMaskData();
+
+    maskData = _maskData;
+}
 }
 
 void Images::getSelectionData(std::vector<std::uint8_t>& selectionImageData, std::vector<std::uint32_t>& selectedIndices, QRect& selectionBoundaries)

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -652,12 +652,12 @@ void Images::getScalarDataForImageStack(const std::uint32_t& dimensionIndex, QVe
     }
 }
 
-void Images::computeMaskData()
+void Images::computeMaskData(bool forceUpdate)
 {
     //Timer timer(__FUNCTION__);
 
     // Only compute if necessary
-    if (_maskData.size() == getNumberOfPixels())
+    if (!forceUpdate && _maskData.size() == getNumberOfPixels())
         return;
     else
         _maskData.resize(getNumberOfPixels(), 0);

--- a/ManiVault/src/plugins/ImageData/src/Images.h
+++ b/ManiVault/src/plugins/ImageData/src/Images.h
@@ -206,6 +206,18 @@ public:
     void getMaskData(std::vector<std::uint8_t>& maskData);
 
     /**
+     * Set mask image data
+     * @param maskData Mask scalar data
+     */
+    void setMaskData(const std::vector<std::uint8_t>& maskData);
+
+    /**
+     * Set mask image data
+     * @param maskData Mask scalar data
+     */
+    void setMaskData(std::vector<std::uint8_t>&& maskData);
+
+    /**
      * Get selection data
      * @param selectionImageData Image data for the selection
      * @param selectedIndices Selected pixel indices

--- a/ManiVault/src/plugins/ImageData/src/Images.h
+++ b/ManiVault/src/plugins/ImageData/src/Images.h
@@ -217,6 +217,11 @@ public:
      */
     void setMaskData(std::vector<std::uint8_t>&& maskData);
 
+    /** Computes and caches the mask data, if mask data is empty, based on linked data set to parent's points
+    * @param forceUpdate update mask data even if not empty (e.g. for when linked data changed)
+    */
+    void computeMaskData(bool forceUpdate = false);
+
     /**
      * Get selection data
      * @param selectionImageData Image data for the selection
@@ -242,9 +247,6 @@ protected:
      * @param scalarDataRange Scalar data range
      */
     void getScalarDataForImageStack(const std::uint32_t& dimensionIndex, QVector<float>& scalarData, QPair<float, float>& scalarDataRange);
-
-    /** Computes and caches the mask data */
-    void computeMaskData();
 
     /**
      * Get pixel coordinate from pixel index

--- a/ManiVault/src/plugins/ImageData/src/Images.h
+++ b/ManiVault/src/plugins/ImageData/src/Images.h
@@ -273,6 +273,12 @@ public: // Serialization
      */
     QVariantMap toVariantMap() const override;
 
+private: // Internal Helper
+    /**
+     * Sets _visibleRectangle based on _maskData
+     */
+    void updateVisibleRectangle();
+
 private:
     std::vector<std::uint32_t>      _indices;               /** Selection indices */
     ImageData*                      _imageData;             /** Pointer to raw image data */

--- a/ManiVault/src/plugins/ImageData/src/Images.h
+++ b/ManiVault/src/plugins/ImageData/src/Images.h
@@ -217,11 +217,6 @@ public:
      */
     void setMaskData(std::vector<std::uint8_t>&& maskData);
 
-    /** Computes and caches the mask data, if mask data is empty, based on linked data set to parent's points
-    * @param forceUpdate update mask data even if not empty (e.g. for when linked data changed)
-    */
-    void computeMaskData(bool forceUpdate = false);
-
     /**
      * Get selection data
      * @param selectionImageData Image data for the selection
@@ -247,6 +242,9 @@ protected:
      * @param scalarDataRange Scalar data range
      */
     void getScalarDataForImageStack(const std::uint32_t& dimensionIndex, QVector<float>& scalarData, QPair<float, float>& scalarDataRange);
+
+    /** Computes and caches the mask data, if mask data is not set by setMaskData, based on linked data set to parent's points */
+    void computeMaskData();
 
     /**
      * Get pixel coordinate from pixel index
@@ -287,4 +285,5 @@ private:
     QSharedPointer<InfoAction>      _infoAction;            /** Shared pointer to info action */
     QRect                           _visibleRectangle;      /** Rectangle which bounds the visible pixels */
     std::vector<std::uint8_t>       _maskData;              /** Mask data */
+    bool                            _maskDataGiven;         /** Wheter mask data was set externally */
 };

--- a/ManiVault/src/plugins/ImageData/src/Images.h
+++ b/ManiVault/src/plugins/ImageData/src/Images.h
@@ -218,6 +218,11 @@ public:
     void setMaskData(std::vector<std::uint8_t>&& maskData);
 
     /**
+     * Clears mask data
+     */
+    void resetMaskData();
+
+    /**
      * Get selection data
      * @param selectionImageData Image data for the selection
      * @param selectedIndices Selected pixel indices

--- a/ManiVault/src/util/Math.h
+++ b/ManiVault/src/util/Math.h
@@ -18,15 +18,15 @@ namespace util
 
 CORE_EXPORT float lerp(float v0, float v1, float t);
 
-CORE_EXPORT inline bool arePointsEqual(const QPointF& point1, const QPointF& point2, qreal epsilon = 1e-5) {
+inline bool arePointsEqual(const QPointF& point1, const QPointF& point2, qreal epsilon = 1e-5) {
     return qAbs(point1.x() - point2.x()) < epsilon && qAbs(point1.y() - point2.y()) < epsilon;
 }
 
-CORE_EXPORT inline bool areSizesEqual(const QSizeF& size1, const QSizeF& size2, qreal epsilon = 1e-5) {
+inline bool areSizesEqual(const QSizeF& size1, const QSizeF& size2, qreal epsilon = 1e-5) {
     return qAbs(size1.width() - size2.width()) < epsilon && qAbs(size1.height() - size2.height()) < epsilon;
 }
 
-CORE_EXPORT inline bool areRectanglesEqual(const QRectF& rect1, const QRectF& rect2, qreal epsilon = 1e-5) {
+inline bool areRectanglesEqual(const QRectF& rect1, const QRectF& rect2, qreal epsilon = 1e-5) {
     return arePointsEqual(rect1.topLeft(), rect2.topLeft()) && areSizesEqual(rect1.size(), rect2.size());
 }
 

--- a/ManiVault/src/util/Math.h
+++ b/ManiVault/src/util/Math.h
@@ -6,7 +6,7 @@
 
 #include "ManiVaultGlobals.h"
 
-#include <QtMath>
+#include <QtNumeric>
 #include <QPointF>
 #include <QRectF>
 #include <QSize>


### PR DESCRIPTION
- Add `Images::setMaskData`
- Change: Do not re-compute `_maskData` in `Images::computeMaskData` if it was set externally with `Images::setMaskData`
- Fix: `Images::getMaskData` should always populate the requested maskData

Also:
- Serialize `Images::_maskData` and `Images::_visibleRectangle`
- Inline header-defined functions do not need to be exported

--- 

Note:
Currently, `Images::computeMaskData` is called all the time, specifically from

[`ImageViewer::ImageSettingsAction`](https://github.com/ManiVaultStudio/ImageViewerPlugin/blob/ba44bba8720385af77f5c625455c28fcf0e27a83/src/ImageSettingsAction.cpp#L168) -> `_layer->computeSelectionIndices()`  -> `_imagesDataset->getSelectionData()` 
-> `Images::computeMaskData()`

We do not have a mechanism right now that notifies about changes to linked data with `DatasetImpl::addLinkedData` but it might be nice to only update `_maskData` when the linked data changed instead of updating it in each `getSelectionData()` call.
