### PR TITLE
Selection group dialog in data hierarchy context menu

### DIFF
--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -374,7 +374,7 @@ SelectionGroupIndexDialog::SelectionGroupIndexDialog(QWidget* parent) :
 {
     setWindowTitle(tr("Selection group index"));
 
-    QLabel* indicesLabel = new QLabel("Set the same selection group index for all selected datasets.");
+    QLabel* indicesLabel = new QLabel("Set the same selection group index for all selected datasets:");
 
     confirmButton.setEnabled(false);
     confirmButton.setToolTip("Selection group index must be larger than -1");

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -10,10 +10,10 @@
 #include <Set.h>
 
 #include <actions/PluginTriggerAction.h>
-#include <actions/TriggerAction.h>
 
 #include <QDebug>
 #include <QMenu>
+#include <QMessageBox>
 #include <QAction>
 #include <QClipboard>
 
@@ -41,6 +41,7 @@ DataHierarchyWidgetContextMenu::DataHierarchyWidgetContextMenu(QWidget* parent, 
     if (_selectedDatasets.count() >= 2 && dataTypes.count() == 1) {
         addSeparator();
         addAction(getGroupAction());
+        addAction(getSelectionGroupAction());
     }
 
     if (!_allDatasets.isEmpty()) {
@@ -160,6 +161,33 @@ QAction* DataHierarchyWidgetContextMenu::getGroupAction()
     });
 
     return groupDataAction;
+}
+
+QAction* DataHierarchyWidgetContextMenu::getSelectionGroupAction()
+{
+    auto selectionGroupAction = new QAction("Selection group...");
+
+    selectionGroupAction->setToolTip("Add datasets to the same selection group");
+    selectionGroupAction->setIcon(StyledIcon("ellipsis"));
+
+    connect(selectionGroupAction, &QAction::triggered, 
+        [this]() -> void {
+            SelectionGroupIndexDialog selectionIndexDialog(nullptr);
+            selectionIndexDialog.setModal(true);
+            const int ok = selectionIndexDialog.exec();
+
+            if ((ok == QDialog::Accepted)) {
+
+                const int SelectionGroupIndex = selectionIndexDialog.getSelectionGroupIndex();
+                for (auto& selectedDataset : _selectedDatasets) {
+                    selectedDataset->setGroupIndex(SelectionGroupIndex);
+                }
+            }
+
+        }
+        );
+
+    return selectionGroupAction;
 }
 
 QMenu* DataHierarchyWidgetContextMenu::getLockMenu()
@@ -339,3 +367,28 @@ QMenu* DataHierarchyWidgetContextMenu::getUnhideMenu()
     return unhideMenu;
 }
 
+SelectionGroupIndexDialog::SelectionGroupIndexDialog(QWidget* parent) :
+    QDialog(parent),
+    confirmButton(this, "Ok"),
+    selectionIndexAction(this, "Selection group index", -1, 250, -1)
+{
+    setWindowTitle(tr("Selection group index"));
+
+    QLabel* indicesLabel = new QLabel("Set the same selection group index for all selected datasets.");
+
+    confirmButton.setEnabled(false);
+    confirmButton.setToolTip("Selection group index must be larger than -1");
+
+    connect(&confirmButton, &TriggerAction::triggered, this, &SelectionGroupIndexDialog::closeDialogAction);
+    connect(this, &SelectionGroupIndexDialog::closeDialog, this, &QDialog::accept);
+
+    connect(&selectionIndexAction, &IntegralAction::valueChanged, [this](int value) {
+        confirmButton.setEnabled(value >= 0);
+        });
+
+    QHBoxLayout* layout = new QHBoxLayout();
+    layout->addWidget(indicesLabel);
+    layout->addWidget(selectionIndexAction.createWidget(this));
+    layout->addWidget(confirmButton.createWidget(this));
+    setLayout(layout);
+}

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -182,6 +182,8 @@ QAction* DataHierarchyWidgetContextMenu::getSelectionGroupAction()
                 for (auto& selectedDataset : _selectedDatasets) {
                     selectedDataset->setGroupIndex(SelectionGroupIndex);
                 }
+
+                mv::data().getSelectionGroupingAction()->setChecked(true);
             }
 
         }

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -13,7 +13,6 @@
 
 #include <QDebug>
 #include <QMenu>
-#include <QMessageBox>
 #include <QAction>
 #include <QClipboard>
 

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -374,7 +374,8 @@ SelectionGroupIndexDialog::SelectionGroupIndexDialog(QWidget* parent) :
     selectionIndexAction(this, "Selection group index", -1, 250, -1)
 {
     setWindowTitle(tr("Selection group index"));
-
+    setWindowIcon(StyledIcon("ellipsis"));
+    
     QLabel* indicesLabel = new QLabel("Set the same selection group index for all selected datasets:");
 
     confirmButton.setEnabled(false);

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
@@ -9,6 +9,9 @@
 
 #include <QMenu>
 
+#include <actions/TriggerAction.h>
+#include <actions/IntegralAction.h>
+
 class QAction;
 
 using namespace mv;
@@ -48,6 +51,12 @@ private:
     QAction* getGroupAction();
 
     /**
+     * Get action for selection grouping
+     * @return Pointer to action for selection grouping
+     */
+    QAction* getSelectionGroupAction();
+
+    /**
      * Get menu for item locking
      * @return Pointer to menu for item locking
      */
@@ -74,4 +83,31 @@ private:
 private:
     Datasets    _allDatasets;           /** All datasets in the data hierarchy */
     Datasets    _selectedDatasets;      /** Selected datasets in the data hierarchy widget */
+};
+
+/**
+ * Helper dialog for selection index selection
+ */
+class SelectionGroupIndexDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    SelectionGroupIndexDialog(QWidget* parent);
+
+    std::int32_t getSelectionGroupIndex() {
+        return selectionIndexAction.getValue();
+    }
+
+signals:
+    void closeDialog(bool onlyIndices);
+
+public slots:
+    // Pass selected data set name from SelectionGroupIndexDialog to BinExporter (dialogClosed)
+    void closeDialogAction() {
+        emit closeDialog(confirmButton.isChecked());
+    }
+
+private:
+    gui::IntegralAction      selectionIndexAction;
+    gui::TriggerAction       confirmButton;
 };


### PR DESCRIPTION
Adds an option to the data hierarchy context menu that let's a user the the selection group index for multiple data sets at once.

![image](https://github.com/user-attachments/assets/5238b920-caae-4303-a043-f3bac0d5be4a)

![image](https://github.com/user-attachments/assets/14935012-b74a-4e34-a37d-0539695d07f0)

