### PR TITLE
Fix crash on open project

### DIFF
--- a/ManiVault/src/AbstractManager.h
+++ b/ManiVault/src/AbstractManager.h
@@ -177,12 +177,14 @@ public: // Locking
         return true;
     };
 
-public: // Core destruction
+protected: // Core destruction
 
     /** Mark core as destroyed */
     void setCoreIsDestroyed() {
         _coreIsDestroyed = true;
     }
+
+public: // Core destruction
 
     /**
      * Establish whether the core is destroyed
@@ -212,6 +214,8 @@ private:
     bool                    _coreIsDestroyed;   /** Boolean determining whether the core is destroyed */
     bool                    _isInitializing;    /** Boolean determining whether the manager is being initialized */
     bool                    _isResetting;       /** Boolean determining whether the manager is resetting */
+
+    friend class Core;
 };
 
 }

--- a/ManiVault/src/AbstractManager.h
+++ b/ManiVault/src/AbstractManager.h
@@ -41,7 +41,10 @@ public:
         QObject(parent),
         Serializable(name),
         _initialized(false),
-        _lockingAction(nullptr)
+        _lockingAction(nullptr),
+		_coreIsDestroyed(false),
+        _isInitializing(false),
+		_isResetting(false)
     {
     }
 
@@ -57,6 +60,8 @@ public:
 #endif
 
         emit managerAboutToBeReset();
+
+        _isResetting = true;
     }
 
     /** Resets the contents of the manager */
@@ -74,7 +79,9 @@ public:
 #ifdef ABSTRACT_MANAGER_VERBOSE
     qDebug() << __FUNCTION__;
 #endif
-        
+
+		_isResetting = false;
+
         emit managerReset();
     }
 
@@ -83,6 +90,8 @@ public:
 #ifdef ABSTRACT_MANAGER_VERBOSE
         qDebug() << __FUNCTION__;
 #endif
+
+        _isInitializing = true;
 
         if (isInitialized()) {
             qDebug() << getSerializationName() << "already initialized";
@@ -98,7 +107,8 @@ public:
         qDebug() << __FUNCTION__;
 #endif
 
-        _initialized = true;
+        _initialized    = true;
+        _isInitializing = false;
 
         emit managerInitialized();
     }
@@ -109,6 +119,22 @@ public:
      */
     bool isInitialized() const {
         return _initialized;
+    }
+
+    /**
+     * Get whether the manager is initializing or not
+     * @return Boolean determining whether the manager is initializing or not
+     */
+    bool isInitializing() const {
+	    return _isInitializing;
+    }
+
+    /**
+     * Get whether the manager is resetting or not
+     * @return Boolean determining whether the manager is resetting or not
+     */
+    bool isResetting() const {
+        return _isResetting;
     }
 
     /**
@@ -184,6 +210,8 @@ private:
     bool                    _initialized;       /** Whether the manager is initialized or not */
     gui::LockingAction*     _lockingAction;     /** Manager locking action */
     bool                    _coreIsDestroyed;   /** Boolean determining whether the core is destroyed */
+    bool                    _isInitializing;    /** Boolean determining whether the manager is being initialized */
+    bool                    _isResetting;       /** Boolean determining whether the manager is resetting */
 };
 
 }

--- a/ManiVault/src/AbstractPluginManager.h
+++ b/ManiVault/src/AbstractPluginManager.h
@@ -75,7 +75,7 @@ public: // Plugin creation/destruction
      * @return Pointer of \p PluginType to created plugin, nullptr if creation failed
      */
     template<typename PluginType>
-    inline PluginType* requestPlugin(const QString& kind, Datasets inputDatasets = Datasets(), Datasets outputDatasets = Datasets())
+    PluginType* requestPlugin(const QString& kind, Datasets inputDatasets = Datasets(), Datasets outputDatasets = Datasets())
     {
         return dynamic_cast<PluginType*>(requestPlugin(kind, inputDatasets, outputDatasets));
     }
@@ -108,12 +108,20 @@ public:
      */
     virtual plugin::ViewPlugin* requestViewPluginFloated(const QString& kind, Datasets datasets = Datasets()) = 0;
 
+public: // Destroy
+
     /**
      * Destroy \p plugin
      * @param plugin Pointer to the plugin that is to be destroyed
      */
     virtual void destroyPlugin(plugin::Plugin* plugin) = 0;
-    
+
+    /**
+     * Destroy plugin by \p pluginId
+     * @param pluginId Globally unique identifier of the plugin that is to be destroyed
+     */
+    virtual void destroyPluginById(const QString& pluginId) = 0;
+
 public: // Plugin factory
 
     /**

--- a/ManiVault/src/LoaderPlugin.cpp
+++ b/ManiVault/src/LoaderPlugin.cpp
@@ -4,6 +4,8 @@
 
 #include "LoaderPlugin.h"
 
+#include "Application.h"
+
 #include "actions/PluginTriggerAction.h"
 
 #include "widgets/FileDialog.h"

--- a/ManiVault/src/actions/PluginLearningCenterAction.cpp
+++ b/ManiVault/src/actions/PluginLearningCenterAction.cpp
@@ -8,6 +8,8 @@
 #include "Plugin.h"
 #include "ViewPlugin.h"
 
+#include "util/Miscellaneous.h"
+
 #include "widgets/ViewPluginLearningCenterOverlayWidget.h"
 #include "widgets/ViewPluginDescriptionOverlayWidget.h"
 #include "widgets/ViewPluginShortcutsDialog.h"

--- a/ManiVault/src/actions/WidgetAction.h
+++ b/ManiVault/src/actions/WidgetAction.h
@@ -206,7 +206,7 @@ public: // Hierarchy queries
     /**
      * Get number of children of \p WidgetActionType, possibly \p recursively
      * @param recursively Count recursively
-     * @returm Number of children
+     * @return Number of children
      */
     template<typename WidgetActionType = WidgetAction>
     std::uint32_t getNumberOfChildren(bool recursively = false) const {

--- a/ManiVault/src/actions/WidgetActionDrag.h
+++ b/ManiVault/src/actions/WidgetActionDrag.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "ManiVaultGlobals.h"
+
 #include <QObject>
 
 namespace mv::gui {

--- a/ManiVault/src/actions/WidgetActionToolButtonMenu.cpp
+++ b/ManiVault/src/actions/WidgetActionToolButtonMenu.cpp
@@ -18,7 +18,6 @@ WidgetActionToolButtonMenu::WidgetActionToolButtonMenu(WidgetActionToolButton& w
     QMenu(&widgetActionToolButton),
     _widgetActionToolButton(widgetActionToolButton),
     _deferredLoadWidgetAction(widgetActionToolButton),
-    _widgetConfigurationFunction(),
     _ignoreCloseEvent(false)
 {
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);

--- a/ManiVault/src/private/DataManager.cpp
+++ b/ManiVault/src/private/DataManager.cpp
@@ -219,7 +219,7 @@ QString DataManager::getRawDataType(const QString& rawDataName) const
     return "Undefined";
 }
 
-Dataset<DatasetImpl> DataManager::createDataset(const QString& kind, const QString& guiName, const Dataset<DatasetImpl>& parentDataset /*= Dataset<DatasetImpl>()*/, const QString& id /*= ""*/, bool notify /*= true*/)
+Dataset<> DataManager::createDataset(const QString& kind, const QString& guiName, const Dataset<DatasetImpl>& parentDataset /*= Dataset<DatasetImpl>()*/, const QString& id /*= ""*/, bool notify /*= true*/)
 {
 #ifdef DATA_MANAGER_VERBOSE
     qDebug() << "Create dataset" << kind << guiName;
@@ -251,7 +251,7 @@ Dataset<DatasetImpl> DataManager::createDataset(const QString& kind, const QStri
     return fullSet;
 }
 
-Dataset<DatasetImpl> DataManager::createDatasetWithoutSelection(const QString& kind, const QString& guiName, const Dataset<DatasetImpl>& parentDataset /*= Dataset<DatasetImpl>()*/, const QString& id /*= ""*/, bool notify /*= true*/)
+Dataset<> DataManager::createDatasetWithoutSelection(const QString& kind, const QString& guiName, const Dataset<DatasetImpl>& parentDataset /*= Dataset<DatasetImpl>()*/, const QString& id /*= ""*/, bool notify /*= true*/)
 {
 #ifdef DATA_MANAGER_VERBOSE
     qDebug() << "Create dataset without selection" << kind << guiName;

--- a/ManiVault/src/private/DockManager.cpp
+++ b/ManiVault/src/private/DockManager.cpp
@@ -142,6 +142,7 @@ void DockManager::removeViewPluginDockWidget(ViewPluginDockWidget* viewPluginDoc
 
     CDockManager::removeDockWidget((DockWidget*)viewPluginDockWidget);
 
+    viewPluginDockWidget->deleteLater();
     //delete viewPluginDockWidget;
 }
 

--- a/ManiVault/src/private/DockManager.cpp
+++ b/ManiVault/src/private/DockManager.cpp
@@ -14,8 +14,6 @@
 
 #include <DockAreaWidget.h> 
 
-#include <QSplitter>
-
 #ifdef _DEBUG
     //#define DOCK_MANAGER_VERBOSE
 #endif
@@ -61,7 +59,13 @@ DockManager::~DockManager()
 
 DockManager::ViewPluginDockWidgets DockManager::getViewPluginDockWidgets()
 {
-    return _viewPluginDockWidgets;
+    ViewPluginDockWidgets viewPluginDockWidgets;
+
+    for (auto dockWidget : dockWidgets())
+        if (auto viewPluginDockWidget = dynamic_cast<ViewPluginDockWidget*>(dockWidget))
+            viewPluginDockWidgets.push_back(viewPluginDockWidget);
+
+    return viewPluginDockWidgets;
 }
 
 DockManager::ViewPluginDockWidgets DockManager::getViewPluginDockWidgets() const
@@ -69,7 +73,7 @@ DockManager::ViewPluginDockWidgets DockManager::getViewPluginDockWidgets() const
     return const_cast<DockManager*>(this)->getViewPluginDockWidgets();
 }
 
-CDockAreaWidget* DockManager::findDockAreaWidget(mv::plugin::ViewPlugin* viewPlugin) const
+CDockAreaWidget* DockManager::findDockAreaWidget(const ViewPlugin* viewPlugin) const
 {
     if (viewPlugin == nullptr)
         return nullptr;
@@ -110,7 +114,7 @@ void DockManager::reset()
     CDockManager::removeAllDockAreas();
 
     for (const auto& viewPluginDockWidget : getViewPluginDockWidgets())
-        removeViewPluginDockWidget(viewPluginDockWidget.get());
+        removeViewPluginDockWidget(viewPluginDockWidget);
 }
 
 void DockManager::addViewPluginDockWidget(ads::DockWidgetArea area, ads::CDockWidget* dockWidget, ads::CDockAreaWidget* dockAreaWidget)
@@ -119,9 +123,6 @@ void DockManager::addViewPluginDockWidget(ads::DockWidgetArea area, ads::CDockWi
     qDebug() << __FUNCTION__ << objectName();
 #endif
     
-    if (auto viewPluginDockWidget = dynamic_cast<ViewPluginDockWidget*>(dockWidget))
-        _viewPluginDockWidgets.push_back(std::shared_ptr<ViewPluginDockWidget>(viewPluginDockWidget));
-
     CDockManager::addDockWidget(area, dockWidget, dockAreaWidget);
 }
 
@@ -131,19 +132,9 @@ void DockManager::removeViewPluginDockWidget(ViewPluginDockWidget* viewPluginDoc
     qDebug() << __FUNCTION__ << objectName();
 #endif
 
-    //viewPluginDockWidget->takeWidget();
-
-    auto shouldRemove = [viewPluginDockWidget](auto& viewPluginDockwidgetRemovalCandidate) -> bool {
-        return viewPluginDockwidgetRemovalCandidate->getId() == viewPluginDockWidget->getId();
-	};
-
-    //findDockAreaWidget(viewPluginDockWidget->getViewPlugin())->
-    //_viewPluginDockWidgets.erase(std::remove_if(_viewPluginDockWidgets.begin(), _viewPluginDockWidgets.end(), shouldRemove), _viewPluginDockWidgets.end());
-
     CDockManager::removeDockWidget((DockWidget*)viewPluginDockWidget);
 
     viewPluginDockWidget->deleteLater();
-    //delete viewPluginDockWidget;
 }
 
 QWidget* DockManager::getWidget()

--- a/ManiVault/src/private/DockManager.h
+++ b/ManiVault/src/private/DockManager.h
@@ -41,7 +41,8 @@ public:
     using CDockManager::grab;
     using CDockManager::setStyleSheet;
     using CDockManager::addDockWidgetFloating;
-    
+
+    using ViewPluginDockWidgets = std::vector<std::shared_ptr<ViewPluginDockWidget>>;
     
     /**
      * Constructs a dock manager derived from the advanced docking system
@@ -63,14 +64,14 @@ public:
      * Get view plugin dock widgets
      * @return Vector of pointers to plugin dock widgets
      */
-    const ViewPluginDockWidgets getViewPluginDockWidgets() const;
+    ViewPluginDockWidgets getViewPluginDockWidgets() const;
 
     /**
      * Find the dock area widget where the widget of \p viewPlugin resides
      * @param viewPlugin Pointer to view plugin that holds the widget
      * @return Pointer to ADS dock widget area (if found, otherwise nullptr)
      */
-    ads::CDockAreaWidget* findDockAreaWidget(mv::plugin::ViewPlugin* viewPlugin);
+    ads::CDockAreaWidget* findDockAreaWidget(mv::plugin::ViewPlugin* viewPlugin) const;
 
     /**
      * Remove \p viewPlugin from the dock manager
@@ -82,10 +83,10 @@ public:
     void reset();
 
     /** Adds a ViewPluginDockWidget */
-    void addViewPluginDockWidget(ads::DockWidgetArea area, ads::CDockWidget* Dockwidget, ads::CDockAreaWidget* DockAreaWidget = nullptr);
+    void addViewPluginDockWidget(ads::DockWidgetArea area, ads::CDockWidget* dockWidget, ads::CDockAreaWidget* dockAreaWidget = nullptr);
 
     /** Removes a ViewPluginDockWidget */
-    void removeViewPluginDockWidget(ads::CDockWidget* Dockwidget);
+    void removeViewPluginDockWidget(ViewPluginDockWidget* viewPluginDockWidget);
 
     /** get as QWidget pointer*/
     QWidget* getWidget();
@@ -93,7 +94,7 @@ public:
 public: // Serialization task
 
     /** Get task for reporting serialization progress */
-    mv::Task* getSerializationTask();
+    mv::Task* getSerializationTask() const;
 
     /**
      * Set task for reporting serialization progress to \p serializationTask
@@ -119,10 +120,8 @@ public: // Serialization
     friend class QPointer<DockManager>;
 
 private:
-    QString     _name;                  /** Dock manager name */
-    mv::Task*   _serializationTask;     /** For reporting serialization progress */
-    mv::Task    _layoutTask;            /** For reporting layout progress */
-
-private:
-    ViewPluginDockWidgets _orderedViewPluginDockWidgets; /* the ViewPluginDockWidgets in the order in which they were created */
+    QString                 _name;                      /** Dock manager name */
+    mv::Task*               _serializationTask;         /** For reporting serialization progress */
+    mv::Task                _layoutTask;                /** For reporting layout progress */
+    ViewPluginDockWidgets   _viewPluginDockWidgets;     /* The ViewPluginDockWidgets in the order in which they were created */
 };

--- a/ManiVault/src/private/DockManager.h
+++ b/ManiVault/src/private/DockManager.h
@@ -42,7 +42,7 @@ public:
     using CDockManager::setStyleSheet;
     using CDockManager::addDockWidgetFloating;
 
-    using ViewPluginDockWidgets = std::vector<std::shared_ptr<ViewPluginDockWidget>>;
+    using ViewPluginDockWidgets = std::vector<ViewPluginDockWidget*>;
     
     /**
      * Constructs a dock manager derived from the advanced docking system
@@ -71,7 +71,7 @@ public:
      * @param viewPlugin Pointer to view plugin that holds the widget
      * @return Pointer to ADS dock widget area (if found, otherwise nullptr)
      */
-    ads::CDockAreaWidget* findDockAreaWidget(mv::plugin::ViewPlugin* viewPlugin) const;
+    ads::CDockAreaWidget* findDockAreaWidget(const mv::plugin::ViewPlugin* viewPlugin) const;
 
     /**
      * Remove \p viewPlugin from the dock manager
@@ -120,8 +120,7 @@ public: // Serialization
     friend class QPointer<DockManager>;
 
 private:
-    QString                 _name;                      /** Dock manager name */
-    mv::Task*               _serializationTask;         /** For reporting serialization progress */
-    mv::Task                _layoutTask;                /** For reporting layout progress */
-    ViewPluginDockWidgets   _viewPluginDockWidgets;     /* The ViewPluginDockWidgets in the order in which they were created */
+    QString     _name;                      /** Dock manager name */
+    mv::Task*   _serializationTask;         /** For reporting serialization progress */
+    mv::Task    _layoutTask;                /** For reporting layout progress */
 };

--- a/ManiVault/src/private/DockWidget.cpp
+++ b/ManiVault/src/private/DockWidget.cpp
@@ -12,7 +12,7 @@
 #include <QToolButton>
 
 #ifdef _DEBUG
-    #define DOCK_WIDGET_VERBOSE
+    //#define DOCK_WIDGET_VERBOSE
 #endif
 
 using namespace ads;
@@ -50,8 +50,6 @@ DockWidget::~DockWidget()
 #ifdef DOCK_WIDGET_VERBOSE
     qDebug() << __FUNCTION__ << getSerializationName();
 #endif
-
-    //takeWidget();
 }
 
 bool DockWidget::event(QEvent* event)
