### PR TITLE
Update "About ManiVault" dialog with version and webpage link

### DIFF
--- a/ManiVault/src/Application.cpp
+++ b/ManiVault/src/Application.cpp
@@ -111,11 +111,20 @@ QString Application::getName()
 
 QString Application::getAbout()
 {
-    return QString("<p>%3 is a flexible and extensible visual analytics framework for high-dimensional data.<br>"
-        "For more information, please visit: <a href=\"http://%2/\">%2</a> </p>"
+    return QString("%3 is a flexible and extensible visual analytics framework for high-dimensional data.<br> <br>"
+        "For more information, please visit: <br>"
+        "Webpage: <a href=\"https://%5/\">%5</a> <br>"
+        "Source: <a href=\"https://%2/\">%2</a> <br> <br>"
+        "%3 Core %4 <br> <br>"
         "This software is licensed under the GNU Lesser General Public License v3.0.<br>"
         "Copyright (C) %1 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft)"
-    ).arg(QStringLiteral("2023"), QStringLiteral("github.com/ManiVaultStudio"), getName());
+    ).arg(
+        /*1: year*/ QStringLiteral("2023"),
+        /*2: source*/ QStringLiteral("github.com/ManiVaultStudio"),
+        /*3: name*/ getName(),
+        /*4: version*/ QString::fromStdString(Application::current()->getVersion().getVersionString()),
+        /*5: webpage*/ QStringLiteral("manivault.studio")
+    );
 }
 
 QString Application::getStartupProjectFilePath() const


### PR DESCRIPTION
Small update to the "About ManiVault" dialog:
- Add core version
- Add link to manivault.studio
- Some formatting

New:
![image](https://github.com/user-attachments/assets/11909102-1dd9-40aa-8c49-73692c397111)

Old:
![image](https://github.com/user-attachments/assets/2b6c44f7-f8a6-4862-acf7-51b29b557896)

---

I came across this when trying to figure out the version of the application without opening a project or looking at the terminal, and it was not available in a spot where I would have expected it.