### PR TITLE
Support redirects in mv::util::FileDownloader

### DIFF
--- a/ManiVault/src/util/FileDownloader.cpp
+++ b/ManiVault/src/util/FileDownloader.cpp
@@ -41,6 +41,8 @@ void FileDownloader::download(const QUrl& url)
 
     QNetworkRequest request(_url);
 
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+
     auto* networkReply = _networkAccessManager.get(request);
 
     const auto fileName = QFileInfo(_url.toString()).fileName();
@@ -90,14 +92,28 @@ void FileDownloader::downloadFinished(QNetworkReply* reply)
     qDebug() << __FUNCTION__ << reply->error();
 #endif
 
+    QString filename = QFileInfo(_url.toString()).fileName();
+
+    QVariant dispositionHeader = reply->rawHeader("Content-Disposition");
+
+    if (dispositionHeader.isValid()) {
+        QRegularExpression re("filename\\*=UTF-8''([^;]+)|filename=\"?([^\";]+)\"?");
+        QRegularExpressionMatch match = re.match(dispositionHeader.toString());
+
+    	if (match.hasMatch()) {
+            filename = QUrl::fromPercentEncoding(match.captured(1).toUtf8());
+
+            if (filename.isEmpty())
+                filename = match.captured(2); // fallback
+        }
+    }
+
     if (_storageMode & StorageMode::File)
     {
-        const auto fileName = QFileInfo(_url.toString()).fileName();
-
         if (_targetDirectory.isEmpty())
-    		_downloadedFilePath = QDir(Application::current()->getTemporaryDir().path()).filePath(fileName);
+    		_downloadedFilePath = QDir(Application::current()->getTemporaryDir().path()).filePath(filename);
         else
-            _downloadedFilePath = QDir(_targetDirectory).filePath(fileName);
+            _downloadedFilePath = QDir(_targetDirectory).filePath(filename);
 
 #ifdef FILE_DOWNLOADER_VERBOSE
         qDebug() << fileName << _downloadedFilePath;

--- a/ManiVault/src/util/ProjectDatabaseProject.cpp
+++ b/ManiVault/src/util/ProjectDatabaseProject.cpp
@@ -48,6 +48,9 @@ ProjectDatabaseProject::ProjectDatabaseProject(const QVariantMap& variantMap) :
             }
         }
     }
+
+    if (!_missingPlugins.isEmpty())
+        qWarning() << "Project" << _title << "is added to the project database but cannot be opened because of missing plugins:" << _missingPlugins.join(", ");
 }
 
 const QString& ProjectDatabaseProject::getTitle() const


### PR DESCRIPTION
Contains the following improvements to the `mv::util::FileDownloader` class:
- [x] Read HTTP response header and extract the file name if the file name is not encoded in the URL. 
- [x] Ability to follow redirects properly  