@@ -105,7 +103,7 @@ QVariantMap DockWidget::toVariantMap() const
     return variantMap;
 }
 
-void DockWidget::updateStyle()
+void DockWidget::updateStyle() const
 {
     _settingsToolButton->setIcon(Application::getIconFont("FontAwesome").getIcon("bars"));
 }

--- a/ManiVault/src/private/DockWidget.cpp
+++ b/ManiVault/src/private/DockWidget.cpp
@@ -51,7 +51,7 @@ DockWidget::~DockWidget()
     qDebug() << __FUNCTION__ << getSerializationName();
 #endif
 
-    takeWidget();
+    //takeWidget();
 }
 
 bool DockWidget::event(QEvent* event)

--- a/ManiVault/src/private/DockWidget.cpp
+++ b/ManiVault/src/private/DockWidget.cpp
@@ -4,9 +4,6 @@
 
 #include "DockWidget.h"
 
-#include <ViewPlugin.h>
-
-#include <util/Serialization.h>
 #include <Application.h>
 
 #include <DockWidgetTab.h>

--- a/ManiVault/src/private/DockWidget.h
+++ b/ManiVault/src/private/DockWidget.h
@@ -35,7 +35,7 @@ public:
     DockWidget(const QString& title, QWidget* parent = nullptr);
 
     /** Destructor */
-    ~DockWidget();
+    ~DockWidget() override;
 
     /**
      * Get string that describes the dock widget type
@@ -68,7 +68,7 @@ public:
 protected:
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/DockWidget.h
+++ b/ManiVault/src/private/DockWidget.h
@@ -89,7 +89,7 @@ public: // Serialization
 public: // Themes
     
     /** refresh the widget and its children according to new style */
-    void updateStyle();
+    void updateStyle() const;
 
 private:
     QToolButton*    _settingsToolButton;    /** Pointer to settings tool button (located in the dock widget tab bar) */

--- a/ManiVault/src/private/PluginManager.h
+++ b/ManiVault/src/private/PluginManager.h
@@ -33,7 +33,7 @@ public:
     void reset() override;
 
     /** Loads all plugin factories from the plugin directory */
-    void loadPluginFactories();
+    void loadPluginFactories() override;
 
     /**
      * Determine whether a plugin of \p kind is loaded
@@ -78,13 +78,19 @@ private:
      */
     void addPlugin(plugin::Plugin* plugin) override;
 
-public:
+public: // Destroy
 
     /**
      * Destroy \p plugin
      * @param plugin Pointer to the plugin that is to be destroyed
      */
     void destroyPlugin(plugin::Plugin* plugin) override;
+
+    /**
+     * Destroy plugin by \p pluginId
+     * @param pluginId Globally unique identifier of the plugin that is to be destroyed
+     */
+    void destroyPluginById(const QString& pluginId) override;
 
 public: // Plugin factory
 
@@ -231,7 +237,7 @@ protected:
      * @param pluginDir Plugin scan directory
      * @return List of resolved plugin filenames
      */
