### PR TITLE
Selection group pattern dialog in data hierarchy context menu 

### DIFF
--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -46,7 +46,7 @@ DataHierarchyWidgetContextMenu::DataHierarchyWidgetContextMenu(QWidget* parent, 
         addAction(getGroupAction());
         addAction(getSelectionGroupAction());
     }
-    else if (_selectedDatasets.count() == 0) {
+    else if (_selectedDatasets.count() == 0 && !_allDatasets.isEmpty()) {
         addSeparator();
         addAction(getSelectionGroupPatternAction());
     }

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -525,19 +525,11 @@ SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* pare
         _confirmButton.setEnabled(value >= 0);
         });
 
-    // Adjust GUI element
-    auto widgetConfigurationFunction = [](WidgetAction* widgetAction, QWidget* widget) -> void {
-        widget->setEnabled(false);
-        widget->setFixedHeight(75);
-        widget->setMinimumWidth(400);
-        widget->setStyleSheet("border: none;");
-        };
-
     auto settingsGroupAction = new VerticalGroupAction(this, "Settings");
 
     settingsGroupAction->addAction(&_selectionPatternAction);
     settingsGroupAction->addAction(&_selectionOptionAction);
-    settingsGroupAction->addAction(&_infoTextAction, StringAction::WidgetFlag::TextEdit, widgetConfigurationFunction);
+    settingsGroupAction->addAction(&_infoTextAction, StringAction::WidgetFlag::Label);
     settingsGroupAction->addAction(&_selectionIndexAction);
     settingsGroupAction->addAction(&_confirmButton);
 

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -467,63 +467,67 @@ QMenu* DataHierarchyWidgetContextMenu::getUnhideMenu()
 
 SelectionGroupIndexDialog::SelectionGroupIndexDialog(QWidget* parent) :
     QDialog(parent),
