### PR TITLE
Several fixes to ensure more robust app closing down

### DIFF
--- a/ManiVault/src/CoreInterface.h
+++ b/ManiVault/src/CoreInterface.h
@@ -134,6 +134,9 @@ signals:
     /** Invoked when the core is about to be initialized */
     void aboutToBeInitialized();
 
+    /** Invoked when the core is about to be destroyed */
+    void aboutToBeDestroyed();
+
     /** Invoked when the core has been initialized */
     void initialized();
 

--- a/ManiVault/src/DataHierarchyItem.cpp
+++ b/ManiVault/src/DataHierarchyItem.cpp
@@ -40,7 +40,7 @@ DataHierarchyItem::DataHierarchyItem(Dataset<DatasetImpl> dataset, Dataset<Datas
 
     if (parentDataset.isValid())
         setParent(&parentDataset->getDataHierarchyItem());
-
+    
     setIcon(getDataset()->icon());
     setVisible(visible);
 }
@@ -138,9 +138,7 @@ QMenu* DataHierarchyItem::getContextMenu(QWidget* parent /*= nullptr*/)
         if (action->isConfigurationFlagSet(WidgetAction::ConfigurationFlag::HiddenInActionContextMenu))
             continue;
 
-        auto contextMenu = action->getContextMenu();
-
-        if (contextMenu)
+        if (auto contextMenu = action->getContextMenu())
             menu->addMenu(contextMenu);
     }
 
@@ -153,9 +151,7 @@ void DataHierarchyItem::populateContextMenu(QMenu* contextMenu)
         if (action->isConfigurationFlagSet(WidgetAction::ConfigurationFlag::HiddenInActionContextMenu))
             continue;
 
-        auto actionContextMenu = action->getContextMenu();
-
-        if (actionContextMenu)
+        if (auto actionContextMenu = action->getContextMenu())
             contextMenu->addMenu(actionContextMenu);
     }
 }

--- a/ManiVault/src/event/EventListener.cpp
+++ b/ManiVault/src/event/EventListener.cpp
@@ -22,7 +22,8 @@ EventListener::EventListener()
 
 EventListener::~EventListener()
 {
-    core()->getEventManager().unregisterEventListener(this);
+    if (!core()->isAboutToBeDestroyed())
+		core()->getEventManager().unregisterEventListener(this);
 }
 
 bool EventListener::isEventTypeSupported(std::uint32_t eventType) const