-    QStringList resolveDependencies(QDir pluginDir) const;
+    QStringList resolveDependencies(QDir pluginDir) const override;
 
 private:
     QHash<QString, PluginFactory*>                  _pluginFactories;   /** All loaded plugin factories */

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -136,7 +136,13 @@ ProjectManager::ProjectManager(QObject* parent) :
     });
 
     connect(&_openProjectAction, &QAction::triggered, this, [this]() -> void {
-        openProject();
+        
+
+        // We defer opening the project with a timer because for some obscure reason, view plugin dock widgets are not
+        // properly removed (using deleteLater()) when openProject(...) is called immediately after resetting the
+        // workspace. QCoreApplication::processEvents() etc. is of no use here, tried numerous other things. This is a
+        // temporary solution, at some point we should revisit this issue...
+        QTimer::singleShot(1, this, [this] { openProject(); });
     });
 
     connect(&_importProjectAction, &QAction::triggered, this, [this]() -> void {
@@ -207,7 +213,13 @@ ProjectManager::ProjectManager(QObject* parent) :
     _recentProjectsAction.initialize("Manager/Project/Recent", "Project", "Ctrl", Application::getIconFont("FontAwesome").getIcon("file"));
 
     connect(&_recentProjectsAction, &RecentFilesAction::triggered, this, [this](const QString& filePath) -> void {
-        openProject(filePath);
+        workspaces().reset();
+
+        // We defer opening the project with a timer because for some obscure reason, view plugin dock widgets are not
+        // properly removed (using deleteLater()) when openProject(...) is called immediately after resetting the
+        // workspace. QCoreApplication::processEvents() etc. is of no use here, tried numerous other things. This is a
+        // temporary solution, at some point we should revisit this issue...
+        QTimer::singleShot(1, this, [this, filePath]() { openProject(filePath); });
     });
 
     connect(&_publishAction, &TriggerAction::triggered, this, [this]() -> void {
@@ -248,14 +260,11 @@ void ProjectManager::reset()
 
     beginReset();
     {
-        auto core = Application::core();
-
         if (!isCoreDestroyed()) {
-            core->getActionsManager().reset();
-            core->getPluginManager().reset();
-            core->getDataHierarchyManager().reset();
-            core->getDataManager().reset();
-            core->getWorkspaceManager().reset();
+            actions().reset();
+            dataHierarchy().reset();
+            data().reset();
+            plugins().reset();
         }
     }
     endReset();
@@ -343,7 +352,7 @@ void ProjectManager::openProject(QString filePath /*= ""*/, bool importDataOnly 
         qDebug() << __FUNCTION__ << filePath;
 #endif
 
-        emit projectAboutToBeOpened(*(_project.get()));
+        emit projectAboutToBeOpened(*_project);
         {
             const auto scopedState = ScopedState(this, State::OpeningProject);
 
@@ -422,7 +431,7 @@ void ProjectManager::openProject(QString filePath /*= ""*/, bool importDataOnly 
 
                 QEventLoop eventLoop;
                 
-                QObject::connect(&openFileDialog, &QDialog::finished, &eventLoop, &QEventLoop::quit);
+                connect(&fileDialog, &QDialog::finished, &eventLoop, &QEventLoop::quit);
                 
                 eventLoop.exec();
 
@@ -438,6 +447,10 @@ void ProjectManager::openProject(QString filePath /*= ""*/, bool importDataOnly 
             }
 
             qDebug().noquote() << "Open ManiVault project from" << filePath;
+
+            workspaces().reset();
+
+            QCoreApplication::processEvents();
 
             if (!importDataOnly)
                 newProject();
@@ -511,7 +524,7 @@ void ProjectManager::openProject(QString filePath /*= ""*/, bool importDataOnly 
 
             qDebug().noquote() << filePath << "loaded successfully";
         }
-        emit projectOpened(*(_project.get()));
+        emit projectOpened(*_project);
     }
     catch (std::exception& e)
     {
@@ -563,7 +576,7 @@ void ProjectManager::saveProject(QString filePath /*= ""*/, const QString& passw
 
         const auto scopedState = ScopedState(this, State::SavingProject);
 
-        emit projectAboutToBeSaved(*(_project.get()));
+        emit projectAboutToBeSaved(*_project);
         {
             if (QFileInfo(filePath).isDir())
                 throw std::runtime_error("Project file path may not be a directory");
@@ -722,7 +735,7 @@ void ProjectManager::saveProject(QString filePath /*= ""*/, const QString& passw
 
             qDebug().noquote() << filePath << "saved successfully";
         }
-        emit projectSaved(*(_project.get()));
+        emit projectSaved(*_project);
     }
     catch (std::exception& e)
     {
@@ -970,12 +983,12 @@ QString ProjectManager::extractFileFromManiVaultProject(const QString& maniVault
 
     QFileInfo extractFileInfo(temporaryDirectoryPath, extractFilePath);
 
-    Archiver archiver;
-
     QString extractedFilePath = "";
 
     try
     {
+        Archiver archiver;
+
         archiver.extractSingleFile(maniVaultFilePath, extractFilePath, extractFileInfo.absoluteFilePath());
 
         extractedFilePath = extractFileInfo.absoluteFilePath();
@@ -1007,8 +1020,8 @@ QImage ProjectManager::getWorkspacePreview(const QString& projectFilePath, const
         
         if (!workspacePreviewImage.isNull())
             return workspacePreviewImage.scaled(targetSize, Qt::KeepAspectRatio);
-        else
-            return {};
+        
+		return {};
     }
     catch (std::exception& e)
     {
@@ -1036,17 +1049,15 @@ void ProjectManager::createProject()
 {
     emit projectAboutToBeCreated();
     {
-        mv::data().reset();
+        data().reset();
 
         reset();
 
         _project.reset(new Project());
     }
-    emit projectCreated(*(_project.get()));
+    emit projectCreated(*_project);
 
     _showStartPageAction.setChecked(false);
-
-    workspaces().reset();
 }
 
 void ProjectManager::fromVariantMap(const QVariantMap& variantMap)
@@ -1059,7 +1070,7 @@ QVariantMap ProjectManager::toVariantMap() const
     if (hasProject())
         return _project->toVariantMap();
 
-    return QVariantMap();
+    return {};
 }
 
 }

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -136,13 +136,13 @@ ProjectManager::ProjectManager(QObject* parent) :
     });
 
     connect(&_openProjectAction, &QAction::triggered, this, [this]() -> void {
-        
+        workspaces().reset();
 
         // We defer opening the project with a timer because for some obscure reason, view plugin dock widgets are not
         // properly removed (using deleteLater()) when openProject(...) is called immediately after resetting the
         // workspace. QCoreApplication::processEvents() etc. is of no use here, tried numerous other things. This is a
         // temporary solution, at some point we should revisit this issue...
-        QTimer::singleShot(1, this, [this] { openProject(); });
+        QTimer::singleShot(100, this, [this] { openProject(); });
     });
 
     connect(&_importProjectAction, &QAction::triggered, this, [this]() -> void {
@@ -219,7 +219,7 @@ ProjectManager::ProjectManager(QObject* parent) :
         // properly removed (using deleteLater()) when openProject(...) is called immediately after resetting the
         // workspace. QCoreApplication::processEvents() etc. is of no use here, tried numerous other things. This is a
         // temporary solution, at some point we should revisit this issue...
-        QTimer::singleShot(1, this, [this, filePath]() { openProject(filePath); });
+        QTimer::singleShot(100, this, [this, filePath]() { openProject(filePath); });
     });
 
     connect(&_publishAction, &TriggerAction::triggered, this, [this]() -> void {

--- a/ManiVault/src/private/ViewPluginDockWidget.cpp
+++ b/ManiVault/src/private/ViewPluginDockWidget.cpp
@@ -67,12 +67,8 @@ ViewPluginDockWidget::~ViewPluginDockWidget()
     qDebug() << __FUNCTION__ << windowTitle();
 #endif
 
-    qDebug() << __FUNCTION__ << windowTitle();
-
 	serializationTasks.remove(getId());
     active.removeOne(this);
-
-    //takeWidget();
 }
 
 QString ViewPluginDockWidget::getTypeString() const
@@ -310,14 +306,14 @@ void ViewPluginDockWidget::setViewPlugin(mv::plugin::ViewPlugin* viewPlugin)
 	setWindowIcon(_viewPlugin->getIcon());
 	setProperty("ViewPluginId", _viewPlugin->getId());
 
-	//auto centralDockWidget = new CDockWidget("Central");
+	auto centralDockWidget = new CDockWidget("Central");
 
-	//centralDockWidget->setWidget(&_viewPlugin->getWidget(), eInsertMode::ForceNoScrollArea);
- //   centralDockWidget->setFeature(CDockWidget::DockWidgetDeleteOnClose, false);
+	centralDockWidget->setWidget(&_viewPlugin->getWidget(), eInsertMode::ForceNoScrollArea);
+    centralDockWidget->setFeature(CDockWidget::DockWidgetDeleteOnClose, false);
 
-	//_dockManager.setCentralWidget(centralDockWidget);
+	_dockManager.setCentralWidget(centralDockWidget);
 
-	//centralDockWidget->dockAreaWidget()->setAllowedAreas(DockWidgetArea::NoDockWidgetArea);
+	centralDockWidget->dockAreaWidget()->setAllowedAreas(DockWidgetArea::NoDockWidgetArea);
 
 	auto hideAllAction = new TriggerAction(this, "Hide All");
 	auto showAllAction = new TriggerAction(this, "Show All");

--- a/ManiVault/src/private/ViewPluginDockWidget.cpp
+++ b/ManiVault/src/private/ViewPluginDockWidget.cpp
@@ -41,7 +41,6 @@ ViewPluginDockWidget::ViewPluginDockWidget(const QString& title /*= ""*/, QWidge
 	_toggleMenu("Toggle", this),
 	_helpAction(this, "Help"),
 	_cachedVisibility(false),
-	_dockManager(this),
 	_progressOverlayWidget(this)
 {
 	active << this;
@@ -67,6 +66,8 @@ ViewPluginDockWidget::~ViewPluginDockWidget()
 #ifdef VIEW_PLUGIN_DOCK_WIDGET_VERBOSE
     qDebug() << __FUNCTION__ << windowTitle();
 #endif
+
+    qDebug() << __FUNCTION__ << windowTitle();
 
 	serializationTasks.remove(getId());
     active.removeOne(this);
@@ -309,13 +310,14 @@ void ViewPluginDockWidget::setViewPlugin(mv::plugin::ViewPlugin* viewPlugin)
 	setWindowIcon(_viewPlugin->getIcon());
 	setProperty("ViewPluginId", _viewPlugin->getId());
 
-	auto centralDockWidget = new CDockWidget("Central");
+	//auto centralDockWidget = new CDockWidget("Central");
 
-	centralDockWidget->setWidget(&_viewPlugin->getWidget(), eInsertMode::ForceNoScrollArea);
+	//centralDockWidget->setWidget(&_viewPlugin->getWidget(), eInsertMode::ForceNoScrollArea);
+ //   centralDockWidget->setFeature(CDockWidget::DockWidgetDeleteOnClose, false);
 
-	_dockManager.setCentralWidget(centralDockWidget);
+	//_dockManager.setCentralWidget(centralDockWidget);
 
-	centralDockWidget->dockAreaWidget()->setAllowedAreas(DockWidgetArea::NoDockWidgetArea);
+	//centralDockWidget->dockAreaWidget()->setAllowedAreas(DockWidgetArea::NoDockWidgetArea);
 
 	auto hideAllAction = new TriggerAction(this, "Hide All");
 	auto showAllAction = new TriggerAction(this, "Show All");

--- a/ManiVault/src/private/ViewPluginDockWidget.cpp
+++ b/ManiVault/src/private/ViewPluginDockWidget.cpp
@@ -168,12 +168,6 @@ void ViewPluginDockWidget::restoreViewPluginState() const
 	_viewPlugin->fromVariantMap(_viewPluginMap);
 }
 
-void ViewPluginDockWidget::restoreViewPluginStates()
-{
-	//for (auto viewPluginDockWidget : dynamic_cast<DockManager*>(dockManager())->getViewPluginDockWidgets())
-	//	viewPluginDockWidget->restoreViewPluginState();
-}
-
 QMenu* ViewPluginDockWidget::getSettingsMenu()
 {
 	return &_settingsMenu;

--- a/ManiVault/src/private/ViewPluginDockWidget.cpp
+++ b/ManiVault/src/private/ViewPluginDockWidget.cpp
@@ -30,8 +30,6 @@ using namespace mv::plugin;
 using namespace mv::util;
 using namespace mv::gui;
 
-QList<ViewPluginDockWidget*> ViewPluginDockWidget::active = QList<ViewPluginDockWidget*>();
-
 QMap<QString, Task*> ViewPluginDockWidget::serializationTasks = QMap<QString, Task*>();
 
 ViewPluginDockWidget::ViewPluginDockWidget(const QString& title /*= ""*/, QWidget* parent /*= nullptr*/) :
@@ -43,8 +41,6 @@ ViewPluginDockWidget::ViewPluginDockWidget(const QString& title /*= ""*/, QWidge
 	_cachedVisibility(false),
 	_progressOverlayWidget(this)
 {
-	active << this;
-
 	setFeature(CDockWidget::DockWidgetDeleteOnClose, false);
 	initialize();
 }
@@ -67,8 +63,9 @@ ViewPluginDockWidget::~ViewPluginDockWidget()
     qDebug() << __FUNCTION__ << windowTitle();
 #endif
 
+    qDebug() << __FUNCTION__ << windowTitle();
+
 	serializationTasks.remove(getId());
-    active.removeOne(this);
 }
 
 QString ViewPluginDockWidget::getTypeString() const
@@ -173,8 +170,8 @@ void ViewPluginDockWidget::restoreViewPluginState() const
 
 void ViewPluginDockWidget::restoreViewPluginStates()
 {
-	for (auto viewPluginDockWidget : ViewPluginDockWidget::active)
-		viewPluginDockWidget->restoreViewPluginState();
+	//for (auto viewPluginDockWidget : dynamic_cast<DockManager*>(dockManager())->getViewPluginDockWidgets())
+	//	viewPluginDockWidget->restoreViewPluginState();
 }
 
 QMenu* ViewPluginDockWidget::getSettingsMenu()

--- a/ManiVault/src/private/ViewPluginDockWidget.cpp
+++ b/ManiVault/src/private/ViewPluginDockWidget.cpp
@@ -17,7 +17,6 @@
 
 #include <DockWidgetTab.h>
 #include <DockAreaWidget.h>
-#include <DockAreaTitleBar.h>
 #include <AutoHideDockContainer.h>
 
 #ifdef _DEBUG
@@ -70,6 +69,9 @@ ViewPluginDockWidget::~ViewPluginDockWidget()
 #endif
 
 	serializationTasks.remove(getId());
+    active.removeOne(this);
+
+    //takeWidget();
 }
 
 QString ViewPluginDockWidget::getTypeString() const
@@ -88,19 +90,6 @@ void ViewPluginDockWidget::initialize()
 
 	connect(&_helpAction, &TriggerAction::triggered, this, [this]() -> void {
 		_viewPlugin->getLearningCenterAction().getViewHelpAction().trigger();
-	});
-
-	connect(&plugins(), &AbstractPluginManager::pluginAboutToBeDestroyed, this, [this](plugin::Plugin* plugin) -> void {
-		if (plugin != _viewPlugin)
-			return;
-
-#ifdef VIEW_PLUGIN_DOCK_WIDGET_VERBOSE
-        qDebug() << "Remove active view plugin dock widget" << plugin->getGuiName();
-#endif
-
-		active.removeOne(this);
-
-		takeWidget();
 	});
 
 	connect(&_settingsMenu, &QMenu::aboutToShow, this, [this]() -> void {
@@ -172,12 +161,12 @@ void ViewPluginDockWidget::loadViewPlugin()
 		setViewPlugin(viewPlugin);
 }
 
-ViewPlugin* ViewPluginDockWidget::getViewPlugin()
+ViewPlugin* ViewPluginDockWidget::getViewPlugin() const
 {
 	return _viewPlugin;
 }
 
-void ViewPluginDockWidget::restoreViewPluginState()
+void ViewPluginDockWidget::restoreViewPluginState() const
 {
 	if (!_viewPlugin)
 		return;
@@ -470,7 +459,7 @@ void ViewPluginDockWidget::setViewPlugin(mv::plugin::ViewPlugin* viewPlugin)
 		toggleView(toggled);
 	});
 
-	connect(this, &CDockWidget::viewToggled, this, [this, viewPlugin](bool toggled) {
+	connect(this, &CDockWidget::viewToggled, viewPlugin, [this, viewPlugin](bool toggled) {
 		QSignalBlocker toggleActionBlocker(&viewPlugin->getVisibleAction());
 
 		viewPlugin->getVisibleAction().setChecked(toggled);

--- a/ManiVault/src/private/ViewPluginDockWidget.h
+++ b/ManiVault/src/private/ViewPluginDockWidget.h
@@ -193,7 +193,7 @@ public: // View plugin isolation
 private:
 
     /**
-     * Assign \p viewPlugin to dock widget (configures the dock widget properties and sets the dock widget widget)
+     * Assign \p viewPlugin to dock widget (configures the dock widget properties and sets the dock widget)
      * @param viewPlugin Pointer to view plugin
      */
     void setViewPlugin(mv::plugin::ViewPlugin* viewPlugin);

--- a/ManiVault/src/private/ViewPluginDockWidget.h
+++ b/ManiVault/src/private/ViewPluginDockWidget.h
@@ -133,10 +133,10 @@ public:
      * Get the view plugin
      * @return Pointer to view plugin (might be nullptr)
      */
-    mv::plugin::ViewPlugin* getViewPlugin();
+    mv::plugin::ViewPlugin* getViewPlugin() const;
 
     /** Restores the view plugin state */
-    void restoreViewPluginState();
+    void restoreViewPluginState() const;
 
     /** Restores the view plugin states of all active view plugins */
     static void restoreViewPluginStates();
@@ -222,5 +222,3 @@ protected:
     friend class ViewPluginsDockWidget;
     friend class WorkspaceManager;
 };
-
-using ViewPluginDockWidgets = QVector<QPointer<ViewPluginDockWidget>>;

--- a/ManiVault/src/private/ViewPluginDockWidget.h
+++ b/ManiVault/src/private/ViewPluginDockWidget.h
@@ -138,9 +138,6 @@ public:
     /** Restores the view plugin state */
     void restoreViewPluginState() const;
 
-    /** Restores the view plugin states of all active view plugins */
-    static void restoreViewPluginStates();
-
 public: // Title bar settings menu
 
     /**

--- a/ManiVault/src/private/ViewPluginDockWidget.h
+++ b/ManiVault/src/private/ViewPluginDockWidget.h
@@ -199,19 +199,18 @@ private:
     void setViewPlugin(mv::plugin::ViewPlugin* viewPlugin);
 
 private:
-    mv::plugin::ViewPlugin*         _viewPlugin;                /** Pointer to view plugin */
-    QString                         _viewPluginKind;            /** Kind of (view) plugin */
-    QVariantMap                     _viewPluginMap;             /** View plugin cached map for deferred loading */
-    QMenu                           _settingsMenu;              /** Menu for view plugin settings */
-    QMenu                           _toggleMenu;                /** Menu for toggling view plugin dock widgets */
-    mv::gui::TriggerAction          _helpAction;                /** Action for triggering help */
-    bool                            _cachedVisibility;          /** Cached visibility for view plugin isolation */
-    ads::CDockManager               _dockManager;               /** Dock manager for internal docking */
-    QMap<QString, CDockWidget*>     _settingsDockWidgetsMap;    /** Created dock widgets for settings actions */
-    ProgressOverlayWidget           _progressOverlayWidget;     /** Overlay widget which shows a very thin view progress bar */
+    QPointer<mv::plugin::ViewPlugin>    _viewPlugin;                /** Pointer to view plugin */
+    QString                             _viewPluginKind;            /** Kind of (view) plugin */
+    QVariantMap                         _viewPluginMap;             /** View plugin cached map for deferred loading */
+    QMenu                               _settingsMenu;              /** Menu for view plugin settings */
+    QMenu                               _toggleMenu;                /** Menu for toggling view plugin dock widgets */
+    mv::gui::TriggerAction              _helpAction;                /** Action for triggering help */
+    bool                                _cachedVisibility;          /** Cached visibility for view plugin isolation */
+    ads::CDockManager                   _dockManager;               /** Dock manager for internal docking */
+    QMap<QString, CDockWidget*>         _settingsDockWidgetsMap;    /** Created dock widgets for settings actions */
+    ProgressOverlayWidget               _progressOverlayWidget;     /** Overlay widget which shows a very thin view progress bar */
 
 protected:
-    static QList<ViewPluginDockWidget*> active;  /** Loaded view plugin dock widgets */
 
     /**
      * Map view plugin dock widget identifier to serialization task

--- a/ManiVault/src/private/ViewPluginsDockWidget.h
+++ b/ManiVault/src/private/ViewPluginsDockWidget.h
@@ -6,13 +6,9 @@
 
 #include <DockWidget.h>
 
-#include "CentralDockWidget.h"
 #include "LogoWidget.h"
 #include "DockManager.h"
-#include "DockWidget.h"
 #include "ViewPluginDockWidget.h"
-
-#include <ViewPlugin.h>
 
 /**
  * View plugins dock widget class
@@ -33,7 +29,7 @@ public:
      * @param dockManager Pointer to docking manager owned by the workspace manager
      * @param parent Pointer to parent widget
      */
-    ViewPluginsDockWidget(QPointer<DockManager> dockManager, QWidget* parent = nullptr);
+    ViewPluginsDockWidget(const QPointer<DockManager>& dockManager, QWidget* parent = nullptr);
 
 private:
 
@@ -44,13 +40,13 @@ private:
      * Invoked when a dock widget is added
      * @param dockWidget Pointer to added dock widget
      */
-    void dockWidgetAdded(ads::CDockWidget* dockWidget);
+    void dockWidgetAdded(const ads::CDockWidget* dockWidget);
 
     /**
      * Invoked when a dock widget is about to be removed
      * @param dockWidget Pointer to about to be removed dock widget
      */
-    void dockWidgetAboutToBeRemoved(ads::CDockWidget* dockWidget);
+    void dockWidgetAboutToBeRemoved(const ads::CDockWidget* dockWidget);
 
 public: // Cache and restore visibility for view plugin isolation
 
@@ -59,7 +55,7 @@ public: // Cache and restore visibility for view plugin isolation
      * @param viewPlugin View plugin to isolate
      * @param isolate Whether to isolate the view plugin or not
      */
-    static void isolate(mv::plugin::ViewPlugin* viewPlugin, bool isolate);
+    static void isolate(const mv::plugin::ViewPlugin* viewPlugin, bool isolate);
 
     /** Caches the visibility of each view plugin */
     static void cacheVisibility();
@@ -68,7 +64,8 @@ public: // Cache and restore visibility for view plugin isolation
     static void restoreVisibility();
 
 private:
-    QPointer<DockManager>           _dockManager;                   /** Dock manager for docking of view plugins */
-    ads::CDockWidget                _centralDockWidget;             /** Central dock widget (show when no view plugins are visible) */
-    LogoWidget                      _logoWidget;                    /** Logo widget for logo dock widget */
+    ads::CDockWidget                _centralDockWidget;     /** Central dock widget (show when no view plugins are visible) */
+    LogoWidget                      _logoWidget;            /** Logo widget for logo dock widget */
+
+    static QPointer<DockManager> dockManager;    /** Dock manager for docking of view plugins */
 };

--- a/ManiVault/src/private/WorkspaceManager.cpp
+++ b/ManiVault/src/private/WorkspaceManager.cpp
@@ -571,7 +571,11 @@ void WorkspaceManager::fromVariantMap(const QVariantMap& variantMap)
     _mainDockManager->fromVariantMap(dockingManagersMap["Main"].toMap());
     _viewPluginsDockManager->fromVariantMap(dockingManagersMap["ViewPlugins"].toMap());
 
-    //ViewPluginDockWidget::restoreViewPluginStates();
+    for (auto viewPluginDockWidget : _mainDockManager->getViewPluginDockWidgets())
+    	viewPluginDockWidget->restoreViewPluginState();
+
+    for (auto viewPluginDockWidget : _viewPluginsDockManager->getViewPluginDockWidgets())
+        viewPluginDockWidget->restoreViewPluginState();
 }
 
 QVariantMap WorkspaceManager::toVariantMap() const

--- a/ManiVault/src/private/WorkspaceManager.cpp
+++ b/ManiVault/src/private/WorkspaceManager.cpp
@@ -199,10 +199,10 @@ void WorkspaceManager::initialize()
                 return;
 
             //if (!mv::plugins().isResetting()) {
-                if (_mainDockManager && viewPlugin->isSystemViewPlugin())
-                    _mainDockManager->removeViewPluginDockWidget(viewPlugin);
-                else if (_viewPluginsDockManager)
-                    _viewPluginsDockManager->removeViewPluginDockWidget(viewPlugin);
+            if (_mainDockManager && viewPlugin->isSystemViewPlugin())
+                _mainDockManager->removeViewPluginDockWidget(viewPlugin);
+            else if (_viewPluginsDockManager)
+                _viewPluginsDockManager->removeViewPluginDockWidget(viewPlugin);
             //}
         });
 
@@ -627,17 +627,16 @@ void WorkspaceManager::createWorkspace()
 
         _workspace.reset(new Workspace());
     }
-    emit workspaceCreated(*(_workspace.get()));
+    emit workspaceCreated(*_workspace.get());
 }
 
 void WorkspaceManager::createIcon()
 {
-    const auto size             = 128;
-    const auto halfSize         = size / 2;
-    const auto margin           = 12;
-    const auto spacing          = 14;
-    const auto halfSpacing      = spacing / 2;
-    const auto lineThickness    = 7.0;
+    constexpr auto size             = 128;
+    constexpr auto halfSize         = size / 2;
+    constexpr auto margin           = 12;
+    constexpr auto spacing          = 14;
+    constexpr auto halfSpacing      = spacing / 2;
 
     QPixmap pixmap(size, size);
 
@@ -647,7 +646,7 @@ void WorkspaceManager::createIcon()
 
     painter.setWindow(0, 0, size, size);
 
-    const auto drawWindow = [&](QRectF rectangle) -> void {
+    const auto drawWindow = [&](const QRectF& rectangle) -> void {
         painter.setBrush(Qt::black);
         painter.setPen(Qt::NoPen);
         painter.drawRect(rectangle);
@@ -657,7 +656,7 @@ void WorkspaceManager::createIcon()
     drawWindow(QRectF(QPointF(halfSize + halfSpacing, margin), QPointF(size - margin, halfSize - halfSpacing)));
     drawWindow(QRectF(QPointF(halfSize + halfSpacing, halfSize + halfSpacing), QPointF(size - margin, size - margin)));
 
-    _icon = mv::gui::createIcon(pixmap);
+    _icon = gui::createIcon(pixmap);
 }
 
 WorkspaceLocations WorkspaceManager::getWorkspaceLocations(const WorkspaceLocation::Types& types /*= WorkspaceLocation::Type::All*/)
@@ -733,9 +732,7 @@ QStringList WorkspaceManager::getViewPluginNames(const QString& workspaceJsonFil
 
     QByteArray data = jsonFile.readAll();
 
-    QJsonDocument jsonDocument;
-
-    jsonDocument = QJsonDocument::fromJson(data);
+    QJsonDocument jsonDocument = QJsonDocument::fromJson(data);
 
     if (jsonDocument.isNull() || jsonDocument.isEmpty())
         return {};
@@ -747,7 +744,7 @@ QStringList WorkspaceManager::getViewPluginNames(const QString& workspaceJsonFil
     const auto getViewPluginNamesFromDockManager = [](const QVariantMap& dockManagerMap) -> QStringList {
         QStringList viewPluginNames;
 
-        for (auto viewPluginDockWidgetVariant : dockManagerMap["ViewPluginDockWidgets"].toList()) {
+        for (const auto& viewPluginDockWidgetVariant : dockManagerMap["ViewPluginDockWidgets"].toList()) {
             const auto viewPluginMap = viewPluginDockWidgetVariant.toMap()["ViewPlugin"].toMap();
 
             viewPluginNames << viewPluginMap["GuiName"].toMap()["Value"].toString();

--- a/ManiVault/src/private/WorkspaceManager.cpp
+++ b/ManiVault/src/private/WorkspaceManager.cpp
@@ -226,8 +226,6 @@ void WorkspaceManager::reset()
 			plugin->destroy();
     }
     endReset();
-
-    //waitForDuration(100);
 }
 
 QIcon WorkspaceManager::getIcon() const

--- a/ManiVault/src/private/WorkspaceManager.cpp
+++ b/ManiVault/src/private/WorkspaceManager.cpp
@@ -197,11 +197,13 @@ void WorkspaceManager::initialize()
 
             if (!viewPlugin)
                 return;
-            
-            if (_mainDockManager && viewPlugin->isSystemViewPlugin())
-                _mainDockManager->removeViewPluginDockWidget(viewPlugin);
-            else if(_viewPluginsDockManager)
-                _viewPluginsDockManager->removeViewPluginDockWidget(viewPlugin);
+
+            //if (!mv::plugins().isResetting()) {
+                if (_mainDockManager && viewPlugin->isSystemViewPlugin())
+                    _mainDockManager->removeViewPluginDockWidget(viewPlugin);
+                else if (_viewPluginsDockManager)
+                    _viewPluginsDockManager->removeViewPluginDockWidget(viewPlugin);
+            //}
         });
 
         connect(&Application::core()->getProjectManager(), &AbstractProjectManager::projectCreated, this, [this]() -> void {
@@ -220,8 +222,8 @@ void WorkspaceManager::reset()
     beginReset();
     {
         if (!isCoreDestroyed())
-			for (auto plugin : Application::core()->getPluginManager().getPluginsByType(plugin::Type::VIEW))
-				plugin->destroy();
+            for (auto plugin : Application::core()->getPluginManager().getPluginsByType(plugin::Type::VIEW))
+                plugin->destroy();
     }
     endReset();
 }
@@ -239,6 +241,7 @@ void WorkspaceManager::newWorkspace()
         qDebug() << __FUNCTION__;
 #endif
 
+        reset();
         createWorkspace();
     }
     catch (std::exception& e)
@@ -500,7 +503,7 @@ void WorkspaceManager::addViewPlugin(plugin::ViewPlugin* viewPlugin, plugin::Vie
     else
         _viewPluginsDockManager->addViewPluginDockWidget(static_cast<DockWidgetArea>(dockArea), viewPluginDockWidget, dockToViewPlugin ? _viewPluginsDockManager->findDockAreaWidget(dockToViewPlugin) : nullptr);
 
-    if (projects().isOpeningProject() || projects().isOpeningProject())
+    if (projects().isOpeningProject() || projects().isImportingProject())
         return;
 
     viewPlugin->getPresetsAction().loadDefaultPreset();
@@ -682,7 +685,6 @@ WorkspaceLocations WorkspaceManager::getWorkspaceLocations(const WorkspaceLocati
 
             workspaceLocations << WorkspaceLocation(workspace.getTitleAction().getString(), recentFilePath, WorkspaceLocation::Type::Recent);
         }
-            
     }
     
     return workspaceLocations;

--- a/ManiVault/src/private/WorkspaceManager.cpp
+++ b/ManiVault/src/private/WorkspaceManager.cpp
@@ -227,7 +227,7 @@ void WorkspaceManager::reset()
     }
     endReset();
 
-    waitForDuration(100);
+    //waitForDuration(100);
 }
 
 QIcon WorkspaceManager::getIcon() const

--- a/ManiVault/src/private/WorkspaceManager.cpp
+++ b/ManiVault/src/private/WorkspaceManager.cpp
@@ -571,7 +571,7 @@ void WorkspaceManager::fromVariantMap(const QVariantMap& variantMap)
     _mainDockManager->fromVariantMap(dockingManagersMap["Main"].toMap());
     _viewPluginsDockManager->fromVariantMap(dockingManagersMap["ViewPlugins"].toMap());
 
-    ViewPluginDockWidget::restoreViewPluginStates();
+    //ViewPluginDockWidget::restoreViewPluginStates();
 }
 
 QVariantMap WorkspaceManager::toVariantMap() const

--- a/ManiVault/src/private/WorkspaceManager.h
+++ b/ManiVault/src/private/WorkspaceManager.h
@@ -223,17 +223,17 @@ public: // Action getters
     gui::TriggerAction& getEditWorkspaceSettingsAction() { return _editWorkspaceSettingsAction; }
 
 private:
-    QScopedPointer<mv::Workspace>       _workspace;                             /** Current workspace */
+    QScopedPointer<Workspace>           _workspace;                             /** Current workspace */
     QPointer<DockManager>               _mainDockManager;                       /** Dock manager for docking system view plugins */
     QPointer<DockManager>               _viewPluginsDockManager;                /** Dock manager for docking non-system view plugins */
     QPointer<ViewPluginsDockWidget>     _viewPluginsDockWidget;                 /** Pointer to view plugins dock widget in which non-system view plugins are docked */
-    mv::gui::TriggerAction              _resetWorkspaceAction;                  /** Action for resetting the current workspace */
-    mv::gui::TriggerAction              _importWorkspaceAction;                 /** Action for importing a workspace from file */
-    mv::gui::TriggerAction              _exportWorkspaceAction;                 /** Action for exporting the current workspace to file */
-    mv::gui::TriggerAction              _exportWorkspaceAsAction;               /** Action for exporting the current workspace to file with a different path */
-    mv::gui::TriggerAction              _editWorkspaceSettingsAction;           /** Action for triggering the workspace settings dialog */
-    mv::gui::TriggerAction              _importWorkspaceFromProjectAction;      /** Action for importing a workspace from a project file */
-    mv::gui::RecentFilesAction          _recentWorkspacesAction;                /** Action for saving the current workspace to file with a different path */
+    gui::TriggerAction                  _resetWorkspaceAction;                  /** Action for resetting the current workspace */
+    gui::TriggerAction                  _importWorkspaceAction;                 /** Action for importing a workspace from file */
+    gui::TriggerAction                  _exportWorkspaceAction;                 /** Action for exporting the current workspace to file */
+    gui::TriggerAction                  _exportWorkspaceAsAction;               /** Action for exporting the current workspace to file with a different path */
+    gui::TriggerAction                  _editWorkspaceSettingsAction;           /** Action for triggering the workspace settings dialog */
+    gui::TriggerAction                  _importWorkspaceFromProjectAction;      /** Action for importing a workspace from a project file */
+    gui::RecentFilesAction              _recentWorkspacesAction;                /** Action for saving the current workspace to file with a different path */
     QIcon                               _icon;                                  /** Manager icon */
     QString                             _styleSheet;                            /** Dock manager style sheet */
 };

--- a/ManiVault/src/util/Miscellaneous.cpp
+++ b/ManiVault/src/util/Miscellaneous.cpp
@@ -3,14 +3,24 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "Miscellaneous.h"
+
+#include "Exception.h"
 #include "Icon.h"
 
 #include <QAction>
+#include <QEventLoop>
+#include <QLayout>
+#include <QLayoutItem>
+#include <QPainter>
+#include <QPixmap>
+#include <QString>
 #include <QStringList>
+#include <QTimer>
 #include <QTcpSocket>
 #include <QUrl>
 #include <QVariant>
-#include <QString>
+
+#include <exception>
 
 namespace mv::util
 {

--- a/ManiVault/src/util/Miscellaneous.cpp
+++ b/ManiVault/src/util/Miscellaneous.cpp
@@ -45,6 +45,20 @@ QString getNoBytesHumanReadable(float noBytes)
     return QString::number(noBytes, 'f', 2) + " " + unit;
 }
 
+QString getTabIndentedMessage(QString message, const std::uint32_t& tabIndex)
+{
+	static constexpr std::uint32_t tabSize = 4;
+
+	QString indentation;
+
+	for (std::uint32_t i = 0; i < tabIndex * tabSize; i++)
+		indentation += " ";
+
+	message.insert(0, indentation);
+
+	return message;
+}
+
 CORE_EXPORT QString getColorAsCssString(const QColor& color, bool alpha /*= true*/)
 {
     if (alpha)
@@ -254,4 +268,14 @@ QVariant getValueByPath(const QVariant& root, const QString& path, const QVarian
 
 	return foundValue; // Return the found value
 }
+
+void waitForDuration(int milliSeconds)
+{
+	QEventLoop localEventLoop;
+
+	QTimer::singleShot(milliSeconds, &localEventLoop, &QEventLoop::quit);
+
+	localEventLoop.exec();
+}
+
 }

--- a/ManiVault/src/util/Miscellaneous.cpp
+++ b/ManiVault/src/util/Miscellaneous.cpp
@@ -288,4 +288,17 @@ void waitForDuration(int milliSeconds)
 	localEventLoop.exec();
 }
 
+void disconnectRecursively(const QObject* object)
+{
+    Q_ASSERT(object);
+
+	if (!object)
+		return;
+
+    [[maybe_unused]] auto result = object->disconnect();
+
+	for (auto child : object->children())
+		disconnectRecursively(child);
+}
+
 }

--- a/ManiVault/src/util/Miscellaneous.h
+++ b/ManiVault/src/util/Miscellaneous.h
@@ -37,7 +37,7 @@ CORE_EXPORT QString getNoBytesHumanReadable(float noBytes);
  * @param actions Actions to sort
  */
 template<typename ActionType>
-inline void sortActions(QVector<QPointer<ActionType>>& actions)
+void sortActions(QVector<QPointer<ActionType>>& actions)
 {
     std::sort(actions.begin(), actions.end(), [](auto actionA, auto actionB) {
         return actionA->text() < actionB->text();
@@ -50,15 +50,12 @@ inline void sortActions(QVector<QPointer<ActionType>>& actions)
  * @return Pointer to parent widget of type \p WidgetClass, otherwise a nullptr
  */
 template <class WidgetClass>
-inline WidgetClass* findParent(const QWidget* widget)
+WidgetClass* findParent(const QWidget* widget)
 {
     auto parentWidget = widget->parentWidget();
 
-    while (parentWidget)
-    {
-        auto parentImpl = qobject_cast<WidgetClass*>(parentWidget);
-
-        if (parentImpl)
+    while (parentWidget) {
+        if (auto parentImpl = qobject_cast<WidgetClass*>(parentWidget))
             return parentImpl;
 
         parentWidget = parentWidget->parentWidget();
@@ -73,18 +70,7 @@ inline WidgetClass* findParent(const QWidget* widget)
  * @param tabIndex Number of tabs to prefix with
  * @return Message indented with tabs
  */
-CORE_EXPORT inline QString getTabIndentedMessage(QString message, const std::uint32_t& tabIndex) {
-    static const std::uint32_t tabSize = 4;
-
-    QString indentation;
-
-    for (std::uint32_t i = 0; i < tabIndex * tabSize; i++)
-        indentation += " ";
-
-    message.insert(0, indentation);
-
-    return message;
-}
+CORE_EXPORT inline QString getTabIndentedMessage(QString message, const std::uint32_t& tabIndex);
 
 /**
  * Get \p color as CSS string, either with or without \p alpha
@@ -122,4 +108,12 @@ CORE_EXPORT QVariant setValueByPath(QVariant root, const QString& path, const QV
  * @return Value, invalid when no value was found
  */
 CORE_EXPORT QVariant getValueByPath(const QVariant& root, const QString& path, const QVariant& valueIfNotFound = QVariant());
+
+
+/**
+ * This method keeps the application event loop responsive while halting the current execution for n \p milliseconds
+ * @param milliSeconds Milliseconds to wait
+ */
+CORE_EXPORT void waitForDuration(int milliSeconds);
+
 }

--- a/ManiVault/src/util/Miscellaneous.h
+++ b/ManiVault/src/util/Miscellaneous.h
@@ -6,12 +6,14 @@
 
 #include "ManiVaultGlobals.h"
 
-#include <QString>
-#include <QWidget>
+#include <QIcon>
 #include <QPointer>
+#include <QString>
+#include <QVariant>
+#include <QVector>
+#include <QWidget>
 
 #include <algorithm>
-#include <qtcpsocket.h>
 
 class QAction;
 

--- a/ManiVault/src/util/Miscellaneous.h
+++ b/ManiVault/src/util/Miscellaneous.h
@@ -118,4 +118,9 @@ CORE_EXPORT QVariant getValueByPath(const QVariant& root, const QString& path, c
  */
 CORE_EXPORT void waitForDuration(int milliSeconds);
 
+/**
+ * Remove all connections (to and from) from \p object and its descendants
+ * @param object Pointer to root object
+ */
+CORE_EXPORT void disconnectRecursively(const QObject* object);
 }

--- a/ManiVault/src/util/Serializable.h
+++ b/ManiVault/src/util/Serializable.h
@@ -39,6 +39,7 @@ public:
      */
     Serializable(const QString& serializationName = "");
 
+    /** Destructor */
     virtual ~Serializable() { }
 
     /**
@@ -46,25 +47,25 @@ public:
      * @param truncated Whether to only return the first six characters of the ID
      * @return Globally unique identifier of the serializable object
      */
-    virtual QString getId(bool truncated = false) const final;
+    QString getId(bool truncated = false) const;
 
     /**
      * Set globally unique identifier (only use this function when strictly necessary and when the ramifications are understood, undefined behaviour might happen otherwise)
      * @param id Globally unique identifier of the serializable object
      */
-    virtual void setId(const QString& id) final;
+    void setId(const QString& id);
 
     /**
      * Get serialization name
      * @return Serialization name
      */
-    virtual QString getSerializationName() const final;
+    QString getSerializationName() const;
 
     /**
      * Set serialization name to \p name
      * @param serializationName Serialization name
      */
-    virtual void setSerializationName(const QString& serializationName) final;
+    void setSerializationName(const QString& serializationName);
 
     /**
      * Load from variant map
@@ -88,34 +89,34 @@ public:
      * Save into \p variantMap
      * @param variantMap Variant map
      */
-    virtual void insertIntoVariantMap(QVariantMap& variantMap) const final;
+    void insertIntoVariantMap(QVariantMap& variantMap) const;
 
     /**
      * Load widget action from JSON document
-     * @param JSON document
+     * @param jsonDocument The JSON document
      */
-    virtual void fromJsonDocument(const QJsonDocument& jsonDocument) final;
+    void fromJsonDocument(const QJsonDocument& jsonDocument);
 
     /**
      * Save widget action to JSON document
      * @return JSON document
      */
-    virtual QJsonDocument toJsonDocument() const final;
+    QJsonDocument toJsonDocument() const;
 
     /**
      * Load from JSON file
      * @param filePath Path to the JSON file (if none/invalid a file open dialog is automatically opened)
      */
-    virtual void fromJsonFile(const QString& filePath = "") final;
+    void fromJsonFile(const QString& filePath = "");
 
     /**
      * Save to JSON file
      * @param filePath Path to the JSON file (if none/invalid a file save dialog is automatically opened)
      */
-    virtual void toJsonFile(const QString& filePath = "") final;
+    void toJsonFile(const QString& filePath = "");
 
     /** Assigns a fresh new identifier to the serializable object */
-    virtual void makeUnique() final;
+    void makeUnique();
 
     /**
      * Creates a new globally unique identifier for a serializable object
@@ -128,7 +129,7 @@ protected: // Serialization
     /**
      * Load serializable object from variant map
      * @param serializable Pointer to serializable object
-     * @param Variant map
+     * @param variantMap The Variant map
      */
     static void fromVariantMap(Serializable* serializable, const QVariantMap& variantMap);
 
@@ -168,7 +169,7 @@ public: // Operators
      * Equality operator
      * @param rhs Right-hand-side operator
      */
-    const bool operator == (const Serializable& rhs) const {
+    bool operator == (const Serializable& rhs) const {
         return rhs.getId() == getId();
     }
     
@@ -176,7 +177,7 @@ public: // Operators
      * Inequality operator
      * @param rhs Right-hand-side operator
      */
-    const bool operator != (const Serializable& rhs) const {
+    bool operator != (const Serializable& rhs) const {
         return rhs.getId() != getId();
     }
 

--- a/ManiVault/src/widgets/FileDialog.cpp
+++ b/ManiVault/src/widgets/FileDialog.cpp
@@ -4,6 +4,8 @@
 
 #include "FileDialog.h"
 
+#include "Application.h"
+
 #ifdef _DEBUG
     #define FILE_DIALOG_VERBOSE
 #endif

--- a/ManiVault/src/widgets/FileDialog.h
+++ b/ManiVault/src/widgets/FileDialog.h
@@ -4,7 +4,12 @@
 
 #pragma once
 
+#include "ManiVaultGlobals.h"
+
 #include <QFileDialog>
+#include <QSize>
+#include <QString>
+#include <QUrl>
 
 namespace mv::gui {
 

--- a/ManiVault/src/widgets/ViewPluginLearningCenterOverlayWidget.cpp
+++ b/ManiVault/src/widgets/ViewPluginLearningCenterOverlayWidget.cpp
@@ -813,7 +813,7 @@ void ViewPluginLearningCenterOverlayWidget::ToolbarWidget::showEvent(QShowEvent*
 
     _numberOfShowEvents++;
 
-    QTimer::singleShot(widgetAsyncUpdateTimerInterval, [this]() -> void {
+    QTimer::singleShot(widgetAsyncUpdateTimerInterval, this, [this]() -> void {
         _backgroundWidget.transitionGeometry(geometry());
 	});
 }

--- a/ManiVault/src/widgets/ViewPluginLearningCenterOverlayWidget.cpp
+++ b/ManiVault/src/widgets/ViewPluginLearningCenterOverlayWidget.cpp
@@ -31,7 +31,7 @@ using namespace mv::util;
 namespace mv::gui
 {
 
-ViewPluginLearningCenterOverlayWidget::ViewPluginLearningCenterOverlayWidget(QWidget* target, const mv::plugin::ViewPlugin* viewPlugin) :
+ViewPluginLearningCenterOverlayWidget::ViewPluginLearningCenterOverlayWidget(QWidget* target, const plugin::ViewPlugin* viewPlugin) :
     OverlayWidget(target),
     _viewPlugin(viewPlugin),
     _toolbarWidget(viewPlugin, this),
@@ -229,7 +229,7 @@ void ViewPluginLearningCenterOverlayWidget::alignmentChanged()
 
 PluginLearningCenterAction& ViewPluginLearningCenterOverlayWidget::getLearningCenterAction() const
 {
-    return const_cast<mv::plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction();
+    return const_cast<plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction();
 }
 
 void ViewPluginLearningCenterOverlayWidget::expand()
@@ -258,7 +258,7 @@ void ViewPluginLearningCenterOverlayWidget::collapse()
         _toolbarItemWidget->getWidgetFader().fadeOut(animationDuration, true);
 }
 
-ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::AbstractToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, const QSize& iconSize /*= QSize(14, 14)*/) :
+ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::AbstractToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, const QSize& iconSize /*= QSize(14, 14)*/) :
     _viewPlugin(viewPlugin),
     _overlayWidget(overlayWidget),
     _iconSize(iconSize),
@@ -313,14 +313,14 @@ WidgetFader& ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::g
     return _widgetFader;
 }
 
-const mv::plugin::ViewPlugin* ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::getViewPlugin() const
+const plugin::ViewPlugin* ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::getViewPlugin() const
 {
     return _viewPlugin;
 }
 
-mv::plugin::ViewPlugin* ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::getViewPlugin()
+plugin::ViewPlugin* ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::getViewPlugin()
 {
-    return const_cast<mv::plugin::ViewPlugin*>(_viewPlugin);
+    return const_cast<plugin::ViewPlugin*>(_viewPlugin);
 }
 
 ViewPluginLearningCenterOverlayWidget* ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::getOverlayWidget() const
@@ -328,7 +328,7 @@ ViewPluginLearningCenterOverlayWidget* ViewPluginLearningCenterOverlayWidget::Ab
     return _overlayWidget;
 }
 
-ViewPluginLearningCenterOverlayWidget::LearningCenterToolbarItemWidget::LearningCenterToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::LearningCenterToolbarItemWidget::LearningCenterToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     const auto updateTooltip = [this]() -> void {
@@ -356,7 +356,7 @@ bool ViewPluginLearningCenterOverlayWidget::LearningCenterToolbarItemWidget::sho
     return getViewPlugin()->getLearningCenterAction().getOverlayVisibleAction().isChecked();
 }
 
-ViewPluginLearningCenterOverlayWidget::VideosToolbarItemWidget::VideosToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::VideosToolbarItemWidget::VideosToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip("Watch related videos");
@@ -404,7 +404,7 @@ bool ViewPluginLearningCenterOverlayWidget::VideosToolbarItemWidget::shouldDispl
     return !getViewPlugin()->getLearningCenterAction().getVideos().empty();
 }
 
-ViewPluginLearningCenterOverlayWidget::DescriptionToolbarItemWidget::DescriptionToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::DescriptionToolbarItemWidget::DescriptionToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip(getViewPlugin()->getLearningCenterAction().getViewDescriptionAction().toolTip());
@@ -427,7 +427,7 @@ bool ViewPluginLearningCenterOverlayWidget::DescriptionToolbarItemWidget::should
     return getViewPlugin()->getLearningCenterAction().hasDescription();
 }
 
-ViewPluginLearningCenterOverlayWidget::ShowDocumentationToolbarItemWidget::ShowDocumentationToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::ShowDocumentationToolbarItemWidget::ShowDocumentationToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip(const_cast<plugin::PluginFactory*>(getViewPlugin()->getFactory())->getTriggerHelpAction().toolTip());
@@ -450,7 +450,7 @@ bool ViewPluginLearningCenterOverlayWidget::ShowDocumentationToolbarItemWidget::
     return const_cast<plugin::PluginFactory*>(getViewPlugin()->getFactory())->hasHelp();
 }
 
-ViewPluginLearningCenterOverlayWidget::ShortcutsToolbarItemWidget::ShortcutsToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::ShortcutsToolbarItemWidget::ShortcutsToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip("View shortcuts");
@@ -477,7 +477,7 @@ bool ViewPluginLearningCenterOverlayWidget::ShortcutsToolbarItemWidget::shouldDi
     return getViewPlugin()->getShortcuts().hasShortcuts();
 }
 
-ViewPluginLearningCenterOverlayWidget::VisitGithubRepoToolbarItemWidget::VisitGithubRepoToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::VisitGithubRepoToolbarItemWidget::VisitGithubRepoToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip(const_cast<plugin::PluginFactory*>(getViewPlugin()->getFactory())->getVisitRepositoryAction().toolTip());
@@ -500,7 +500,7 @@ bool ViewPluginLearningCenterOverlayWidget::VisitGithubRepoToolbarItemWidget::sh
     return const_cast<plugin::PluginFactory*>(getViewPlugin()->getFactory())->getRepositoryUrl().isValid();
 }
 
-ViewPluginLearningCenterOverlayWidget::ToLearningCenterToolbarItemWidget::ToLearningCenterToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::ToLearningCenterToolbarItemWidget::ToLearningCenterToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip(mv::help().getToLearningCenterAction().toolTip());
@@ -523,7 +523,7 @@ bool ViewPluginLearningCenterOverlayWidget::ToLearningCenterToolbarItemWidget::s
     return true;
 }
 
-ViewPluginLearningCenterOverlayWidget::HideToolbarItemWidget::HideToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::HideToolbarItemWidget::HideToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip(getViewPlugin()->getLearningCenterAction().getHideToolbarAction().toolTip());
@@ -548,7 +548,7 @@ bool ViewPluginLearningCenterOverlayWidget::HideToolbarItemWidget::shouldDisplay
 
 std::vector<ViewPluginLearningCenterOverlayWidget::AlignmentToolbarItemWidget::Alignment> ViewPluginLearningCenterOverlayWidget::AlignmentToolbarItemWidget::alignments = {};
 
-ViewPluginLearningCenterOverlayWidget::AlignmentToolbarItemWidget::AlignmentToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::AlignmentToolbarItemWidget::AlignmentToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip("Move the toolbar");
@@ -581,7 +581,7 @@ bool ViewPluginLearningCenterOverlayWidget::AlignmentToolbarItemWidget::shouldDi
     return true;
 }
 
-ViewPluginLearningCenterOverlayWidget::ToolbarWidget::BackgroundWidget::BackgroundWidget(QWidget* target, const mv::plugin::ViewPlugin* viewPlugin) :
+ViewPluginLearningCenterOverlayWidget::ToolbarWidget::BackgroundWidget::BackgroundWidget(QWidget* target, const plugin::ViewPlugin* viewPlugin) :
     QWidget(target),
     _viewPlugin(viewPlugin),
     _geometryAnimation(this, "geometry")
@@ -638,7 +638,7 @@ void ViewPluginLearningCenterOverlayWidget::ToolbarWidget::BackgroundWidget::pai
 
     std::int32_t radius = 0;
 
-    const auto alignment = const_cast<mv::plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction().getAlignment();
+    const auto alignment = const_cast<plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction().getAlignment();
 
     if (alignment & Qt::AlignLeft || alignment & Qt::AlignRight) {
         radius              = (width() - 2 * rectangleMargin) / 2;
@@ -678,7 +678,7 @@ void ViewPluginLearningCenterOverlayWidget::ToolbarWidget::BackgroundWidget::pai
     QWidget::paintEvent(event);
 }
 
-ViewPluginLearningCenterOverlayWidget::ToolbarWidget::ToolbarWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, bool alwaysVisible /*= false*/) :
+ViewPluginLearningCenterOverlayWidget::ToolbarWidget::ToolbarWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, bool alwaysVisible /*= false*/) :
     QWidget(overlayWidget),
     _viewPlugin(viewPlugin),
     _overlayWidget(overlayWidget),
@@ -750,7 +750,7 @@ ViewPluginLearningCenterOverlayWidget::ToolbarWidget::ToolbarWidget(const mv::pl
 
 PluginLearningCenterAction& ViewPluginLearningCenterOverlayWidget::ToolbarWidget::getLearningCenterAction() const
 {
-    return const_cast<mv::plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction();
+    return const_cast<plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction();
 }
 
 void ViewPluginLearningCenterOverlayWidget::ToolbarWidget::addWidget(QWidget* widget)

--- a/ManiVault/src/widgets/ViewPluginLearningCenterOverlayWidget.cpp
+++ b/ManiVault/src/widgets/ViewPluginLearningCenterOverlayWidget.cpp
@@ -6,13 +6,20 @@
 
 #include "Application.h"
 #include "CoreInterface.h"
+#include "ViewPlugin.h"
+
+#include "actions/PluginLearningCenterAction.h"
+
 #include "util/Icon.h"
+#include "util/Miscellaneous.h"
 
 #include <QDebug>
-#include <QMainWindow>
-#include <QMenu>
 #include <QDesktopServices>
 #include <QGraphicsPixmapItem>
+#include <QGraphicsScene>
+#include <QMainWindow>
+#include <QMenu>
+#include <QPainter>
 #include <QResizeEvent>
 
 #ifdef _DEBUG
@@ -24,7 +31,7 @@ using namespace mv::util;
 namespace mv::gui
 {
 
-ViewPluginLearningCenterOverlayWidget::ViewPluginLearningCenterOverlayWidget(QWidget* target, const plugin::ViewPlugin* viewPlugin) :
+ViewPluginLearningCenterOverlayWidget::ViewPluginLearningCenterOverlayWidget(QWidget* target, const mv::plugin::ViewPlugin* viewPlugin) :
     OverlayWidget(target),
     _viewPlugin(viewPlugin),
     _toolbarWidget(viewPlugin, this),
@@ -222,7 +229,7 @@ void ViewPluginLearningCenterOverlayWidget::alignmentChanged()
 
 PluginLearningCenterAction& ViewPluginLearningCenterOverlayWidget::getLearningCenterAction() const
 {
-    return const_cast<plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction();
+    return const_cast<mv::plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction();
 }
 
 void ViewPluginLearningCenterOverlayWidget::expand()
@@ -251,7 +258,7 @@ void ViewPluginLearningCenterOverlayWidget::collapse()
         _toolbarItemWidget->getWidgetFader().fadeOut(animationDuration, true);
 }
 
-ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::AbstractToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, const QSize& iconSize /*= QSize(14, 14)*/) :
+ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::AbstractToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, const QSize& iconSize /*= QSize(14, 14)*/) :
     _viewPlugin(viewPlugin),
     _overlayWidget(overlayWidget),
     _iconSize(iconSize),
