### PR TITLE
Consistent registry entries

### DIFF
--- a/ManiVault/src/PluginFactory.cpp
+++ b/ManiVault/src/PluginFactory.cpp
@@ -58,7 +58,7 @@ void PluginFactory::initialize()
 
 QString PluginFactory::getGlobalSettingsPrefix() const
 {
-    return QString("%1/").arg(getKind());
+    return QString("Plugins/%1/").arg(getKind());
 }
 
 PluginGlobalSettingsGroupAction* PluginFactory::getGlobalSettingsGroupAction() const

--- a/ManiVault/src/SelectionGroup.cpp
+++ b/ManiVault/src/SelectionGroup.cpp
@@ -1,5 +1,7 @@
 #include "SelectionGroup.h"
 
+#include <stdexcept>
+
 namespace mv
 {
     void BiMap::addKeyValuePairs(const std::vector<QString>& keys, const std::vector<uint32_t>& values)
@@ -32,7 +34,7 @@ namespace mv
             }
             catch (std::out_of_range& oor)
             {
-                qWarning() << "Trying to find value: " << values[i] << " in value-key map, but no such value exists.";
+                qWarning() << "Trying to find value: " << values[i] << " in value-key map, but no such value exists. Error: " << oor.what();
                 return std::vector<QString>();
             }
         }

--- a/ManiVault/src/SelectionGroup.cpp
+++ b/ManiVault/src/SelectionGroup.cpp
@@ -15,7 +15,7 @@ namespace mv
         _kvMap.clear();
         _vkMap.clear();
 
