### PR TITLE
Keep recursion for linked data

### DIFF
--- a/ManiVault/src/private/EventManager.cpp
+++ b/ManiVault/src/private/EventManager.cpp
@@ -235,6 +235,16 @@ void EventManager::notifyDatasetDataSelectionChanged(const Dataset<DatasetImpl>&
         qDebug() << __FUNCTION__ << dataset->getGuiName() << datasetNotifiedString;
 #endif
 
+        if (ignoreDatasets != nullptr && ignoreDatasets->contains(dataset))
+            return;
+
+        Datasets notified{ dataset };
+
+        if (ignoreDatasets == nullptr)
+            ignoreDatasets = &notified;
+        else
+            *ignoreDatasets << dataset;
+
         dataset->markSelectionDirty(true);
 
         // For all selection groups, set the current dataset as having a changed selection
@@ -244,8 +254,10 @@ void EventManager::notifyDatasetDataSelectionChanged(const Dataset<DatasetImpl>&
         }
 
         // If the dataset has any linked dataset, then dirty them as well
-        for (const LinkedData& ld : dataset->getLinkedData())
+        for (const LinkedData& ld : dataset->getLinkedData()) {
             ld.getTargetDataset()->markSelectionDirty(true);
+            notifyDatasetDataSelectionChanged(ld.getTargetDataset(), ignoreDatasets);
+        }
     }
     catch (std::exception& e)
     {


### PR DESCRIPTION
We need to keep this recursion to properly resolve all the linked data selection (linked data of linked data).

The same recursion also takes place in [`resolveLinkedPointData`](https://github.com/ManiVaultStudio/core/blob/bbbb52ea6b3eb0da6ace69d29e6d673162565326/ManiVault/src/plugins/PointData/src/PointData.cpp#L823) in `PointData.cpp`.

Fixes regression after https://github.com/ManiVaultStudio/core/commit/ae5a8b8eb17df76e00c437d27cce92089544ecde.