@@ -306,14 +313,14 @@ WidgetFader& ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::g
     return _widgetFader;
 }
 
-const plugin::ViewPlugin* ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::getViewPlugin() const
+const mv::plugin::ViewPlugin* ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::getViewPlugin() const
 {
     return _viewPlugin;
 }
 
-plugin::ViewPlugin* ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::getViewPlugin()
+mv::plugin::ViewPlugin* ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::getViewPlugin()
 {
-    return const_cast<plugin::ViewPlugin*>(_viewPlugin);
+    return const_cast<mv::plugin::ViewPlugin*>(_viewPlugin);
 }
 
 ViewPluginLearningCenterOverlayWidget* ViewPluginLearningCenterOverlayWidget::AbstractToolbarItemWidget::getOverlayWidget() const
@@ -321,7 +328,7 @@ ViewPluginLearningCenterOverlayWidget* ViewPluginLearningCenterOverlayWidget::Ab
     return _overlayWidget;
 }
 
-ViewPluginLearningCenterOverlayWidget::LearningCenterToolbarItemWidget::LearningCenterToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::LearningCenterToolbarItemWidget::LearningCenterToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     const auto updateTooltip = [this]() -> void {
@@ -349,7 +356,7 @@ bool ViewPluginLearningCenterOverlayWidget::LearningCenterToolbarItemWidget::sho
     return getViewPlugin()->getLearningCenterAction().getOverlayVisibleAction().isChecked();
 }
 