--- a/ManiVault/src/private/Core.cpp
+++ b/ManiVault/src/private/Core.cpp
@@ -34,7 +34,9 @@ Core::Core() :
     _aboutToBeDestroyed(false)
 {
     connect(Application::current(), &QCoreApplication::aboutToQuit, this, [this]() -> void {
-        _aboutToBeDestroyed = true;
+        emit aboutToBeDestroyed();
+
+    	_aboutToBeDestroyed = true;
 
         for (auto& manager : _managers)
             manager->setCoreIsDestroyed();

--- a/ManiVault/src/private/DataHierarchyManager.cpp
+++ b/ManiVault/src/private/DataHierarchyManager.cpp
@@ -22,6 +22,10 @@ namespace mv
 DataHierarchyManager::DataHierarchyManager(QObject* parent) :
     AbstractDataHierarchyManager(parent)
 {
+    connect(core(), &CoreInterface::aboutToBeDestroyed, this, [this]() -> void {
+        for (auto& item : _items)
+            item->setParent(nullptr); // Clear parent to avoid dangling pointers
+    });
 }
 
 DataHierarchyManager::~DataHierarchyManager()

--- a/ManiVault/src/private/DataManager.cpp
+++ b/ManiVault/src/private/DataManager.cpp
@@ -308,83 +308,82 @@ void DataManager::addDataset(Dataset<DatasetImpl> dataset, Dataset<DatasetImpl> 
 
 void DataManager::removeDataset(Dataset<DatasetImpl> dataset)
 {
-    try
-    {
-
+    try {
 #ifdef DATA_MANAGER_VERBOSE
-        qDebug() << "Remove dataset" << dataset->getGuiName() << "from the data manager";
+    	qDebug() << "Remove dataset" << dataset->getGuiName() << "from the data manager";
 #endif
 
-        if (!dataset.isValid())
-            throw std::runtime_error("Dataset smart pointer is invalid");
+    	if (!dataset.isValid())
+    		throw std::runtime_error("Dataset smart pointer is invalid");
 
-        if (dataset->isLocked()) {
+    	if (dataset->isLocked()) {
 
 #ifdef DATA_MANAGER_VERBOSE
-            qDebug() << "Dataset is locked and will be removed as soon as it is un-locked";
+    		qDebug() << "Dataset is locked and will be removed as soon as it is un-locked";
 #endif
 
-            connect(&dataset->getDataHierarchyItem(), &DataHierarchyItem::lockedChanged, this, [this, dataset](bool locked) -> void {
-                disconnect(&dataset->getDataHierarchyItem(), &DataHierarchyItem::lockedChanged, this, nullptr);
+    		connect(&dataset->getDataHierarchyItem(), &DataHierarchyItem::lockedChanged, this, [this, dataset](bool locked) -> void {
+				disconnect(&dataset->getDataHierarchyItem(), &DataHierarchyItem::lockedChanged, this, nullptr);
 
-                if (!locked)
-                    removeDataset(dataset);
-            });
+				if (!locked)
+					removeDataset(dataset);
+				});
+    	}
+
+    	const auto datasetId = dataset->getId();
+    	const auto rawDataName = dataset->getRawDataName();
+
+    	dataset->setAboutToBeRemoved();
+
+    	for (const auto& underiveDataset : _datasets) {
+    		if (underiveDataset->isDerivedData() && underiveDataset->getNextSourceDataset<DatasetImpl>()->getId() == dataset->getId()) {
+    			if (underiveDataset->mayUnderive()) {
+    				underiveDataset->_derived = false;
+    				underiveDataset->setSourceDataset(Dataset<DatasetImpl>());
+    			}
+    			else {
+    				removeDataset(underiveDataset.get());
+    			}
+    		}
+    	}
+
+        if (!mv::core()->isAboutToBeDestroyed()) {
+	        for (const auto dataHierarchyItem : dataset->getDataHierarchyItem().getChildren()) {
+	        	if (!dataHierarchyItem->getDataset()->mayUnderive())
+	        		removeDataset(dataHierarchyItem->getDataset());
+	        	else
+	        		dataHierarchyItem->setParent(nullptr);
+	        }
         }
 
-        const auto datasetId    = dataset->getId();
-        const auto datasetType  = dataset->getDataType();
-        const auto rawDataName  = dataset->getRawDataName();
+    	dataset->setLocked(true);
 
-        dataset->setAboutToBeRemoved();
+    	if (!mv::core()->isAboutToBeDestroyed()) {
+    		events().notifyDatasetAboutToBeRemoved(dataset);
+    		emit datasetAboutToBeRemoved(dataset);
+		}
 
-        for (const auto& underiveDataset : _datasets) {
-            if (underiveDataset->isDerivedData() && underiveDataset->getNextSourceDataset<DatasetImpl>()->getId() == dataset->getId()) {
-                if (underiveDataset->mayUnderive()) {
-                    underiveDataset->_derived = false;
-                    underiveDataset->setSourceDataset(Dataset<DatasetImpl>());
-                }
-                else {
-                    removeDataset(underiveDataset.get());
-                }
-            }
-        }
+        const auto it = std::find_if(_datasets.begin(), _datasets.end(), [datasetId](const auto& datasetPtr) -> bool {
+            return datasetId == datasetPtr->getId();
+        });
+    
+        if (it == _datasets.end())
+            throw std::runtime_error(QString("Dataset with id %1 not found in database").arg(dataset->getId()).toStdString());
+    
+        if (auto analysisPlugin = dataset->getAnalysis())
+            analysisPlugin->destroy();
+    
+        const auto shouldRemoveRawData = !mv::core()->isAboutToBeDestroyed() && dataset->isFull();
+    
+        _datasets.erase(it);
+    
+        if (shouldRemoveRawData)
+            removeRawData(rawDataName);
 
-        for (const auto dataHierarchyItem : dataset->getDataHierarchyItem().getChildren()) {
-            if (!dataHierarchyItem->getDataset()->mayUnderive())
-                removeDataset(dataHierarchyItem->getDataset());
-            else
-                dataHierarchyItem->setParent(nullptr);
-        }
-
-        dataset->setLocked(true);
-
-        events().notifyDatasetAboutToBeRemoved(dataset);
-        {
-            emit datasetAboutToBeRemoved(dataset);
-            {
-                const auto it = std::find_if(_datasets.begin(), _datasets.end(), [datasetId](const auto& datasetPtr) -> bool {
-                    return datasetId == datasetPtr->getId();
-                });
-
-                if (it == _datasets.end())
-                    throw std::runtime_error(QString("Dataset with id %1 not found in database").arg(dataset->getId()).toStdString());
-
-                auto analysisPlugin = dataset->getAnalysis();
-
-                if (analysisPlugin)
-                    analysisPlugin->destroy();
-
-                const auto shouldRemoveRawData = dataset->isFull();
-
-                _datasets.erase(it);
-
-                if (shouldRemoveRawData)
-                    removeRawData(rawDataName);
-            }
-            emit datasetRemoved(datasetId);
-        }
-        events().notifyDatasetRemoved(datasetId, datasetType);
+	    if (!mv::core()->isAboutToBeDestroyed()) {
+		    events().notifyDatasetRemoved(datasetId, dataset->getDataType());
+    		emit datasetRemoved(datasetId);
+	    }
     }
     catch (std::exception& e)
     {

--- a/ManiVault/src/private/EventManager.cpp
+++ b/ManiVault/src/private/EventManager.cpp
@@ -125,7 +125,10 @@ void EventManager::unregisterEventListener(EventListener* eventListener)
 void EventManager::notifyDatasetAdded(const Dataset<DatasetImpl>& dataset)
 {
     try {
-        DatasetAddedEvent dataEvent(dataset);
+        if (core()->isAboutToBeDestroyed())
+            return;
+
+    	DatasetAddedEvent dataEvent(dataset);
 
         const auto eventListeners = _eventListeners;
 
@@ -145,6 +148,9 @@ void EventManager::notifyDatasetAdded(const Dataset<DatasetImpl>& dataset)
 void EventManager::notifyDatasetAboutToBeRemoved(const Dataset<DatasetImpl>& dataset)
 {
     try {
+        if (core()->isAboutToBeDestroyed())
+            return;
+
         DatasetAboutToBeRemovedEvent dataAboutToBeRemovedEvent(dataset);
 
         const auto eventListeners = _eventListeners;
@@ -165,6 +171,9 @@ void EventManager::notifyDatasetAboutToBeRemoved(const Dataset<DatasetImpl>& dat
 void EventManager::notifyDatasetRemoved(const QString& datasetId, const DataType& dataType)
 {
     try {
+        if (core()->isAboutToBeDestroyed())
+            return;
+
         DatasetRemovedEvent dataRemovedEvent(nullptr, datasetId, dataType);
 
         const auto eventListeners = _eventListeners;
@@ -185,6 +194,9 @@ void EventManager::notifyDatasetRemoved(const QString& datasetId, const DataType
 void EventManager::notifyDatasetDataChanged(const Dataset<DatasetImpl>& dataset)
 {
     try {
+        if (core()->isAboutToBeDestroyed())
+            return;
+
         DatasetDataChangedEvent dataEvent(dataset);
 
         const auto eventListeners = _eventListeners;
@@ -205,6 +217,9 @@ void EventManager::notifyDatasetDataChanged(const Dataset<DatasetImpl>& dataset)
 void EventManager::notifyDatasetDataDimensionsChanged(const Dataset<DatasetImpl>& dataset)
 {
     try {
+        if (core()->isAboutToBeDestroyed())
+            return;
+
         DatasetDataDimensionsChangedEvent dataEvent(dataset);
 
         const auto eventListeners = _eventListeners;
@@ -225,6 +240,9 @@ void EventManager::notifyDatasetDataDimensionsChanged(const Dataset<DatasetImpl>
 void EventManager::notifyDatasetDataSelectionChanged(const Dataset<DatasetImpl>& dataset, Datasets* ignoreDatasets /*= nullptr*/)
 {
     try {
+        if (core()->isAboutToBeDestroyed())
+            return;
+
 #ifdef EVENT_MANAGER_VERBOSE
         QStringList datasetNotifiedString;
 
@@ -271,6 +289,8 @@ void EventManager::notifyDatasetDataSelectionChanged(const Dataset<DatasetImpl>&
 void EventManager::notifyDatasetLocked(const Dataset<DatasetImpl>& dataset)
 {
     try {
+        if (core()->isAboutToBeDestroyed())
+            return;
 
         if (!dataset.isValid())
             throw std::runtime_error("Dataset is invalid");
@@ -295,6 +315,8 @@ void EventManager::notifyDatasetLocked(const Dataset<DatasetImpl>& dataset)
 void EventManager::notifyDatasetUnlocked(const Dataset<DatasetImpl>& dataset)
 {
     try {
+        if (core()->isAboutToBeDestroyed())
+            return;
 
         if (!dataset.isValid())
             throw std::runtime_error("Dataset is invalid");


### PR DESCRIPTION
- [x] Core interface emits an about-to-be-destroyed signal upon app close
- [x] Data manager now avoids particular subroutines when the core is about to be destroyed
- [x] Same for the event manager (does not emit events when the core is about to be destroyed)
- [x] Small style improvements in the data hierarchy item class
- [x] Unparent all data hierarchy items when the core is about to be destroyed to avoid memory double-deletion