### PR TITLE
Fix zoom changes brush size

### DIFF
--- a/ManiVault/src/util/PixelSelectionTool.cpp
+++ b/ManiVault/src/util/PixelSelectionTool.cpp
@@ -22,6 +22,7 @@ PixelSelectionTool::PixelSelectionTool(QWidget* targetWidget, const bool& enable
     _active(false),
     _notifyDuringSelection(true),
     _brushRadius(BRUSH_RADIUS_DEFAULT),
+    _fixedBrushRadiusModifier(Qt::NoModifier),
     _mousePosition(),
     _mousePositions(),
     _mouseButtons(),
@@ -124,6 +125,16 @@ void PixelSelectionTool::setBrushRadius(const float& brushRadius)
     emit brushRadiusChanged(_brushRadius);
     
     paint();
+}
+
+Qt::KeyboardModifier PixelSelectionTool::getFixedBrushRadiusModifier() const
+{
+    return _fixedBrushRadiusModifier;
+}
+
+void PixelSelectionTool::setFixedBrushRadiusModifier(Qt::KeyboardModifier fixedBrushRadiusModifier)
+{
+    _fixedBrushRadiusModifier = fixedBrushRadiusModifier;
 }
 
 QColor PixelSelectionTool::getMainColor() const
@@ -495,6 +506,9 @@ bool PixelSelectionTool::eventFilter(QObject* target, QEvent* event)
                 case PixelSelectionType::Brush:
                 case PixelSelectionType::Sample:
                 {
+                    if (_fixedBrushRadiusModifier != Qt::NoModifier && QGuiApplication::keyboardModifiers() == _fixedBrushRadiusModifier)
+                        break;
+
                     if (wheelEvent->angleDelta().y() < 0)
                         setBrushRadius(_brushRadius - BRUSH_RADIUS_DELTA);
                     else

--- a/ManiVault/src/util/PixelSelectionTool.h
+++ b/ManiVault/src/util/PixelSelectionTool.h
@@ -86,6 +86,12 @@ public: // Getters/setters
      */
     void setBrushRadius(const float& brushRadius);
 
+    /** Get fixed brush radius modifier */
+    Qt::KeyboardModifier getFixedBrushRadiusModifier() const;
+
+    /** Set fixed brush radius modifier */
+    void setFixedBrushRadiusModifier(Qt::KeyboardModifier fixedBrushRadiusModifier);
+
     /** Get main drawing color */
     QColor getMainColor() const;
 
@@ -186,6 +192,7 @@ protected:
     bool                        _active;                    /** Whether the selection process is active */
     bool                        _notifyDuringSelection;     /** Whether the selection is published continuously or at the end */
     float                       _brushRadius;               /** Brush radius */
+    Qt::KeyboardModifier        _fixedBrushRadiusModifier;  /** Do not change brush radius when fixed by pressing a key (e.g. for navigation) */
     QPoint                      _mousePosition;             /** Current mouse position */
     QVector<QPoint>             _mousePositions;            /** Recorded mouse positions */
     int                         _mouseButtons;              /** State of the left, middle and right mouse buttons */

--- a/ManiVault/src/util/PixelSelectionTool.h
+++ b/ManiVault/src/util/PixelSelectionTool.h
@@ -105,7 +105,7 @@ public: // Getters/setters
     void setChanged();
 
     /**
-     * Get whether the selection process is cBurrently active
+     * Get whether the selection process is currently active
      * @return Boolean indicating whether the selection process is currently active
      */
     bool isActive() const {


### PR DESCRIPTION
In the scatterplot plugin, zooming while using the brush selection changes the brush size since both respond to mouse wheel changes.

This PR adds a keyboard modifier that prevents the brush size change. In the Scatterplot the zooming is only active when `ALT` is pressed. With this PR, during `ALT` presses, die brush size won't change.

Towards https://github.com/ManiVaultStudio/Scatterplot/issues/155