-ViewPluginLearningCenterOverlayWidget::VideosToolbarItemWidget::VideosToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::VideosToolbarItemWidget::VideosToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip("Watch related videos");
@@ -397,7 +404,7 @@ bool ViewPluginLearningCenterOverlayWidget::VideosToolbarItemWidget::shouldDispl
     return !getViewPlugin()->getLearningCenterAction().getVideos().empty();
 }
 
-ViewPluginLearningCenterOverlayWidget::DescriptionToolbarItemWidget::DescriptionToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::DescriptionToolbarItemWidget::DescriptionToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip(getViewPlugin()->getLearningCenterAction().getViewDescriptionAction().toolTip());
@@ -420,7 +427,7 @@ bool ViewPluginLearningCenterOverlayWidget::DescriptionToolbarItemWidget::should
     return getViewPlugin()->getLearningCenterAction().hasDescription();
 }
 
-ViewPluginLearningCenterOverlayWidget::ShowDocumentationToolbarItemWidget::ShowDocumentationToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::ShowDocumentationToolbarItemWidget::ShowDocumentationToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip(const_cast<plugin::PluginFactory*>(getViewPlugin()->getFactory())->getTriggerHelpAction().toolTip());
@@ -443,7 +450,7 @@ bool ViewPluginLearningCenterOverlayWidget::ShowDocumentationToolbarItemWidget::
     return const_cast<plugin::PluginFactory*>(getViewPlugin()->getFactory())->hasHelp();
 }
 
