### PR TITLE
Add QStyleHints header conditionally

### DIFF
--- a/ManiVault/src/util/NamedIcon.cpp
+++ b/ManiVault/src/util/NamedIcon.cpp
@@ -15,6 +15,10 @@
 #include <QCryptographicHash>
 #include <QByteArray>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#include <QStyleHints>
+#endif
+
 using namespace mv::gui;
 
 namespace mv::util


### PR DESCRIPTION
...otherwise the build fails with Qt 6.6.3 on ubuntu 24.04 since later on in the file we use 

```cpp
#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
        return QApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
#else
[...]
```