### PR TITLE
Fix view plugin learning center overlay blocking the view plugin widget interaction

### DIFF
--- a/ManiVault/src/actions/PluginLearningCenterAction.cpp
+++ b/ManiVault/src/actions/PluginLearningCenterAction.cpp
@@ -84,7 +84,6 @@ PluginLearningCenterAction::PluginLearningCenterAction(QObject* parent, const QS
 
     const auto pluginOverlayVisibleChanged = [this]() -> void {
         _toolbarVisibleAction.setIconByName(_toolbarVisibleAction.isChecked() ? "eye" : "eye-slash");
-        _alignmentAction.setEnabled(_toolbarVisibleAction.isChecked());
     };
 
     pluginOverlayVisibleChanged();
@@ -139,6 +138,7 @@ QMenu* PluginLearningCenterAction::getAlignmentContextMenu(QWidget* parent)
 {
     auto contextMenu = new QMenu("Alignment", parent);
 
+    contextMenu->setEnabled(_toolbarVisibleAction.isChecked());
     contextMenu->setIcon(Application::getIconFont("FontAwesome").getIcon("arrows-alt"));
 
     if (getAlignment() != (Qt::AlignTop | Qt::AlignLeft))

--- a/ManiVault/src/actions/PluginLearningCenterAction.cpp
+++ b/ManiVault/src/actions/PluginLearningCenterAction.cpp
@@ -82,13 +82,14 @@ PluginLearningCenterAction::PluginLearningCenterAction(QObject* parent, const QS
     _alignmentAction.setConfigurationFlag(WidgetAction::ConfigurationFlag::HiddenInActionContextMenu);
     _alignmentAction.setConnectionPermissionsToForceNone();
 
-    const auto updateViewPluginOverlayVisibleActionIcon = [this]() -> void {
+    const auto pluginOverlayVisibleChanged = [this]() -> void {
         _toolbarVisibleAction.setIconByName(_toolbarVisibleAction.isChecked() ? "eye" : "eye-slash");
+        _alignmentAction.setEnabled(_toolbarVisibleAction.isChecked());
     };
 
-    updateViewPluginOverlayVisibleActionIcon();
+    pluginOverlayVisibleChanged();
 
-    connect(&_toolbarVisibleAction, &ToggleAction::toggled, this, updateViewPluginOverlayVisibleActionIcon);
+    connect(&_toolbarVisibleAction, &ToggleAction::toggled, this, pluginOverlayVisibleChanged);
 
     _moveToTopLeftAction.setIcon(getAlignmentIcon(Qt::AlignTop | Qt::AlignLeft));
     _moveToTopRightAction.setIcon(getAlignmentIcon(Qt::AlignTop | Qt::AlignRight));

--- a/ManiVault/src/util/WidgetOverlayer.cpp
+++ b/ManiVault/src/util/WidgetOverlayer.cpp
@@ -77,6 +77,8 @@ void WidgetOverlayer::addMouseEventReceiverWidget(const QWidget* mouseEventRecei
     _mouseEventReceiverWidgets << mouseEventReceiverWidget;
 
     emit mouseEventReceiverWidgetAdded(mouseEventReceiverWidget);
+
+    _sourceWidget->setAttribute(Qt::WA_TransparentForMouseEvents, false);
 }
 
 void WidgetOverlayer::removeMouseEventReceiverWidget(const QWidget* mouseEventReceiverWidget)
@@ -89,6 +91,8 @@ void WidgetOverlayer::removeMouseEventReceiverWidget(const QWidget* mouseEventRe
     _mouseEventReceiverWidgets.removeOne(mouseEventReceiverWidget);
 
     emit mouseEventReceiverWidgetRemoved(mouseEventReceiverWidget);
+
+    _sourceWidget->setAttribute(Qt::WA_TransparentForMouseEvents, true);
 }
 
 WidgetOverlayer::MouseEventReceiverWidgets WidgetOverlayer::getMouseEventReceiverWidgets()


### PR DESCRIPTION
- [x] Set overlay widget attribute to transparent for mouse events when there are no mouse event receiver widgets
- [x] Disable alignment action when toolbar is hidden