### PR TITLE
Implements two dataset(s) identifier copy modalities

### DIFF
--- a/ManiVault/src/MiscellaneousSettingsAction.cpp
+++ b/ManiVault/src/MiscellaneousSettingsAction.cpp
@@ -37,6 +37,7 @@ MiscellaneousSettingsAction::MiscellaneousSettingsAction(QObject* parent) :
     addAction(&_keepDescendantsAfterRemovalAction);
     addAction(&_statusBarVisibleAction);
     addAction(&_statusBarOptionsAction);
+    addAction(&_showSimplifiedGuidsAction);
 }
 
 void MiscellaneousSettingsAction::updateStatusBarOptionsAction()

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.cpp
@@ -16,6 +16,7 @@
 #include <QVBoxLayout>
 #include <QStyledItemDelegate>
 #include <QStyleOptionViewItem>
+#include <QClipboard>
 
 #include <stdexcept>
 
@@ -70,7 +71,7 @@ public:
 private:
 
     /** Updates the editor widget visibility based on the dataset task status */
-    void updateEditorWidgetVisibility() {
+    void updateEditorWidgetVisibility() const {
         const auto datasetTaskStatus = _progressItem->getDatasetTask().getStatus();
 
         if (datasetTaskStatus == Task::Status::Running || datasetTaskStatus == Task::Status::RunningIndeterminate || datasetTaskStatus == Task::Status::Finished)
@@ -80,7 +81,7 @@ private:
     }
 
     /** Updates the editor widget read-only state based on the dataset task status */
-    void updateEditorWidgetReadOnly() {
+    void updateEditorWidgetReadOnly() const {
         _progressEditorWidget->setEnabled(!_progressItem->getDataset()->isLocked());
     }
 
@@ -102,7 +103,7 @@ public:
 
     /**
      * Construct with owning parent \p dataHierarchyWidget
-     * @param parent Pointer to owning parent data hierarchy widget
+     * @param dataHierarchyWidget Pointer to owning parent data hierarchy widget
      */
     explicit ItemDelegate(DataHierarchyWidget* dataHierarchyWidget) :
         QStyledItemDelegate(dataHierarchyWidget),
@@ -121,12 +122,12 @@ public:
      * @param index Model index to create the editor for
      * @return Pointer to widget if progress column, nullptr otherwise
      */
-    QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const {
+    QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const override {
         if (static_cast<AbstractDataHierarchyModel::Column>(index.column()) != AbstractDataHierarchyModel::Column::Progress)
             return QStyledItemDelegate::createEditor(parent, option, index);
 
         const auto sourceModelIndex = _dataHierarchyWidget->getFilterModel().mapToSource(index);
-        const auto progressItem     = static_cast<AbstractDataHierarchyModel::ProgressItem*>(_dataHierarchyWidget->getTreeModel().itemFromIndex(sourceModelIndex));
+        const auto progressItem     = dynamic_cast<AbstractDataHierarchyModel::ProgressItem*>(_dataHierarchyWidget->getTreeModel().itemFromIndex(sourceModelIndex));
         
         return new ProgressItemDelegateEditorWidget(progressItem, parent);
     }
@@ -136,7 +137,7 @@ public:
      * @param option Style option
      * @param index Model index of the cell for which the geometry changed
      */
-    void updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const {
+    void updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const override {
         Q_UNUSED(index)
 
         if (editor == nullptr)
@@ -156,7 +157,7 @@ protected:
     {
         QStyledItemDelegate::initStyleOption(option, index);
 
-        auto item = static_cast<AbstractDataHierarchyModel::Item*>(_dataHierarchyWidget->getTreeModel().itemFromIndex(_dataHierarchyWidget->getFilterModel().mapToSource(index)));
+        auto item = dynamic_cast<AbstractDataHierarchyModel::Item*>(_dataHierarchyWidget->getTreeModel().itemFromIndex(_dataHierarchyWidget->getFilterModel().mapToSource(index)));
 
         if (item->getDataset()->isLocked())// || index.column() >= static_cast<int>(AbstractDataHierarchyModel::Column::IsGroup))
             option->state &= ~QStyle::State_Enabled;
@@ -230,7 +231,7 @@ DataHierarchyWidget::DataHierarchyWidget(QWidget* parent) :
 
     connect(expandAllAction, &TriggerAction::triggered, this, [this]() -> void {
         _hierarchyWidget.getExpandAllAction().trigger();
-        });
+	});
 
     auto& treeView = _hierarchyWidget.getTreeView();
 
@@ -427,6 +428,12 @@ DataHierarchyWidget::DataHierarchyWidget(QWidget* parent) :
         });
     }
 
+    connect(&_hierarchyWidget.getTreeView(), &QTreeView::clicked, this, [this](const QModelIndex& index) -> void {
+        if (index.column() != static_cast<int>(AbstractDataHierarchyModel::Column::DatasetId))
+            return;
+
+        QGuiApplication::clipboard()->setText(_treeModel.getItem(_filterModel.mapToSource(index))->getDataset()->getId());
+	});
 }
 
 QModelIndex DataHierarchyWidget::getModelIndexByDataset(const Dataset<DatasetImpl>& dataset) const
