### PR TITLE
Add cmake function to handle plugin meta data

### DIFF
--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -37,6 +37,9 @@ include(mv_check_and_set_AVX)
 # Helper function to install runtime dependencies
 include(mv_install_dependencies_utils)
 
+# Helper function to handle plugin meta data
+include(mv_plugin_meta_data)
+
 # Generate a header file that contains the EXPORT macro for public libraries
 include(GenerateExportHeader)
 
@@ -487,17 +490,12 @@ install(EXPORT "ManiVaultPublicExport"
         COMPONENT MVPUBLIC_EXPORT
 )
 
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mv_install_dependencies_utils.cmake"
-        DESTINATION cmake/mv
-        COMPONENT MVPUBLIC_CMAKE_HELPER
-)
-
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mv_install_dependencies.cmake.in"
-        DESTINATION cmake/mv
-        COMPONENT MVPUBLIC_CMAKE_HELPER
-)
-
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mv_check_and_set_AVX.cmake"
+# Copy cmake helper files
+install(FILES 
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mv_install_dependencies_utils.cmake"
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mv_install_dependencies.cmake.in"
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mv_check_and_set_AVX.cmake"
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mv_plugin_meta_data.cmake"
         DESTINATION cmake/mv
         COMPONENT MVPUBLIC_CMAKE_HELPER
 )

--- a/ManiVault/cmake/MvCoreConfig.cmake.in
+++ b/ManiVault/cmake/MvCoreConfig.cmake.in
@@ -15,6 +15,7 @@ check_required_components("@PROJECT_NAME@")
 # include some helper functions
 include("${ManiVault_CMAKE_DIR}/mv_install_dependencies_utils.cmake")
 include("${ManiVault_CMAKE_DIR}/mv_check_and_set_AVX.cmake")
+include("${ManiVault_CMAKE_DIR}/mv_plugin_meta_data.cmake")
 
 message(STATUS "Found ManiVault version ${ManiVault_VERSION}. Use for example as:")
 message(STATUS "   find_package(ManiVault COMPONENTS Core PointData ClusterData ImageData ColorData TextData CONFIG)")

--- a/ManiVault/cmake/mv_plugin_meta_data.cmake
+++ b/ManiVault/cmake/mv_plugin_meta_data.cmake
@@ -1,0 +1,45 @@
+function(mv_handle_plugin_config plugin_target)
+    
+    # Read config file
+    set(PLUGIN_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/PluginInfo.json")
+
+    if(NOT EXISTS "${PLUGIN_CONFIG_FILE}")
+        message(FATAL_ERROR "JSON file not found: ${PLUGIN_CONFIG_FILE}")
+    endif()
+
+    file(READ ${PLUGIN_CONFIG_FILE} PLUGIN_INFO_JSON)
+
+    # Check if config file contains certain entries
+    set(HAS_PLUGIN_TYPE 0)
+
+    # Get the number of top-level keys
+    string(JSON TOP_LEVEL_COUNT LENGTH "${PLUGIN_INFO_JSON}")
+
+    math(EXPR LAST_INDEX "${TOP_LEVEL_COUNT} - 1")
+    foreach(I RANGE 0 ${LAST_INDEX})
+        string(JSON KEY_NAME MEMBER "${PLUGIN_INFO_JSON}" ${I})
+        if("${KEY_NAME}" STREQUAL "type")
+            set(HAS_PLUGIN_TYPE 1)
+        endif()
+    endforeach()
+
+    string(JSON PLUGIN_NAME GET "${PLUGIN_INFO_JSON}" name)
+    message(STATUS "ManiVault plugin: ${PLUGIN_NAME}")
+
+    # Extract plugin version
+    string(JSON PLUGIN_VERSION GET "${PLUGIN_INFO_JSON}" version plugin)
+    message(STATUS "  version: ${PLUGIN_VERSION}")
+    set_target_properties(${plugin_target} PROPERTIES
+        OUTPUT_NAME  "${plugin_target}_p${PLUGIN_VERSION}_c${ManiVault_VERSION}"
+    )
+
+    # Extract plugin type
+    if(HAS_PLUGIN_TYPE)
+        string(JSON PLUGIN_TYPE GET "${PLUGIN_INFO_JSON}" type)
+        message(STATUS "  type: ${PLUGIN_TYPE}")
+        set_target_properties(${plugin_target} PROPERTIES
+            FOLDER "${PLUGIN_TYPE}Plugins"
+        )
+    endif()
+
+endfunction()


### PR DESCRIPTION
Add a CMake helper function that handles plugin meta data from a `./PluginConfig.json` file.

- Appends the plugin version to the output file name
- For Visual Studio, set up the target in the plugin type folder (optional)

Example `./PluginConfig.json`, see https://github.com/ManiVaultStudio/Scatterplot/pull/176:
```json
{
    "name" : "Scatterplot View",
    "version" :  {
        "plugin" : "1.0.0",
        "core" : ["1.3"]
    },
    "type" : "Viewer",
    "dependencies" : ["Points"]
}
```

The fields `name`, `version::plugin` are required for the new `mv_handle_plugin_config` helper function. `type` is optional. `dependencies` is used in the core IIRC. `version::core` is so far unused but informative and might be used in the future.