### PR TITLE
Plugin config file handling: optionally disable folder placement

### DIFF
--- a/ManiVault/cmake/mv_plugin_meta_data.cmake
+++ b/ManiVault/cmake/mv_plugin_meta_data.cmake
@@ -37,9 +37,13 @@ function(mv_handle_plugin_config plugin_target)
     if(HAS_PLUGIN_TYPE)
         string(JSON PLUGIN_TYPE GET "${PLUGIN_INFO_JSON}" type)
         message(STATUS "  type: ${PLUGIN_TYPE}")
-        set_target_properties(${plugin_target} PROPERTIES
-            FOLDER "${PLUGIN_TYPE}Plugins"
-        )
+
+        # Do not place target in folder if disabled
+        if(${ARGC} EQUAL 1)
+            set_target_properties(${plugin_target} PROPERTIES
+                FOLDER "${PLUGIN_TYPE}Plugins"
+            )
+        endif()
     endif()
 
 endfunction()

--- a/ManiVault/cmake/mv_plugin_meta_data.cmake
+++ b/ManiVault/cmake/mv_plugin_meta_data.cmake
@@ -1,3 +1,13 @@
+# -----------------------------------------------------------------------------
+# Handle plugin meta data,
+# -----------------------------------------------------------------------------
+# Appends the version to the target's output file, and sort target in plugin
+# type folder (if the generator supports this, and it's not disabled)
+#
+# Usage:
+#  mv_handle_plugin_config(${TARGET})
+#  mv_handle_plugin_config(${TARGET} 0)    # optional argument, disables automatic folder placement
+
 function(mv_handle_plugin_config plugin_target)
     
     # Read config file


### PR DESCRIPTION
In some cases, you might want to place your plugin in a different solution folder than the plugin type. (E.g. all the [Example Plugins](https://github.com/ManiVaultStudio/ExamplePlugins) should go in an extra folder in the Visual Studio solution.)

This is now possible with:
```cmake
mv_handle_plugin_config(${PROJECT_NAME} 0) 

set_target_properties(${PROJECT_NAME}
    PROPERTIES
    FOLDER Example
)
```

The default remains that
```cmake
mv_handle_plugin_config(${PROJECT_NAME}) 
```
This adds the plugin into a folder based on the plugin type as specified in the `PluginInfo.json` config file.