-ViewPluginLearningCenterOverlayWidget::ShortcutsToolbarItemWidget::ShortcutsToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::ShortcutsToolbarItemWidget::ShortcutsToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip("View shortcuts");
@@ -470,7 +477,7 @@ bool ViewPluginLearningCenterOverlayWidget::ShortcutsToolbarItemWidget::shouldDi
     return getViewPlugin()->getShortcuts().hasShortcuts();
 }
 
-ViewPluginLearningCenterOverlayWidget::VisitGithubRepoToolbarItemWidget::VisitGithubRepoToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::VisitGithubRepoToolbarItemWidget::VisitGithubRepoToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip(const_cast<plugin::PluginFactory*>(getViewPlugin()->getFactory())->getVisitRepositoryAction().toolTip());
@@ -493,7 +500,7 @@ bool ViewPluginLearningCenterOverlayWidget::VisitGithubRepoToolbarItemWidget::sh
     return const_cast<plugin::PluginFactory*>(getViewPlugin()->getFactory())->getRepositoryUrl().isValid();
 }
 
-ViewPluginLearningCenterOverlayWidget::ToLearningCenterToolbarItemWidget::ToLearningCenterToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::ToLearningCenterToolbarItemWidget::ToLearningCenterToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip(mv::help().getToLearningCenterAction().toolTip());
@@ -516,7 +523,7 @@ bool ViewPluginLearningCenterOverlayWidget::ToLearningCenterToolbarItemWidget::s
     return true;
 }
 
