### PR TITLE
Fix points data dimension change

### DIFF
--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -773,6 +773,8 @@ const std::vector<QString>& Points::getDimensionNames() const
 
 void Points::setDimensionNames(const std::vector<QString>& dimNames)
 {
+    assert(dimNames.size() == getRawData<PointData>()->getNumDimensions());
+
     getRawData<PointData>()->setDimensionNames(dimNames);
 
     mv::events().notifyDatasetDataDimensionsChanged(this);

--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -394,15 +394,26 @@ void Points::init()
 // Point Set
 // =============================================================================
 
+void Points::handleNumberDimensionsChanged(std::size_t newNumDimensions) {
+    std::vector<QString> dimensionNames = getDimensionNames();
+    std::size_t oldDimSize = dimensionNames.size();
+    dimensionNames.resize(newNumDimensions, "");
+
+    for (std::size_t addedDimension = oldDimSize; addedDimension < newNumDimensions; addedDimension++) {
+        dimensionNames[addedDimension] = QString("Dim %1").arg(addedDimension + 1);
+    }
+
+    setDimensionNames(dimensionNames);  // calls notifyDatasetDataDimensionsChanged
+}
 
 void Points::setData(std::nullptr_t, const std::size_t numPoints, const std::size_t numDimensions)
 {
-    const auto notifyDimensionsChanged = numDimensions != getRawData<PointData>()->getNumDimensions();
+    const auto numDimensionsChanged = numDimensions != getRawData<PointData>()->getNumDimensions();
 
     getRawData<PointData>()->setData(nullptr, numPoints, numDimensions);
 
-    if (notifyDimensionsChanged)
-        events().notifyDatasetDataDimensionsChanged(this);
+    if (numDimensionsChanged)
+        handleNumberDimensionsChanged(numDimensions);
 }
 
 void Points::extractDataForDimension(std::vector<float>& result, const int dimensionIndex) const

--- a/ManiVault/src/plugins/PointData/src/PointData.h
+++ b/ManiVault/src/plugins/PointData/src/PointData.h
@@ -595,6 +595,9 @@ private:
         }
     }
 
+    // When the number of dimensions is changed in setData(), update dimension names and notify core
+    void handleNumberDimensionsChanged(std::size_t newNumDimensions);
+
 public:
     Points(QString dataName, bool mayUnderive = true, const QString& guid = "");
     ~Points() override;
@@ -686,12 +689,12 @@ public:
     template <typename T>
     void setData(const T* const data, const std::size_t numPoints, const std::size_t numDimensions)
     {
-        const auto notifyDimensionsChanged = numDimensions != getRawData<PointData>()->getNumDimensions();
+        const auto numDimensionsChanged = numDimensions != getRawData<PointData>()->getNumDimensions();
 
         getRawData<PointData>()->setData(data, numPoints, numDimensions);
 
-        if (notifyDimensionsChanged)
-            mv::events().notifyDatasetDataDimensionsChanged(this);
+        if (numDimensionsChanged)
+            handleNumberDimensionsChanged(numDimensions);
     }
 
     /// Just calls the corresponding member function of its PointData.
@@ -701,24 +704,24 @@ public:
     template <typename T>
     void setData(const std::vector<T>& data, const std::size_t numDimensions)
     {
-        const auto notifyDimensionsChanged = numDimensions != getRawData<PointData>()->getNumDimensions();
+        const auto numDimensionsChanged = numDimensions != getRawData<PointData>()->getNumDimensions();
 
         getRawData<PointData>()->setData(data, numDimensions);
 
-        if (notifyDimensionsChanged)
-            mv::events().notifyDatasetDataDimensionsChanged(this);
+        if (numDimensionsChanged)
+            handleNumberDimensionsChanged(numDimensions);
     }
 
     /// Just calls the corresponding member function of its PointData.
     template <typename T>
     void setData(std::vector<T>&& data, const std::size_t numDimensions)
     {
-        const auto notifyDimensionsChanged = numDimensions != getRawData<PointData>()->getNumDimensions();
+        const auto numDimensionsChanged = numDimensions != getRawData<PointData>()->getNumDimensions();
 
         getRawData<PointData>()->setData(std::move(data), numDimensions);
 
-        if (notifyDimensionsChanged)
-            mv::events().notifyDatasetDataDimensionsChanged(this);
+        if (numDimensionsChanged)
+            handleNumberDimensionsChanged(numDimensions);
     }
 
     void extractDataForDimension(std::vector<float>& result, const int dimensionIndex) const;


### PR DESCRIPTION
Currently, changing the number of in a point data set can lead to a crash. When increasing the number of dimensions, the DimensionsPickerAction crashes, since `Points::setData` notifies a change in dimensions but does not resize the dimension names vector. 

Example to reproduce: Increase the number of embedding dimensions from the default 2 to 3 in the UMAP plugin.

This PR resizes the dimension names vector if the number of dimensions changes in `Points::setData`.