### PR TITLE
A parent for PluginFactory's base class

### DIFF
--- a/ManiVault/src/PluginFactory.cpp
+++ b/ManiVault/src/PluginFactory.cpp
@@ -17,7 +17,7 @@ namespace mv::plugin
 {
 
 PluginFactory::PluginFactory(Type type, const QString& title) :
-    WidgetAction(nullptr, title),
+    WidgetAction(mv::Application::current(), title),
     _type(type),
     _pluginTriggerAction(this, this, "Plugin trigger", "A plugin trigger action creates a new plugin when triggered", QIcon()),
     _numberOfInstances(0),


### PR DESCRIPTION
The `PluginFactory` must not outlive the application.