-ViewPluginLearningCenterOverlayWidget::HideToolbarItemWidget::HideToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::HideToolbarItemWidget::HideToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip(getViewPlugin()->getLearningCenterAction().getHideToolbarAction().toolTip());
@@ -541,7 +548,7 @@ bool ViewPluginLearningCenterOverlayWidget::HideToolbarItemWidget::shouldDisplay
 
 std::vector<ViewPluginLearningCenterOverlayWidget::AlignmentToolbarItemWidget::Alignment> ViewPluginLearningCenterOverlayWidget::AlignmentToolbarItemWidget::alignments = {};
 
-ViewPluginLearningCenterOverlayWidget::AlignmentToolbarItemWidget::AlignmentToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
+ViewPluginLearningCenterOverlayWidget::AlignmentToolbarItemWidget::AlignmentToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget) :
     AbstractToolbarItemWidget(viewPlugin, overlayWidget)
 {
     setToolTip("Move the toolbar");
@@ -574,7 +581,7 @@ bool ViewPluginLearningCenterOverlayWidget::AlignmentToolbarItemWidget::shouldDi
     return true;
 }
 
-ViewPluginLearningCenterOverlayWidget::ToolbarWidget::BackgroundWidget::BackgroundWidget(QWidget* target, const plugin::ViewPlugin* viewPlugin) :
+ViewPluginLearningCenterOverlayWidget::ToolbarWidget::BackgroundWidget::BackgroundWidget(QWidget* target, const mv::plugin::ViewPlugin* viewPlugin) :
     QWidget(target),
     _viewPlugin(viewPlugin),
     _geometryAnimation(this, "geometry")
@@ -631,7 +638,7 @@ void ViewPluginLearningCenterOverlayWidget::ToolbarWidget::BackgroundWidget::pai
 
     std::int32_t radius = 0;
 
-    const auto alignment = const_cast<plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction().getAlignment();
+    const auto alignment = const_cast<mv::plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction().getAlignment();
 
     if (alignment & Qt::AlignLeft || alignment & Qt::AlignRight) {
         radius              = (width() - 2 * rectangleMargin) / 2;
@@ -671,7 +678,7 @@ void ViewPluginLearningCenterOverlayWidget::ToolbarWidget::BackgroundWidget::pai
     QWidget::paintEvent(event);
 }
 
-ViewPluginLearningCenterOverlayWidget::ToolbarWidget::ToolbarWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, bool alwaysVisible /*= false*/) :
+ViewPluginLearningCenterOverlayWidget::ToolbarWidget::ToolbarWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, bool alwaysVisible /*= false*/) :
     QWidget(overlayWidget),
     _viewPlugin(viewPlugin),
     _overlayWidget(overlayWidget),
@@ -743,7 +750,7 @@ ViewPluginLearningCenterOverlayWidget::ToolbarWidget::ToolbarWidget(const plugin
 
 PluginLearningCenterAction& ViewPluginLearningCenterOverlayWidget::ToolbarWidget::getLearningCenterAction() const
 {
-    return const_cast<plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction();
+    return const_cast<mv::plugin::ViewPlugin*>(_viewPlugin)->getLearningCenterAction();
 }
 
 void ViewPluginLearningCenterOverlayWidget::ToolbarWidget::addWidget(QWidget* widget)

--- a/ManiVault/src/widgets/ViewPluginLearningCenterOverlayWidget.h
+++ b/ManiVault/src/widgets/ViewPluginLearningCenterOverlayWidget.h
@@ -15,6 +15,10 @@ namespace mv::plugin {
     class ViewPlugin;
 }
 
+namespace mv::gui {
+    class PluginLearningCenterAction;
+}
+
 namespace mv::gui
 {
 
@@ -42,7 +46,7 @@ protected:
          * @param overlayWidget Pointer to overlay widget
          * @param iconSize Size of the item icon
          */
-        AbstractToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, const QSize& iconSize = QSize(14, 14));
+        AbstractToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, const QSize& iconSize = QSize(14, 14));
 
         /** Show only when required (when AbstractToolbarItemWidget::shouldDisplay() returns true) */
         void showConditionally();
@@ -86,13 +90,13 @@ protected:
          * Get view plugin
          * @return Pointer to view plugin
          */
-        const plugin::ViewPlugin* getViewPlugin() const;
+        const mv::plugin::ViewPlugin* getViewPlugin() const;
 
         /**
          * Get non-const pointer to view plugin
          * @return Non-const pointer to view plugin
          */
