### PR TITLE
Fix github-actions reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Windows build
         if: startsWith(runner.os, 'Windows')
-        uses: ManiVaultStudio/github-actions/conan_windows_build@feature/PrepareCIUpdate022025
+        uses: ManiVaultStudio/github-actions/conan_windows_build@main
         with:
           conan-visual-version: ${{matrix.build-cversion}}
           conan-visual-runtime: ${{matrix.build-runtime}}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Linux build
         if: startsWith(matrix.os, 'ubuntu')
-        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@feature/PrepareCIUpdate022025
+        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@main
         with:
           conan-compiler: ${{matrix.build-compiler}}
           conan-cc: ${{matrix.build-cc}}
@@ -105,7 +105,7 @@ jobs:
           
       - name: Mac build
         if: startsWith(matrix.os, 'macos')
-        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@feature/PrepareCIUpdate022025
+        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@main
         with:
           conan-compiler: ${{matrix.build-compiler}}
           conan-cc: ${{matrix.build-cc}}


### PR DESCRIPTION
Switch github-actions consistently to main from feature branch. Another fix to https://github.com/ManiVaultStudio/core/pull/813