-    confirmButton(this, "Ok"),
-    selectionIndexAction(this, "Selection group index", -1, 250, -1)
+    _confirmButton(this, "Ok"),
+    _selectionIndexAction(this, "Set the same selection group index for all selected datasets", -1, 250, -1)
 {
     setWindowTitle(tr("Selection group index"));
     setWindowIcon(StyledIcon("ellipsis"));
     
-    QLabel* indicesLabel = new QLabel("Set the same selection group index for all selected datasets:");
+    _confirmButton.setEnabled(false);
+    _confirmButton.setToolTip("Selection group index must be larger than -1");
 
-    confirmButton.setEnabled(false);
-    confirmButton.setToolTip("Selection group index must be larger than -1");
-
-    connect(&confirmButton, &TriggerAction::triggered, this, &SelectionGroupIndexDialog::closeDialogAction);
+    connect(&_confirmButton, &TriggerAction::triggered, this, &SelectionGroupIndexDialog::closeDialogAction);
     connect(this, &SelectionGroupIndexDialog::closeDialog, this, &QDialog::accept);
 
-    connect(&selectionIndexAction, &IntegralAction::valueChanged, [this](int value) {
-        confirmButton.setEnabled(value >= 0);
+    connect(&_selectionIndexAction, &IntegralAction::valueChanged, [this](int value) {
+        _confirmButton.setEnabled(value >= 0);
         });
 
-    QHBoxLayout* layout = new QHBoxLayout();
-    layout->addWidget(indicesLabel);
-    layout->addWidget(selectionIndexAction.createWidget(this));
-    layout->addWidget(confirmButton.createWidget(this));
+    auto groupAction = new HorizontalGroupAction(this, "Settings");
+
+    groupAction->addAction(&_selectionIndexAction);
+    groupAction->addAction(&_confirmButton);
+
+    auto layout = new QHBoxLayout();
+
+    layout->addWidget(groupAction->createWidget(this));
+
     setLayout(layout);
 }
 
 SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* parent) :
     QDialog(parent),
-    confirmButton(this, "Ok"),
-    selectionPatternAction(this, "Pattern"),
-    selectionOptionAction(this, "Prefix/Suffix"),
-    selectionIndexAction(this, "Selection group starting index", -1, 1024, -1)
+    _confirmButton(this, "Ok"),
+    _selectionPatternAction(this, "Pattern"),
+    _selectionOptionAction(this, "Prefix/Suffix"),
+    _selectionIndexAction(this, "Start selection group indices at", -1, 1024, -1)
 {
     setWindowTitle(tr("Selection group pattern"));
     setWindowIcon(StyledIcon("ellipsis"));
     
-    QLabel* indicesLabel = new QLabel("Start selection group indices at:");
+    _confirmButton.setEnabled(false);
+    _confirmButton.setToolTip("Selection group index must be larger than -1");
 
-    confirmButton.setEnabled(false);
-    confirmButton.setToolTip("Selection group index must be larger than -1");
+    _selectionOptionAction.initialize({ "Suffix", "Prefix" }, "Suffix");
 
-    selectionOptionAction.initialize({ "Suffix", "Prefix" }, "Suffix");
-
-    connect(&confirmButton, &TriggerAction::triggered, this, &SelectionPatternGroupIndexDialog::closeDialogAction);
+    connect(&_confirmButton, &TriggerAction::triggered, this, &SelectionPatternGroupIndexDialog::closeDialogAction);
     connect(this, &SelectionPatternGroupIndexDialog::closeDialog, this, &QDialog::accept);
 
-    connect(&selectionIndexAction, &IntegralAction::valueChanged, [this](int value) {
-        confirmButton.setEnabled(value >= 0);
+    connect(&_selectionIndexAction, &IntegralAction::valueChanged, [this](int value) {
+        _confirmButton.setEnabled(value >= 0);
         });
 
-    int row = 0; // start a new row with ++row
-    QGridLayout* layout = new QGridLayout();
-    layout->addWidget(selectionPatternAction.createLabelWidget(this), row, 0);
-    layout->addWidget(selectionPatternAction.createWidget(this), row, 1);
-    layout->addWidget(selectionOptionAction.createLabelWidget(this), ++row, 0);
-    layout->addWidget(selectionOptionAction.createWidget(this), row, 1);
-    layout->addWidget(indicesLabel, ++row, 0);
-    layout->addWidget(selectionIndexAction.createWidget(this), row, 1);
-    layout->addWidget(confirmButton.createWidget(this), ++row, 1);
-    setLayout(layout);
+
+    auto settingsGroupAction = new VerticalGroupAction(this, "Settings");
+
+    settingsGroupAction->addAction(&_selectionPatternAction);
+    settingsGroupAction->addAction(&_selectionOptionAction);
+    settingsGroupAction->addAction(&_selectionIndexAction);
+    settingsGroupAction->addAction(&_confirmButton);
+
+    auto layout = new QVBoxLayout();
+
+    layout->addWidget(settingsGroupAction->createWidget(this));
+
+	setLayout(layout);
 }

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -499,12 +499,16 @@ SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* pare
     QDialog(parent),
     _confirmButton(this, "Ok"),
     _selectionPatternAction(this, "Pattern"),
-    _selectionOptionAction(this, "Prefix/Suffix"),
+    _selectionOptionAction(this, "Setting"),
+    _infoTextAction(this, "Info"),
     _selectionIndexAction(this, "Start selection group indices at", -1, 1024, -1)
 {
     setWindowTitle(tr("Selection group pattern"));
     setWindowIcon(StyledIcon("ellipsis"));
     
+    _infoTextAction.setString("\"Prefix\" defines the prefix to match names with.\n\"Suffix\" is used to define a prefix, taken from entries with matching suffix.");
+    _infoTextAction.setToolTip("E.g. given the data names \"A\", \"A.end\", \"B\", \"B.end\" and a suffix \".end\",\nthis will group (\"A\", \"A.end\") and (\"B\", \"B.end\")");
+
     _confirmButton.setEnabled(false);
     _confirmButton.setToolTip("Selection group index must be larger than -1");
 
@@ -522,6 +526,7 @@ SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* pare
 
     settingsGroupAction->addAction(&_selectionPatternAction);
     settingsGroupAction->addAction(&_selectionOptionAction);
+    settingsGroupAction->addAction(&_infoTextAction);
     settingsGroupAction->addAction(&_selectionIndexAction);
     settingsGroupAction->addAction(&_confirmButton);
 

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -476,12 +476,15 @@ SelectionGroupIndexDialog::SelectionGroupIndexDialog(QWidget* parent) :
     _confirmAction.setEnabled(false);
     _confirmAction.setToolTip("Selection group index must be larger than -1");
 
-    connect(&_confirmAction, &TriggerAction::triggered, this, &SelectionGroupIndexDialog::closeDialogAction);
+    connect(&_confirmAction, &TriggerAction::triggered, this, [this]() -> void {
+        emit closeDialog(_confirmAction.isChecked());
+    });
+
     connect(this, &SelectionGroupIndexDialog::closeDialog, this, &QDialog::accept);
 
     connect(&_selectionIndexAction, &IntegralAction::valueChanged, [this](int value) {
         _confirmAction.setEnabled(value >= 0);
-        });
+    });
 
     auto groupAction = new HorizontalGroupAction(this, "Settings");
 
@@ -506,7 +509,7 @@ SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* pare
     setWindowTitle(tr("Selection group pattern"));
     setWindowIcon(StyledIcon("ellipsis"));
     
-    QString infoString = QStringLiteral("\"Prefix\" defines the prefix to match names with.\n"
+    const auto infoString = QStringLiteral("\"Prefix\" defines the prefix to match names with.\n"
         "\"Suffix\" is used to define a prefix, taken from entries with matching suffix.\n"
         "E.g.given the data names \"A\", \"A.end\", \"B\", \"B.end\" and a suffix \".end\",\n"
         "this will group (\"A\", \"A.end\") and (\"B\", \"B.end\")");
@@ -518,12 +521,15 @@ SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* pare
 
     _selectionOptionAction.initialize({ "Suffix", "Prefix" }, "Suffix");
 
-    connect(&_confirmAction, &TriggerAction::triggered, this, &SelectionPatternGroupIndexDialog::closeDialogAction);
+    connect(&_confirmAction, &TriggerAction::triggered, this, [this]() -> void {
+        emit closeDialog(_confirmAction.isChecked());
+    });
+
     connect(this, &SelectionPatternGroupIndexDialog::closeDialog, this, &QDialog::accept);
 
     connect(&_selectionIndexAction, &IntegralAction::valueChanged, [this](int value) {
         _confirmAction.setEnabled(value >= 0);
-        });
+    });
 
     auto settingsGroupAction = new VerticalGroupAction(this, "Settings");
 

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -467,26 +467,26 @@ QMenu* DataHierarchyWidgetContextMenu::getUnhideMenu()
 
 SelectionGroupIndexDialog::SelectionGroupIndexDialog(QWidget* parent) :
     QDialog(parent),
-    _confirmButton(this, "Ok"),
+    _confirmAction(this, "Ok"),
     _selectionIndexAction(this, "Set the same selection group index for all selected datasets", -1, 250, -1)
 {
     setWindowTitle(tr("Selection group index"));
     setWindowIcon(StyledIcon("ellipsis"));
     
-    _confirmButton.setEnabled(false);
-    _confirmButton.setToolTip("Selection group index must be larger than -1");
+    _confirmAction.setEnabled(false);
+    _confirmAction.setToolTip("Selection group index must be larger than -1");
 
-    connect(&_confirmButton, &TriggerAction::triggered, this, &SelectionGroupIndexDialog::closeDialogAction);
+    connect(&_confirmAction, &TriggerAction::triggered, this, &SelectionGroupIndexDialog::closeDialogAction);
     connect(this, &SelectionGroupIndexDialog::closeDialog, this, &QDialog::accept);
 
     connect(&_selectionIndexAction, &IntegralAction::valueChanged, [this](int value) {
-        _confirmButton.setEnabled(value >= 0);
+        _confirmAction.setEnabled(value >= 0);
         });
 
     auto groupAction = new HorizontalGroupAction(this, "Settings");
 
     groupAction->addAction(&_selectionIndexAction);
-    groupAction->addAction(&_confirmButton);
+    groupAction->addAction(&_confirmAction);
 
     auto layout = new QHBoxLayout();
 
@@ -497,7 +497,7 @@ SelectionGroupIndexDialog::SelectionGroupIndexDialog(QWidget* parent) :
 
 SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* parent) :
     QDialog(parent),
-    _confirmButton(this, "Ok"),
+    _confirmAction(this, "Ok"),
     _selectionPatternAction(this, "Pattern"),
     _selectionOptionAction(this, "Setting"),
     _infoTextAction(this, "Info"),
@@ -513,16 +513,16 @@ SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* pare
 
     _infoTextAction.setString(infoString);
 
-    _confirmButton.setEnabled(false);
-    _confirmButton.setToolTip("Selection group index must be larger than -1");
+    _confirmAction.setEnabled(false);
+    _confirmAction.setToolTip("Selection group index must be larger than -1");
 
     _selectionOptionAction.initialize({ "Suffix", "Prefix" }, "Suffix");
 
-    connect(&_confirmButton, &TriggerAction::triggered, this, &SelectionPatternGroupIndexDialog::closeDialogAction);
+    connect(&_confirmAction, &TriggerAction::triggered, this, &SelectionPatternGroupIndexDialog::closeDialogAction);
     connect(this, &SelectionPatternGroupIndexDialog::closeDialog, this, &QDialog::accept);
 
     connect(&_selectionIndexAction, &IntegralAction::valueChanged, [this](int value) {
-        _confirmButton.setEnabled(value >= 0);
+        _confirmAction.setEnabled(value >= 0);
         });
 
     auto settingsGroupAction = new VerticalGroupAction(this, "Settings");
@@ -531,7 +531,7 @@ SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* pare
     settingsGroupAction->addAction(&_selectionOptionAction);
     settingsGroupAction->addAction(&_infoTextAction, StringAction::WidgetFlag::Label);
     settingsGroupAction->addAction(&_selectionIndexAction);
-    settingsGroupAction->addAction(&_confirmButton);
+    settingsGroupAction->addAction(&_confirmAction);
 
     auto layout = new QVBoxLayout();
 

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -499,7 +499,7 @@ SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* pare
     selectionOptionAction(this, "Prefix/Suffix"),
     selectionIndexAction(this, "Selection group starting index", -1, 1024, -1)
 {
-    setWindowTitle(tr("Selection group index"));
+    setWindowTitle(tr("Selection group pattern"));
     setWindowIcon(StyledIcon("ellipsis"));
     
     QLabel* indicesLabel = new QLabel("Start selection group indices at:");

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -506,8 +506,12 @@ SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* pare
     setWindowTitle(tr("Selection group pattern"));
     setWindowIcon(StyledIcon("ellipsis"));
     
-    _infoTextAction.setString("\"Prefix\" defines the prefix to match names with.\n\"Suffix\" is used to define a prefix, taken from entries with matching suffix.");
-    _infoTextAction.setToolTip("E.g. given the data names \"A\", \"A.end\", \"B\", \"B.end\" and a suffix \".end\",\nthis will group (\"A\", \"A.end\") and (\"B\", \"B.end\")");
+    QString infoString = QStringLiteral("\"Prefix\" defines the prefix to match names with.\n"
+        "\"Suffix\" is used to define a prefix, taken from entries with matching suffix.\n"
+        "E.g.given the data names \"A\", \"A.end\", \"B\", \"B.end\" and a suffix \".end\",\n"
+        "this will group (\"A\", \"A.end\") and (\"B\", \"B.end\")");
+
+    _infoTextAction.setString(infoString);
 
     _confirmButton.setEnabled(false);
     _confirmButton.setToolTip("Selection group index must be larger than -1");
@@ -521,12 +525,19 @@ SelectionPatternGroupIndexDialog::SelectionPatternGroupIndexDialog(QWidget* pare
         _confirmButton.setEnabled(value >= 0);
         });
 
+    // Adjust GUI element
+    auto widgetConfigurationFunction = [](WidgetAction* widgetAction, QWidget* widget) -> void {
+        widget->setEnabled(false);
+        widget->setFixedHeight(75);
+        widget->setMinimumWidth(400);
+        widget->setStyleSheet("border: none;");
+        };
 
     auto settingsGroupAction = new VerticalGroupAction(this, "Settings");
 
     settingsGroupAction->addAction(&_selectionPatternAction);
     settingsGroupAction->addAction(&_selectionOptionAction);
-    settingsGroupAction->addAction(&_infoTextAction);
+    settingsGroupAction->addAction(&_infoTextAction, StringAction::WidgetFlag::TextEdit, widgetConfigurationFunction);
     settingsGroupAction->addAction(&_selectionIndexAction);
     settingsGroupAction->addAction(&_confirmButton);
 

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
@@ -103,19 +103,28 @@ class SelectionGroupIndexDialog : public QDialog
     Q_OBJECT
 
 public:
+
+    /**
+     * Construct with \p parent widget
+     * @param parent Parent widget
+     */
     SelectionGroupIndexDialog(QWidget* parent);
 
+    /**
+     * Convenience function to get the selection group index from the corresponding action
+     * @return The selection group index
+     */
     std::int32_t getSelectionGroupIndex() const {
         return _selectionIndexAction.getValue();
     }
 
 signals:
-    void closeDialog(bool onlyIndices);
 
-public slots:
-    void closeDialogAction() {
-        emit closeDialog(_confirmAction.isChecked());
-    }
+    /**
+     * Invoked when the dialog needs to be closed
+     * @param onlyIndices Whether the selection index is valid or not
+     */
+    void closeDialog(bool onlyIndices);
 
 private:
     gui::IntegralAction      _selectionIndexAction;      /** For setting the selection group index */
@@ -132,27 +141,44 @@ class SelectionPatternGroupIndexDialog : public QDialog
     Q_OBJECT
 
 public:
+
+    /**
+     * Construct with \p parent widget
+     * @param parent Parent widget
+     */
     SelectionPatternGroupIndexDialog(QWidget* parent);
 
+    /**
+     * Convenience function to get the selection group index from the corresponding action
+     * @return The selection group index
+     */
     std::int32_t getSelectionGroupIndex() const {
         return _selectionIndexAction.getValue();
     }
 
+    /**
+     * Convenience function to get the selection group pattern from the corresponding action
+     * @return The selection group index
+     */
     QString getSelectionGroupPattern() const {
         return _selectionPatternAction.getString();
     }
 
+    /**
+     * Convenience function to get the selection group option from the corresponding action
+     * @return The selection group option
+     */
     std::int32_t getSelectionGroupOption() const {
         return _selectionOptionAction.getCurrentIndex();
     }
 
 signals:
-    void closeDialog(bool onlyIndices);
 
-public slots:
-    void closeDialogAction() {
-        emit closeDialog(_confirmAction.isChecked());
-    }
+    /**
+     * Invoked when the dialog needs to be closed
+     * @param onlyIndices Whether the selection index is valid or not
+     */
+    void closeDialog(bool onlyIndices);
 
 private:
     gui::IntegralAction     _selectionIndexAction;      /** For setting the selection group index */

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
@@ -158,5 +158,6 @@ private:
     gui::IntegralAction     _selectionIndexAction;
     gui::StringAction       _selectionPatternAction;
     gui::OptionAction       _selectionOptionAction;
+    gui::StringAction       _infoTextAction;            // TODO: how to I make this just an info text
     gui::TriggerAction      _confirmButton;
 };

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
@@ -24,7 +24,7 @@ using namespace mv::plugin;
  * 
  * Constructs a data hierarchy widget context menu based on the current dataset selection
  * 
