### PR TITLE
Prevent some overflows

### DIFF
--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -68,7 +68,7 @@ std::uint64_t PointData::getNumberOfElements() const
 }
 
 
-std::uint64_t  PointData::getRawDataSize() const
+std::uint64_t PointData::getRawDataSize() const
 {
     if (_isDense)
     {
@@ -77,7 +77,7 @@ std::uint64_t  PointData::getRawDataSize() const
     }
     else
     {
-        return (_numRows + 4) * sizeof(size_t) + _sparseData.getNumNonZeros() * (sizeof(size_t) + sizeof(float));
+        return static_cast<std::uint64_t>(_numRows + 4) * sizeof(size_t) + _sparseData.getNumNonZeros() * (sizeof(size_t) + sizeof(float));
     }
 }
 

--- a/ManiVault/src/util/Miscellaneous.cpp
+++ b/ManiVault/src/util/Miscellaneous.cpp
@@ -26,7 +26,7 @@
 namespace mv::util
 {
 
-QString getIntegerCountHumanReadable(const float& count)
+QString getIntegerCountHumanReadable(const double& count)
 {
     if (count >= 0 && count < 1000)
         return QString::number(count);
@@ -40,7 +40,7 @@ QString getIntegerCountHumanReadable(const float& count)
     return "";
 }
 
-QString getNoBytesHumanReadable(float noBytes)
+QString getNoBytesHumanReadable(double noBytes)
 {
     QStringList list{ "KB", "MB", "GB", "TB" };
 

--- a/ManiVault/src/util/Miscellaneous.h
+++ b/ManiVault/src/util/Miscellaneous.h
@@ -25,14 +25,14 @@ namespace mv::util
  * @param count Integer count
  * @return Human readable string of an integer count
  */
-CORE_EXPORT QString getIntegerCountHumanReadable(const float& count);
+CORE_EXPORT QString getIntegerCountHumanReadable(const double& count);
 
 /**
  * Returns a human readable string of a byte count
  * @param noBytes Number of bytes
  * @return Human readable string of a byte count
  */
-CORE_EXPORT QString getNoBytesHumanReadable(float noBytes);
+CORE_EXPORT QString getNoBytesHumanReadable(double noBytes);
 
 /**
  * Sort action based on their text


### PR DESCRIPTION
For very large images `getIntegerCountHumanReadable` results in negative numbers in the image viewer:

![image](https://github.com/user-attachments/assets/da4e01c1-3a7b-4f5f-8457-3e8f00245290)

This change from float to double together with https://github.com/ManiVaultStudio/ImageLoaderPlugin/pull/123 fixes that:

![image](https://github.com/user-attachments/assets/697d5cf8-1bd7-4756-9fde-d32dfd788799)