@@ -434,7 +441,7 @@ QModelIndex DataHierarchyWidget::getModelIndexByDataset(const Dataset<DatasetImp
     const auto modelIndices = _treeModel.match(_treeModel.index(0, static_cast<int>(AbstractDataHierarchyModel::Column::DatasetId), QModelIndex()), Qt::EditRole, dataset->getId(), 1, Qt::MatchFlag::MatchRecursive);
 
     if (modelIndices.isEmpty())
-        throw new std::runtime_error(QString("'%1' not found in the data hierarchy model").arg(dataset->text()).toLatin1());
+        throw std::runtime_error(QString("'%1' not found in the data hierarchy model").arg(dataset->text()).toLatin1());
 
     return modelIndices.first();
 }

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -15,8 +15,7 @@
 #include <QDebug>
 #include <QMenu>
 #include <QAction>
-
-#include <stdexcept>
+#include <QClipboard>
 
 using namespace mv;
 using namespace mv::util;
@@ -72,13 +71,34 @@ DataHierarchyWidgetContextMenu::DataHierarchyWidgetContextMenu(QWidget* parent, 
 
         addAction(removeDatasetsAction);
     }
+
+    if (!_selectedDatasets.isEmpty()) {
+        addSeparator();
+
+        const auto copySelectedDatasetIdsToClipboard = [this]() -> void {
+            QStringList datasetIds;
+
+            for (const auto& selectedDataset : _selectedDatasets)
+                datasetIds << selectedDataset->getId();
+
+            QGuiApplication::clipboard()->setText(datasetIds.join("\n"));
+        };
+
+        auto copyAction = new QAction(QString("Copy dataset ID%1").arg(_selectedDatasets.count() > 1 ? "'s" : ""));
+
+        copyAction->setIcon(Application::getIconFont("FontAwesome").getIcon("barcode"));
+
+        connect(copyAction, &QAction::triggered, copyAction, copySelectedDatasetIdsToClipboard);
+
+        addAction(copyAction);
+    }
 }
 
 void DataHierarchyWidgetContextMenu::addMenusForPluginType(plugin::Type pluginType)
 {
     QMap<QString, QMenu*> menus;
 
-    for (auto pluginTriggerAction : Application::core()->getPluginManager().getPluginTriggerActions(pluginType, _selectedDatasets)) {
+    for (const auto& pluginTriggerAction : Application::core()->getPluginManager().getPluginTriggerActions(pluginType, _selectedDatasets)) {
         const auto titleSegments = pluginTriggerAction->getMenuLocation().split("/");
 
         QString menuPath, previousMenuPath = titleSegments.first();
@@ -311,3 +331,4 @@ QMenu* DataHierarchyWidgetContextMenu::getUnhideMenu()
 
     return unhideMenu;
 }
+

--- a/ManiVault/src/util/Serializable.cpp
+++ b/ManiVault/src/util/Serializable.cpp
@@ -32,7 +32,7 @@ Serializable::Serializable(const QString& name /*= ""*/) :
 QString Serializable::getId(bool truncated /*= false*/) const
 {
     if (truncated)
-        return _id.left(8);
+        return _id.right(8);
         
     return _id;
 }


### PR DESCRIPTION
- [x] Copy with dataset hierarchy context menu
- [x] Copy by clicking on the dataset identifier column
- [x] Enables toggling simplified GUIDs