- * @author Thomas Kroes
+ * @author Thomas Kroes, Alexander Vieth
  */
 class DataHierarchyWidgetContextMenu final : public QMenu
 {
@@ -95,15 +95,18 @@ private:
 
 /**
  * Helper dialog for selection index selection
+ *
+ * @author Alexander Vieth
  */
 class SelectionGroupIndexDialog : public QDialog
 {
     Q_OBJECT
+
 public:
     SelectionGroupIndexDialog(QWidget* parent);
 
-    std::int32_t getSelectionGroupIndex() {
-        return selectionIndexAction.getValue();
+    std::int32_t getSelectionGroupIndex() const {
+        return _selectionIndexAction.getValue();
     }
 
 signals:
@@ -111,33 +114,36 @@ signals:
 
 public slots:
     void closeDialogAction() {
-        emit closeDialog(confirmButton.isChecked());
+        emit closeDialog(_confirmButton.isChecked());
     }
 
 private:
-    gui::IntegralAction      selectionIndexAction;
-    gui::TriggerAction       confirmButton;
+    gui::IntegralAction      _selectionIndexAction;
+    gui::TriggerAction       _confirmButton;
 };
 
 /**
  * Helper dialog for selection pattern selection
+ *
+ * @author Alexander Vieth
  */
 class SelectionPatternGroupIndexDialog : public QDialog
 {
     Q_OBJECT
+
 public:
     SelectionPatternGroupIndexDialog(QWidget* parent);
 
-    std::int32_t getSelectionGroupIndex() {
-        return selectionIndexAction.getValue();
+    std::int32_t getSelectionGroupIndex() const {
+        return _selectionIndexAction.getValue();
     }
 
-    QString getSelectionGroupPattern() {
-        return selectionPatternAction.getString();
+    QString getSelectionGroupPattern() const {
+        return _selectionPatternAction.getString();
     }
 
-    std::int32_t getSelectionGroupOption() {
-        return selectionOptionAction.getCurrentIndex();
+    std::int32_t getSelectionGroupOption() const {
+        return _selectionOptionAction.getCurrentIndex();
     }
 
 signals:
@@ -145,12 +151,12 @@ signals:
 
 public slots:
     void closeDialogAction() {
-        emit closeDialog(confirmButton.isChecked());
+        emit closeDialog(_confirmButton.isChecked());
     }
 
 private:
-    gui::IntegralAction     selectionIndexAction;
-    gui::StringAction       selectionPatternAction;
-    gui::OptionAction       selectionOptionAction;
-    gui::TriggerAction      confirmButton;
+    gui::IntegralAction     _selectionIndexAction;
+    gui::StringAction       _selectionPatternAction;
+    gui::OptionAction       _selectionOptionAction;
+    gui::TriggerAction      _confirmButton;
 };

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
@@ -9,8 +9,9 @@
 
 #include <QMenu>
 
-#include <actions/TriggerAction.h>
 #include <actions/IntegralAction.h>
+#include <actions/StringAction.h>
+#include <actions/TriggerAction.h>
 
 class QAction;
 
@@ -55,6 +56,12 @@ private:
      * @return Pointer to action for selection grouping
      */
     QAction* getSelectionGroupAction();
+
+    /**
+     * Get action for selection-pattern grouping
+     * @return Pointer to action for selection-pattern grouping
+     */
+    QAction* getSelectionGroupPatternAction();
 
     /**
      * Get menu for item locking
@@ -102,7 +109,6 @@ signals:
     void closeDialog(bool onlyIndices);
 
 public slots:
-    // Pass selected data set name from SelectionGroupIndexDialog to BinExporter (dialogClosed)
     void closeDialogAction() {
         emit closeDialog(confirmButton.isChecked());
     }
@@ -110,4 +116,35 @@ public slots:
 private:
     gui::IntegralAction      selectionIndexAction;
     gui::TriggerAction       confirmButton;
+};
+
+/**
+ * Helper dialog for selection pattern selection
+ */
+class SelectionPatternGroupIndexDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    SelectionPatternGroupIndexDialog(QWidget* parent);
+
+    std::int32_t getSelectionGroupIndex() {
+        return selectionIndexAction.getValue();
+    }
+
+    QString getSelectionGroupPattern() {
+        return selectionPatternAction.getString();
+    }
+
+signals:
+    void closeDialog(bool onlyIndices);
+
+public slots:
+    void closeDialogAction() {
+        emit closeDialog(confirmButton.isChecked());
+    }
+
+private:
+    gui::IntegralAction     selectionIndexAction;
+    gui::StringAction       selectionPatternAction;
+    gui::TriggerAction      confirmButton;
 };

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
@@ -158,6 +158,6 @@ private:
     gui::IntegralAction     _selectionIndexAction;
     gui::StringAction       _selectionPatternAction;
     gui::OptionAction       _selectionOptionAction;
-    gui::StringAction       _infoTextAction;            // TODO: how to I make this just an info text
+    gui::StringAction       _infoTextAction;
     gui::TriggerAction      _confirmButton;
 };

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
@@ -10,6 +10,7 @@
 #include <QMenu>
 
 #include <actions/IntegralAction.h>
+#include <actions/OptionAction.h>
 #include <actions/StringAction.h>
 #include <actions/TriggerAction.h>
 
@@ -135,6 +136,10 @@ public:
         return selectionPatternAction.getString();
     }
 
+    std::int32_t getSelectionGroupOption() {
+        return selectionOptionAction.getCurrentIndex();
+    }
+
 signals:
     void closeDialog(bool onlyIndices);
 
@@ -146,5 +151,6 @@ public slots:
 private:
     gui::IntegralAction     selectionIndexAction;
     gui::StringAction       selectionPatternAction;
+    gui::OptionAction       selectionOptionAction;
     gui::TriggerAction      confirmButton;
 };

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
@@ -114,12 +114,12 @@ signals:
 
 public slots:
     void closeDialogAction() {
-        emit closeDialog(_confirmButton.isChecked());
+        emit closeDialog(_confirmAction.isChecked());
     }
 
 private:
-    gui::IntegralAction      _selectionIndexAction;
-    gui::TriggerAction       _confirmButton;
+    gui::IntegralAction      _selectionIndexAction;      /** For setting the selection group index */
+    gui::TriggerAction       _confirmAction;             /** Triggers the grouping */
 };
 
 /**
@@ -151,13 +151,13 @@ signals:
 
 public slots:
     void closeDialogAction() {
-        emit closeDialog(_confirmButton.isChecked());
+        emit closeDialog(_confirmAction.isChecked());
     }
 
 private:
-    gui::IntegralAction     _selectionIndexAction;
-    gui::StringAction       _selectionPatternAction;
-    gui::OptionAction       _selectionOptionAction;
-    gui::StringAction       _infoTextAction;
-    gui::TriggerAction      _confirmButton;
+    gui::IntegralAction     _selectionIndexAction;      /** For setting the selection group index */
+    gui::StringAction       _selectionPatternAction;    /** For setting the selection group pattern */
+    gui::OptionAction       _selectionOptionAction;     /** Action for choosing whether to use prefix or suffix */
+    gui::StringAction       _infoTextAction;            /** For displaying some information */
+    gui::TriggerAction      _confirmAction;             /** Triggers the grouping */
 };


### PR DESCRIPTION
Similar to https://github.com/ManiVaultStudio/core/pull/841

This PR let's you define a prefix/suffix pattern on which datasets will be assigned to selection groups.

UI:
![image](https://github.com/user-attachments/assets/6d9ed738-6b86-4478-90da-d8695326e3d6)

Available on right-click when no data is selected:
![image](https://github.com/user-attachments/assets/dbf54e6a-736b-48ca-91a8-18d559e79bd7)

Example:
![image](https://github.com/user-attachments/assets/abaec445-c4ff-4cf4-94b9-afd796e7e872)

Results in:
![image](https://github.com/user-attachments/assets/f89755a3-f17a-4c33-a89d-a554b5744640)

(A branch based on the 1.3 release which contains the same changes as this PR is [here](https://github.com/ManiVaultStudio/core/tree/feature/SelectionGroupPattern), to show that the changes build on the CI.)