### PR TITLE
Add const getMap for SelectionMap

### DIFF
--- a/ManiVault/src/LinkedData.cpp
+++ b/ManiVault/src/LinkedData.cpp
@@ -76,11 +76,6 @@ void SelectionMap::populateMappingIndices(std::uint32_t pointIndex, Indices& ind
     }
 }
 
-SelectionMap::Map& SelectionMap::getMap()
-{
-    return _map;
-}
-
 bool SelectionMap::hasMappingForPointIndex(std::uint32_t pointIndex) const
 {
     switch (_type)

--- a/ManiVault/src/LinkedData.h
+++ b/ManiVault/src/LinkedData.h
@@ -56,7 +56,13 @@ public:
      * Get map for indexed pixels
      * @return Index map
      */
-    Map& getMap();
+    Map& getMap() { return _map; };
+
+    /**
+     * Get map for indexed pixels
+     * @return Index map
+     */
+    const Map& getMap() const { return _map; };
 
     /**
      * Establishes whether a mapping exists for \p pointIndex


### PR DESCRIPTION
Currently, we cannot use `getMap()` for a `SelectionMap` that we access from `LinkedData` via `getMapping` because the latter returns `const SelectionMap&`.

I suggest adding `const Map& getMap()`.

I moved the function to the header to inline them which gets around `C++ cannot overload functions distinguished by return type alone` compilation errors...