-        for (int i = 0; i < keys.size(); i++)
+        for (size_t i = 0; i < keys.size(); i++)
         {
             _kvMap[keys[i]] = values[i];
             _vkMap[values[i]] = keys[i];
@@ -26,7 +26,7 @@ namespace mv
     {
         std::vector<QString> keys(values.size());
 
-        for (int i = 0; i < values.size(); i++)
+        for (size_t i = 0; i < values.size(); i++)
         {
             try
             {
@@ -59,7 +59,7 @@ namespace mv
         //    }
         //}
 
-        for (int i = 0; i < keys.size(); i++)
+        for (size_t i = 0; i < keys.size(); i++)
         {
             if (auto it = _kvMap.find(keys[i]); it != _kvMap.end()) {
                 values.push_back(it->second);
@@ -82,7 +82,7 @@ namespace mv
         std::vector<QString> keys;
 
         // Find the keys associated with the given indices
-        for (int i = 0; i < _datasets.size(); i++)
+        for (size_t i = 0; i < _datasets.size(); i++)
         {
             Dataset<DatasetImpl> d = _datasets[i];
             if (d == dataset)
@@ -91,7 +91,7 @@ namespace mv
             }
         }
         // Find values associated with the found keys in other datasets
-        for (int i = 0; i < _datasets.size(); i++)
+        for (size_t i = 0; i < _datasets.size(); i++)
         {
             Dataset<DatasetImpl> d = _datasets[i];
             if (d != dataset)

--- a/ManiVault/src/SelectionGroup.cpp
+++ b/ManiVault/src/SelectionGroup.cpp
@@ -2,11 +2,6 @@
 
 namespace mv
 {
-    BiMap::BiMap()
-    {
-
-    }
-
     void BiMap::addKeyValuePairs(const std::vector<QString>& keys, const std::vector<uint32_t>& values)
     {
         if (keys.size() != values.size())

--- a/ManiVault/src/SelectionGroup.h
+++ b/ManiVault/src/SelectionGroup.h
@@ -16,8 +16,6 @@ namespace mv
 class CORE_EXPORT BiMap
 {
 public:
-    BiMap();
-
     void addKeyValuePairs(const std::vector<QString>& keys, const std::vector<uint32_t>& values);
 
     std::vector<QString> getKeysByValues(const std::vector<uint32_t>& values) const;

--- a/ManiVault/src/SelectionGroup.h
+++ b/ManiVault/src/SelectionGroup.h
@@ -24,8 +24,8 @@ public:
     std::vector<uint32_t> getValuesByKeys(const std::vector<QString>& values) const;
 
 private:
-    std::unordered_map<QString, uint32_t> _kvMap;
-    std::unordered_map<uint32_t, QString> _vkMap;
+    std::unordered_map<QString, uint32_t> _kvMap = {};
+    std::unordered_map<uint32_t, QString> _vkMap = {};
 };
 
 class CORE_EXPORT KeyBasedSelectionGroup
@@ -36,8 +36,8 @@ class CORE_EXPORT KeyBasedSelectionGroup
         void selectionChanged(Dataset<DatasetImpl> dataset, const std::vector<uint32_t>& indices) const;
 
     private:
-        std::vector<Dataset<DatasetImpl>> _datasets;
+        std::vector<Dataset<DatasetImpl>> _datasets = {};
+        std::vector<BiMap> _biMaps = {};
+};
 
-        std::vector<BiMap> _biMaps;
-    };
 }

--- a/ManiVault/src/actions/GroupsAction.h
+++ b/ManiVault/src/actions/GroupsAction.h
@@ -86,7 +86,7 @@ public:
     protected:
         /**
         * Override QObject's event handling
-        * @return Boolean Wheter the event was recognized and processed
+        * @return Boolean Whether the event was recognized and processed
         */
         bool event(QEvent* event) override;
 

--- a/ManiVault/src/actions/ModelFilterAction.cpp
+++ b/ManiVault/src/actions/ModelFilterAction.cpp
@@ -10,6 +10,7 @@ namespace mv::gui {
 
 ModelFilterAction::ModelFilterAction(QObject* parent, const QString& title) :
     HorizontalGroupAction(parent, title),
+    _model(nullptr),
     _filterModel(nullptr),
     _filterNameAction(this, "Name"),
     _filterColumnAction(this, "Column"),

--- a/ManiVault/src/actions/ModelFilterAction.h
+++ b/ManiVault/src/actions/ModelFilterAction.h
@@ -53,7 +53,7 @@ public: // Action getters
     StringAction& getFilterNameAction() { return _filterNameAction; }
     OptionAction& getFilterColumnAction() { return _filterColumnAction; }
     GroupAction& getFilterGroupAction() { return _filterGroupAction; }
-    ToggleAction& getFfilterCaseSensitiveAction() { return _filterCaseSensitiveAction; }
+    ToggleAction& getFilterCaseSensitiveAction() { return _filterCaseSensitiveAction; }
     ToggleAction& getFilterRegularExpressionAction() { return _filterRegularExpressionAction; }
 
 private:

--- a/ManiVault/src/actions/ModelSelectionAction.cpp
+++ b/ManiVault/src/actions/ModelSelectionAction.cpp
@@ -14,6 +14,7 @@ namespace mv::gui {
 ModelSelectionAction::ModelSelectionAction(QObject* parent, const QString& title, QItemSelectionModel* selectionModel /*= nullptr*/) :
     HorizontalGroupAction(parent, title),
     _selectionModel(nullptr),
+    _sourceModel(nullptr),
     _selectAllAction(this, "All"),
     _clearSelectionAction(this, "Clear"),
     _invertSelectionAction(this, "Invert")

--- a/ManiVault/src/actions/WidgetAction.cpp
+++ b/ManiVault/src/actions/WidgetAction.cpp
@@ -27,7 +27,7 @@ using namespace mv::util;
 
 namespace mv::gui {
 
-bool isInPopupMode(QWidget* parent) {
+static bool isInPopupMode(QWidget* parent) {
     return parent->property("Popup").isValid() ? parent->property("Popup").toBool() : false;
 }
 

--- a/ManiVault/src/actions/WidgetAction.h
+++ b/ManiVault/src/actions/WidgetAction.h
@@ -426,7 +426,7 @@ public: // Widgets
 protected:
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/UnhideAction.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/UnhideAction.h
@@ -37,7 +37,7 @@ public:
 protected:
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/plugins/ImageData/src/Images.h
+++ b/ManiVault/src/plugins/ImageData/src/Images.h
@@ -290,5 +290,5 @@ private:
     QSharedPointer<InfoAction>      _infoAction;            /** Shared pointer to info action */
     QRect                           _visibleRectangle;      /** Rectangle which bounds the visible pixels */
     std::vector<std::uint8_t>       _maskData;              /** Mask data */
-    bool                            _maskDataGiven;         /** Wheter mask data was set externally */
+    bool                            _maskDataGiven;         /** Whether mask data was set externally */
 };

--- a/ManiVault/src/private/DockAreaTitleBar.h
+++ b/ManiVault/src/private/DockAreaTitleBar.h
@@ -32,7 +32,7 @@ public:
 protected:
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/LearningPageExamplesWidget.h
+++ b/ManiVault/src/private/LearningPageExamplesWidget.h
@@ -34,7 +34,7 @@ private:
 protected:
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/LearningPagePluginAction.h
+++ b/ManiVault/src/private/LearningPagePluginAction.h
@@ -101,7 +101,7 @@ protected:
 
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/LearningPagePluginAction.h
+++ b/ManiVault/src/private/LearningPagePluginAction.h
@@ -44,7 +44,7 @@ private:
          * Invoked on mouse press
          * @param event Pointer to mouse event
          */
-        void mousePressEvent(QMouseEvent* event);
+        void mousePressEvent(QMouseEvent* event) override;
 
         /**
          * Invoked on mouse hover

--- a/ManiVault/src/private/LearningPageVideosWidget.h
+++ b/ManiVault/src/private/LearningPageVideosWidget.h
@@ -32,7 +32,7 @@ protected:
 
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/MainWindow.h
+++ b/ManiVault/src/private/MainWindow.h
@@ -52,7 +52,7 @@ private: // Window geometry persistence
     
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/PageActionsWidget.h
+++ b/ManiVault/src/private/PageActionsWidget.h
@@ -57,7 +57,7 @@ public:
 protected:
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/PageContentWidget.h
+++ b/ManiVault/src/private/PageContentWidget.h
@@ -66,7 +66,7 @@ protected:
 
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/PageHeaderWidget.h
+++ b/ManiVault/src/private/PageHeaderWidget.h
@@ -40,7 +40,7 @@ protected:
 
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/PageTutorialsWidget.h
+++ b/ManiVault/src/private/PageTutorialsWidget.h
@@ -45,7 +45,7 @@ public:
 protected:
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/PageWidget.h
+++ b/ManiVault/src/private/PageWidget.h
@@ -49,7 +49,7 @@ protected:
 
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/PluginManager.h
+++ b/ManiVault/src/private/PluginManager.h
@@ -160,7 +160,7 @@ public: // Plugin trigger actions
      * @param datasets Vector of input datasets
      * @return Vector of plugin trigger actions
      */
-    gui::PluginTriggerActions getPluginTriggerActions(const plugin::Type& pluginType, const Datasets& datasets) const;
+    gui::PluginTriggerActions getPluginTriggerActions(const plugin::Type& pluginType, const Datasets& datasets) const override;
 
     /**
      * Get plugin trigger actions by \p pluginType and \p dataTypes
@@ -168,7 +168,7 @@ public: // Plugin trigger actions
      * @param dataTypes Vector of input data types
      * @return Vector of plugin trigger actions
      */
-    gui::PluginTriggerActions getPluginTriggerActions(const plugin::Type& pluginType, const DataTypes& dataTypes) const;
+    gui::PluginTriggerActions getPluginTriggerActions(const plugin::Type& pluginType, const DataTypes& dataTypes) const override;
 
     /**
      * Get plugin trigger actions by \p pluginKind and \p datasets
@@ -176,7 +176,7 @@ public: // Plugin trigger actions
      * @param datasets Vector of input datasets
      * @return Vector of plugin trigger actions
      */
-    gui::PluginTriggerActions getPluginTriggerActions(const QString& pluginKind, const Datasets& datasets) const;
+    gui::PluginTriggerActions getPluginTriggerActions(const QString& pluginKind, const Datasets& datasets) const override;
 
     /**
      * Get plugin trigger actions by \p pluginKind and \p dataTypes
@@ -184,7 +184,7 @@ public: // Plugin trigger actions
      * @param dataTypes Vector of input data types
      * @return Vector of plugin trigger actions
      */
-    gui::PluginTriggerActions getPluginTriggerActions(const QString& pluginKind, const DataTypes& dataTypes) const;
+    gui::PluginTriggerActions getPluginTriggerActions(const QString& pluginKind, const DataTypes& dataTypes) const override;
 
 public: // Plugin query
 

--- a/ManiVault/src/private/StartPageOpenProjectWidget.h
+++ b/ManiVault/src/private/StartPageOpenProjectWidget.h
@@ -34,7 +34,7 @@ protected:
 
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/TutorialsWidget.h
+++ b/ManiVault/src/private/TutorialsWidget.h
@@ -33,7 +33,7 @@ protected:
 protected:
     /**
      * Override QObject's event handling
-     * @return Boolean Wheter the event was recognized and processed
+     * @return Boolean Whether the event was recognized and processed
      */
     bool event(QEvent* event) override;
 

--- a/ManiVault/src/private/ViewPluginDockWidget.h
+++ b/ManiVault/src/private/ViewPluginDockWidget.h
@@ -73,7 +73,7 @@ private:
     protected:
         /**
          * Override QObject's event handling
-         * @return Boolean Wheter the event was recognized and processed
+         * @return Boolean Whether the event was recognized and processed
          */
         bool event(QEvent* event) override;
 

--- a/ManiVault/src/util/Logger.h
+++ b/ManiVault/src/util/Logger.h
@@ -6,8 +6,9 @@
 
 #include "ManiVaultGlobals.h"
 
-#include <QString>
 #include <QMap>
+#include <QString>
+#include <QtLogging>
 
 #include <cstddef>
 #include <deque>
@@ -23,14 +24,14 @@ namespace mv::util
 
 struct CORE_EXPORT MessageRecord
 {
-    std::size_t number;
-    QtMsgType type;
-    int version;
-    int line;
-    const char* file;
-    const char* function;
-    const char* category;
-    QString message;
+    std::size_t number = 0;
+    QtMsgType type = {};
+    int version = 0;
+    int line = 0;
+    const char* file = nullptr;
+    const char* function = nullptr;
+    const char* category = nullptr;
+    QString message = {};
 
     QString toString() const;
 };


### PR DESCRIPTION
My ManiVault related registry entries currently look like this:

```
HKEY_CURRENT_USER\
    SOFTWARE\
        BioVault\
            ManiVault\
                BIN Loader
                ErrorLogging
                GlobalSettings\
                Image Loader\
                LearningPage\
                MainWindow
                Manager\
                Plugins
                    Image Loader\
                Projects
                ScreenShot\
        HDPS\
            Plugins\
                ExtCsvLoader
                H510XLoader
        ManiVault\
            Plugins\
                BIN Loader
                H5ADLoader
```

Notably, `BIN Loader` is not listed in `Plugins` and `Image Loader` appears twice.

I think this happens since `PluginFactory::getGlobalSettingsPrefix` does not add `Plugins` but `WidgetAction::setSettingsPrefix` does. I suggest a consistent placement under `Plugins`.

Th other misplaced plugin registry entries under `HDPS` and `ManiVault` (missing `BioVault`) are addressed in https://github.com/ManiVaultStudio/BinIO/pull/24, https://github.com/ManiVaultStudio/ExtCsvLoader/pull/7 and https://github.com/ManiVaultStudio/HDF5Loader/pull/29.

Drive-by changes:
- Several warning fixes, mostly init and conversion stuff