-        plugin::ViewPlugin* getViewPlugin();
+        mv::plugin::ViewPlugin* getViewPlugin();
 
         /**
          * Get non-const pointer to overlay widget
@@ -101,7 +105,7 @@ protected:
         ViewPluginLearningCenterOverlayWidget* getOverlayWidget() const;
 
     private:
-        const plugin::ViewPlugin*                   _viewPlugin;            /** Const pointer to source view plugin */
+        const mv::plugin::ViewPlugin*               _viewPlugin;            /** Const pointer to source view plugin */
         ViewPluginLearningCenterOverlayWidget*      _overlayWidget;         /** Pointer to overlay widget */
         const QSize                                 _iconSize;              /** Size of the item icon */
         QHBoxLayout                                 _layout;                /** For placing the icon label */
@@ -119,7 +123,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        LearningCenterToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        LearningCenterToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Get icon
@@ -144,7 +148,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        VideosToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        VideosToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -175,7 +179,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        DescriptionToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        DescriptionToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -206,7 +210,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        ShowDocumentationToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        ShowDocumentationToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -237,7 +241,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        ShortcutsToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        ShortcutsToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -268,7 +272,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        VisitGithubRepoToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        VisitGithubRepoToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -299,7 +303,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        ToLearningCenterToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        ToLearningCenterToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -330,7 +334,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        HideToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        HideToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -368,7 +372,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        AlignmentToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        AlignmentToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -406,7 +410,7 @@ protected:
              * @param target Pointer to target widget
              * @param viewPlugin Pointer to view plugin
              */
-            BackgroundWidget(QWidget* target, const plugin::ViewPlugin* viewPlugin);
+            BackgroundWidget(QWidget* target, const mv::plugin::ViewPlugin* viewPlugin);
 
             
 	        /**
@@ -425,9 +429,9 @@ protected:
             void paintEvent(QPaintEvent* event) override;
 
         private:
-            const plugin::ViewPlugin*   _viewPlugin;            /** Pointer to view plugin */
-            QPropertyAnimation          _geometryAnimation;     /** Animates the position and size of the background widget */
-            QRect                       _previousGeometry;      /** Previous geometry, used as start value for geometry animation */
+            const mv::plugin::ViewPlugin*   _viewPlugin;            /** Pointer to view plugin */
+            QPropertyAnimation              _geometryAnimation;     /** Animates the position and size of the background widget */
+            QRect                           _previousGeometry;      /** Previous geometry, used as start value for geometry animation */
         };
 
     public:
@@ -438,7 +442,7 @@ protected:
          * @param overlayWidget Pointer to parent overlay widget
          * @param alwaysVisible Whether the toolbar widget should always be visible, regardless of the view plugin overlay visibility setting
          */
-        ToolbarWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, bool alwaysVisible = false);
+        ToolbarWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, bool alwaysVisible = false);
 
         /**
          * Add \p widget to the toolbar
@@ -485,7 +489,7 @@ protected:
         PluginLearningCenterAction& getLearningCenterAction() const;
 
     private:
-        const plugin::ViewPlugin*               _viewPlugin;                /** Const pointer to source view plugin */
+        const mv::plugin::ViewPlugin*           _viewPlugin;                /** Const pointer to source view plugin */
         ViewPluginLearningCenterOverlayWidget*  _overlayWidget;             /** Pointer to owning overlay widget */
         bool                                    _alwaysVisible;             /** Whether the toolbar widget should always be visible, regardless of the view plugin overlay visibility setting */
         std::vector<QWidget*>                   _widgets;                   /** Registered widgets */
@@ -507,7 +511,7 @@ public:
      * @param target Pointer to parent widget (overlay widget will be layered on top of this widget)
      * @param viewPlugin Pointer to the view plugin for which to create the overlay
      */
-    ViewPluginLearningCenterOverlayWidget(QWidget* target, const plugin::ViewPlugin* viewPlugin);
+    ViewPluginLearningCenterOverlayWidget(QWidget* target, const mv::plugin::ViewPlugin* viewPlugin);
 
     /**
      * Set target widget to \p targetWidget
@@ -580,7 +584,7 @@ signals:
     void collapsed();
 
 private:
-    const plugin::ViewPlugin*                   _viewPlugin;                            /** Pointer to the view plugin for which to create the overlay */
+    const mv::plugin::ViewPlugin*               _viewPlugin;                            /** Pointer to the view plugin for which to create the overlay */
     QVBoxLayout                                 _layout;                                /** For alignment of the learning center toolbar */
     ToolbarWidget                               _toolbarWidget;                         /** Toolbar widget which contains the various learning center actions */
     LearningCenterToolbarItemWidget             _learningCenterToolbarItemWidget;       /** Primary learning center toolbar item widget */

--- a/ManiVault/src/widgets/ViewPluginLearningCenterOverlayWidget.h
+++ b/ManiVault/src/widgets/ViewPluginLearningCenterOverlayWidget.h
@@ -46,7 +46,7 @@ protected:
          * @param overlayWidget Pointer to overlay widget
          * @param iconSize Size of the item icon
          */
-        AbstractToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, const QSize& iconSize = QSize(14, 14));
+        AbstractToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, const QSize& iconSize = QSize(14, 14));
 
         /** Show only when required (when AbstractToolbarItemWidget::shouldDisplay() returns true) */
         void showConditionally();
@@ -90,13 +90,13 @@ protected:
          * Get view plugin
          * @return Pointer to view plugin
          */
-        const mv::plugin::ViewPlugin* getViewPlugin() const;
+        const plugin::ViewPlugin* getViewPlugin() const;
 
         /**
          * Get non-const pointer to view plugin
          * @return Non-const pointer to view plugin
          */
-        mv::plugin::ViewPlugin* getViewPlugin();
+        plugin::ViewPlugin* getViewPlugin();
 
         /**
          * Get non-const pointer to overlay widget
@@ -105,7 +105,7 @@ protected:
         ViewPluginLearningCenterOverlayWidget* getOverlayWidget() const;
 
     private:
-        const mv::plugin::ViewPlugin*               _viewPlugin;            /** Const pointer to source view plugin */
+        const plugin::ViewPlugin*                   _viewPlugin;            /** Const pointer to source view plugin */
         ViewPluginLearningCenterOverlayWidget*      _overlayWidget;         /** Pointer to overlay widget */
         const QSize                                 _iconSize;              /** Size of the item icon */
         QHBoxLayout                                 _layout;                /** For placing the icon label */
@@ -123,7 +123,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        LearningCenterToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        LearningCenterToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Get icon
@@ -148,7 +148,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        VideosToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        VideosToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -179,7 +179,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        DescriptionToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        DescriptionToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -210,7 +210,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        ShowDocumentationToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        ShowDocumentationToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -241,7 +241,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        ShortcutsToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        ShortcutsToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -272,7 +272,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        VisitGithubRepoToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        VisitGithubRepoToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -303,7 +303,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        ToLearningCenterToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        ToLearningCenterToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -334,7 +334,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        HideToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        HideToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -372,7 +372,7 @@ protected:
          * @param viewPlugin Pointer to view plugin
          * @param overlayWidget Pointer to overlay widget
          */
-        AlignmentToolbarItemWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
+        AlignmentToolbarItemWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget);
 
         /**
          * Invoked when the mouse button is pressed
@@ -410,7 +410,7 @@ protected:
              * @param target Pointer to target widget
              * @param viewPlugin Pointer to view plugin
              */
-            BackgroundWidget(QWidget* target, const mv::plugin::ViewPlugin* viewPlugin);
+            BackgroundWidget(QWidget* target, const plugin::ViewPlugin* viewPlugin);
 
             
 	        /**
@@ -429,7 +429,7 @@ protected:
             void paintEvent(QPaintEvent* event) override;
 
         private:
-            const mv::plugin::ViewPlugin*   _viewPlugin;            /** Pointer to view plugin */
+            const plugin::ViewPlugin*       _viewPlugin;            /** Pointer to view plugin */
             QPropertyAnimation              _geometryAnimation;     /** Animates the position and size of the background widget */
             QRect                           _previousGeometry;      /** Previous geometry, used as start value for geometry animation */
         };
@@ -442,7 +442,7 @@ protected:
          * @param overlayWidget Pointer to parent overlay widget
          * @param alwaysVisible Whether the toolbar widget should always be visible, regardless of the view plugin overlay visibility setting
          */
-        ToolbarWidget(const mv::plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, bool alwaysVisible = false);
+        ToolbarWidget(const plugin::ViewPlugin* viewPlugin, ViewPluginLearningCenterOverlayWidget* overlayWidget, bool alwaysVisible = false);
 
         /**
          * Add \p widget to the toolbar
@@ -489,7 +489,7 @@ protected:
         PluginLearningCenterAction& getLearningCenterAction() const;
 
     private:
-        const mv::plugin::ViewPlugin*           _viewPlugin;                /** Const pointer to source view plugin */
+        const plugin::ViewPlugin*               _viewPlugin;                /** Const pointer to source view plugin */
         ViewPluginLearningCenterOverlayWidget*  _overlayWidget;             /** Pointer to owning overlay widget */
         bool                                    _alwaysVisible;             /** Whether the toolbar widget should always be visible, regardless of the view plugin overlay visibility setting */
         std::vector<QWidget*>                   _widgets;                   /** Registered widgets */
@@ -511,7 +511,7 @@ public:
      * @param target Pointer to parent widget (overlay widget will be layered on top of this widget)
      * @param viewPlugin Pointer to the view plugin for which to create the overlay
      */
-    ViewPluginLearningCenterOverlayWidget(QWidget* target, const mv::plugin::ViewPlugin* viewPlugin);
+    ViewPluginLearningCenterOverlayWidget(QWidget* target, const plugin::ViewPlugin* viewPlugin);
 
     /**
      * Set target widget to \p targetWidget
@@ -584,7 +584,7 @@ signals:
     void collapsed();
 
 private:
-    const mv::plugin::ViewPlugin*               _viewPlugin;                            /** Pointer to the view plugin for which to create the overlay */
+    const plugin::ViewPlugin*                   _viewPlugin;                            /** Pointer to the view plugin for which to create the overlay */
     QVBoxLayout                                 _layout;                                /** For alignment of the learning center toolbar */
     ToolbarWidget                               _toolbarWidget;                         /** Toolbar widget which contains the various learning center actions */
     LearningCenterToolbarItemWidget             _learningCenterToolbarItemWidget;       /** Primary learning center toolbar item widget */

--- a/ManiVault/src/widgets/ViewPluginShortcutsDialog.h
+++ b/ManiVault/src/widgets/ViewPluginShortcutsDialog.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "ManiVaultGlobals.h"
+
 #include <QDialog>
 #include <QScrollArea>
 #include <QVBoxLayout>


### PR DESCRIPTION
## Solution to the problem
`ADS` does not physically remove the dock widget, this leads to issues such as crashes and memory leakage. Simply deleting the dock widget after calling ` CDockManager::removeDockWidget((DockWidget*)viewPluginDockWidget);` does not work; `ManiVault Studio` will crash somewhere at a later point in time (challenging to debug where exactly, the call stack is not really of use here). This PR solves this problem by:
- Explicitly removing the dock widget with: `viewPluginDockWidget->deleteLater()`
- Replacing `mv::plugin::ViewPlugin* _viewPlugin` with `QPointer<mv::plugin::ViewPlugin> _viewPlugin`, this ensures that the member is reset (to `nullptr`) when the view plugin is destroyed

Additionally, we did some refactoring; view plugin dock widget instances are not tracked in a static member anymore

The video below shows that the problem seems to have been solved. Please be aware that other projects might also cause crashes due to underlying issues such as buggy plugin removal.
![FixCrashOpen](https://github.com/user-attachments/assets/7d6cc1c8-291d-45e6-b602-79d510b0b612)

## Drive-by improvements
- [x] `DockManager` does not track `ViewPluginDockWidget` instances anymore (turned out redundant)
- [x] Numerous code style improvements
- [x] Added `mv::AbstractManager::_coreIsDestroyed;` member, queried with `mv::AbstractManager::isCoreDestroyed() const`
- [x] Added `mv::AbstractManager::_isInitializing;` member, queried with `mv::AbstractManager::isInitializing() const`
- [x] Added `mv::AbstractManager::_isResetting;` member, queried with `mv::AbstractManager::isResetting() const`
- [x] Added `mv::PluginManager::destroyPluginById(const QString& pluginId)`
- [x] Added `waitForDuration(...)` to `mv::util` namespace (this method keeps the application event loop responsive while halting the current execution for *n* milliseconds)
- [x] Fix bug in `ViewPluginLearningCenterOverlayWidget` class, a lambda was not correctly bound to the `this` pointer (causing a crash)

