### PR TITLE
Fix crash when removing plugin that uses HorizontalToolbarAction

### DIFF
--- a/ManiVault/src/actions/HorizontalToolbarAction.cpp
+++ b/ManiVault/src/actions/HorizontalToolbarAction.cpp
@@ -18,8 +18,8 @@ HorizontalToolbarAction::HorizontalToolbarAction(QObject* parent, const QString&
 HorizontalToolbarAction::Widget::Widget(QWidget* parent, HorizontalToolbarAction* horizontalToolbarAction, const std::int32_t& widgetFlags) :
     WidgetActionWidget(parent, horizontalToolbarAction, widgetFlags),
     _horizontalToolbarAction(horizontalToolbarAction),
-    _layout(),
-    _toolbarLayout(),
+    _layout(new QHBoxLayout()),
+    _toolbarLayout(new QHBoxLayout()),
     _toolbarWidget(),
     _timer()
 {
@@ -28,16 +28,16 @@ HorizontalToolbarAction::Widget::Widget(QWidget* parent, HorizontalToolbarAction
     _timer.setInterval(300);
     _timer.setSingleShot(true);
 
-    _toolbarLayout.setContentsMargins(ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN);
-    _toolbarLayout.setSpacing(0);
+    _toolbarLayout->setContentsMargins(ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN);
+    _toolbarLayout->setSpacing(0);
 
-    _toolbarWidget.setLayout(&_toolbarLayout);
-    _toolbarLayout.setAlignment(horizontalToolbarAction->getGroupAction().getAlignment());
+    _toolbarWidget.setLayout(_toolbarLayout);
+    _toolbarLayout->setAlignment(horizontalToolbarAction->getGroupAction().getAlignment());
     
-    _layout.setContentsMargins(0, 0, 0, 0);
-    _layout.addWidget(&_toolbarWidget);
+    _layout->setContentsMargins(0, 0, 0, 0);
+    _layout->addWidget(&_toolbarWidget);
 
-    setLayout(&_layout);
+    setLayout(_layout);
 
     connect(_horizontalToolbarAction, &ToolbarAction::actionWidgetsChanged, this, &HorizontalToolbarAction::Widget::setActionWidgets);
     connect(_horizontalToolbarAction, &ToolbarAction::layoutInvalidated, this, &Widget::updateLayout);
@@ -78,7 +78,7 @@ void HorizontalToolbarAction::Widget::setActionWidgets()
 {
     QLayoutItem* layoutItem;
 
-    while ((layoutItem = _toolbarLayout.takeAt(0)) != nullptr) {
+    while ((layoutItem = _toolbarLayout->takeAt(0)) != nullptr) {
         delete layoutItem->widget();
         delete layoutItem;
     }
@@ -87,9 +87,9 @@ void HorizontalToolbarAction::Widget::setActionWidgets()
         auto stretchAction = dynamic_cast<const StretchAction*>(actionItem->getAction());
 
         if (stretchAction)
-            _toolbarLayout.addWidget(actionItem->createWidget(&_toolbarWidget), stretchAction->getStretch());
+            _toolbarLayout->addWidget(actionItem->createWidget(&_toolbarWidget), stretchAction->getStretch());
         else
-            _toolbarLayout.addWidget(actionItem->createWidget(&_toolbarWidget));
+            _toolbarLayout->addWidget(actionItem->createWidget(&_toolbarWidget));
     }
 
     updateLayout();
@@ -133,7 +133,7 @@ void HorizontalToolbarAction::Widget::updateLayout()
         for (auto actionItem : _horizontalToolbarAction->getActionItems())
             width += actionItem->getWidgetSize(states[actionItem]).width();
 
-        width += (std::max(1, static_cast<int>(_horizontalToolbarAction->getActionItems().count() - 1)) * _toolbarLayout.spacing());
+        width += (std::max(1, static_cast<int>(_horizontalToolbarAction->getActionItems().count() - 1)) * _toolbarLayout->spacing());
 
         return width;
     };

--- a/ManiVault/src/actions/HorizontalToolbarAction.h
+++ b/ManiVault/src/actions/HorizontalToolbarAction.h
@@ -53,8 +53,8 @@ public: // Widgets
 
     protected:
         HorizontalToolbarAction*    _horizontalToolbarAction;   /** Pointer to horizontal toolbar action that creates the widget */
-        QHBoxLayout                 _layout;                    /** Main layout */
-        QHBoxLayout                 _toolbarLayout;             /** Toolbar layout */
+        QHBoxLayout*                _layout;                    /** Main layout */
+        QHBoxLayout*                _toolbarLayout;             /** Toolbar layout */
         QWidget                     _toolbarWidget;             /** Toolbar widget */
         QTimer                      _timer;                     /** Timer to periodically update the layout */
 

--- a/ManiVault/src/actions/VerticalToolbarAction.cpp
+++ b/ManiVault/src/actions/VerticalToolbarAction.cpp
@@ -15,22 +15,22 @@ VerticalToolbarAction::VerticalToolbarAction(QObject* parent, const QString& tit
 VerticalToolbarAction::Widget::Widget(QWidget* parent, VerticalToolbarAction* verticalToolbarAction, const std::int32_t& widgetFlags) :
     WidgetActionWidget(parent, verticalToolbarAction, widgetFlags),
     _verticalToolbarAction(verticalToolbarAction),
-    _layout(),
-    _toolbarLayout(),
+    _layout(new QVBoxLayout()),
+    _toolbarLayout(new QVBoxLayout()),
     _toolbarWidget()
 {
-    _toolbarLayout.setContentsMargins(ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN);
-    _toolbarLayout.setAlignment(Qt::AlignLeft);
+    _toolbarLayout->setContentsMargins(ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN, ToolbarAction::CONTENTS_MARGIN);
+    _toolbarLayout->setAlignment(Qt::AlignLeft);
 
-    _toolbarWidget.setLayout(&_toolbarLayout);
+    _toolbarWidget.setLayout(_toolbarLayout);
     
-    _layout.setSizeConstraint(QLayout::SetFixedSize);
-    _layout.setContentsMargins(0, 0, 0, 0);
-    _layout.setAlignment(Qt::AlignLeft);
-    _layout.addWidget(&_toolbarWidget);
-    _layout.addStretch(1);
+    _layout->setSizeConstraint(QLayout::SetFixedSize);
+    _layout->setContentsMargins(0, 0, 0, 0);
+    _layout->setAlignment(Qt::AlignLeft);
+    _layout->addWidget(&_toolbarWidget);
+    _layout->addStretch(1);
     
-    setLayout(&_layout);
+    setLayout(_layout);
 
     connect(_verticalToolbarAction, &ToolbarAction::actionWidgetsChanged, this, &VerticalToolbarAction::Widget::setActionWidgets);
 
@@ -41,13 +41,13 @@ void VerticalToolbarAction::Widget::setActionWidgets()
 {
     QLayoutItem* layoutItem;
 
-    while ((layoutItem = _toolbarLayout.takeAt(0)) != nullptr) {
+    while ((layoutItem = _toolbarLayout->takeAt(0)) != nullptr) {
         delete layoutItem->widget();
         delete layoutItem;
     }
 
     for (auto actionItem : _verticalToolbarAction->getActionItems())
-        _toolbarLayout.addWidget(actionItem->createWidget(&_toolbarWidget));
+        _toolbarLayout->addWidget(actionItem->createWidget(&_toolbarWidget));
 }
 
 }

--- a/ManiVault/src/actions/VerticalToolbarAction.h
+++ b/ManiVault/src/actions/VerticalToolbarAction.h
@@ -43,8 +43,8 @@ public: // Widgets
 
     protected:
         VerticalToolbarAction* _verticalToolbarAction;      /** Pointer to vertical toolbar action that creates the widget */
-        QVBoxLayout             _layout;                    /** Main layout */
-        QVBoxLayout             _toolbarLayout;             /** Toolbar layout */
+        QVBoxLayout*            _layout;                    /** Main layout */
+        QVBoxLayout*            _toolbarLayout;             /** Toolbar layout */
         QWidget                 _toolbarWidget;             /** Toolbar widget */
 
         friend class VerticalToolbarAction;


### PR DESCRIPTION
When removing a Scatterplot, the application crashes. 

The issue seems to come from the destruction of `HorizontalToolbarAction::Widget`. I think this stems from [QWidget::setLayout](https://doc.qt.io/qt-6/qwidget.html#setLayout) taking ownership of the `_toolbarLayout` and `_layout` layouts it is passed to, which leads to a double-destruction attempt here.

Using `QHBoxLayout*` instead of `QHBoxLayout` let's Qt manage their destruction and let's us remove Scatterplot plugins.