### PR TITLE
Properly restore floating view plugins from project

### DIFF
--- a/ManiVault/src/private/DockManager.cpp
+++ b/ManiVault/src/private/DockManager.cpp
@@ -61,7 +61,7 @@ DockManager::ViewPluginDockWidgets DockManager::getViewPluginDockWidgets()
 {
     ViewPluginDockWidgets viewPluginDockWidgets;
 
-    for (auto dockWidget : dockWidgets())
+    for (auto dockWidget : dockWidgetsMap().values())
         if (auto viewPluginDockWidget = dynamic_cast<ViewPluginDockWidget*>(dockWidget))
             viewPluginDockWidgets.push_back(viewPluginDockWidget);
 


### PR DESCRIPTION
Use ads:DockManager::dockWidgetsMap().values() instead of ads:DockManager::dockWidget(), which only returns non-floating dock widgets (very odd)