### PR TITLE
Wider selection group column

### DIFF
--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.cpp
@@ -250,7 +250,7 @@ DataHierarchyWidget::DataHierarchyWidget(QWidget* parent) :
     treeViewHeader->setMinimumSectionSize(18);
 
     treeViewHeader->resizeSection(AbstractDataHierarchyModel::Column::Name, 150);
-    treeViewHeader->resizeSection(AbstractDataHierarchyModel::Column::SelectionGroupIndex, treeViewHeader->minimumSectionSize());
+    treeViewHeader->resizeSection(AbstractDataHierarchyModel::Column::SelectionGroupIndex, 30);
     treeViewHeader->resizeSection(AbstractDataHierarchyModel::Column::IsVisible, treeViewHeader->minimumSectionSize());
     treeViewHeader->resizeSection(AbstractDataHierarchyModel::Column::IsGroup, treeViewHeader->minimumSectionSize());
     treeViewHeader->resizeSection(AbstractDataHierarchyModel::Column::IsDerived, treeViewHeader->minimumSectionSize());


### PR DESCRIPTION
The selection index column in the data hierarchy is so small that you cannot see the selection group when adjusting it.

After (proposed):
![image](https://github.com/user-attachments/assets/e11058ba-f57a-4719-ab72-cd6d3c04d87f)


Before (now):
![image](https://github.com/user-attachments/assets/238ff190-86be-43aa-bb98-0aeba504f0d7)
