### PR TITLE
Fix regression after 813

### DIFF
--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -171,12 +171,6 @@ if(APPLE)
     set(CMAKE_XCODE_GENERATE_SCHEME ON)
 endif()
 
-if (MSVC)
-    target_compile_options(zlibstatic PRIVATE "$<IF:$<CONFIG:DEBUG>,/MDd,/MD>")
-    target_compile_options(QuaZip PRIVATE "$<IF:$<CONFIG:DEBUG>,/MDd,/MD>")
-    target_compile_options(qtadvanceddocking-qt6 PRIVATE "$<IF:$<CONFIG:DEBUG>,/MDd,/MD>")
-endif()
-
 # -----------------------------------------------------------------------------
 # Source files
 # -----------------------------------------------------------------------------

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -105,7 +105,9 @@ endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
 endif()
 
 # -----------------------------------------------------------------------------
@@ -167,6 +169,12 @@ CPMAddPackage(
 
 if(APPLE)
     set(CMAKE_XCODE_GENERATE_SCHEME ON)
+endif()
+
+if (MSVC)
+    target_compile_options(zlibstatic PRIVATE "$<IF:$<CONFIG:DEBUG>,/MDd,/MD>")
+    target_compile_options(QuaZip PRIVATE "$<IF:$<CONFIG:DEBUG>,/MDd,/MD>")
+    target_compile_options(qtadvanceddocking-qt6 PRIVATE "$<IF:$<CONFIG:DEBUG>,/MDd,/MD>")
 endif()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Qt (and other libraries do this similarly) try to gauge whether the current compiler provides the `<atomic>` header by [quickly compiling a little test program](https://github.com/qt/qtbase/blob/e84145d6c14e92c3a499904f70046bc3ceee5960/cmake/FindWrapAtomic.cmake). This check failed with msvc on the CI (but not locally) after https://github.com/ManiVaultStudio/core/pull/813. This PR restores that behavior.