### PR TITLE
Turn compile acceleration options OFF for build releases

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -65,7 +65,7 @@ class HdpsCoreConan(ConanFile):
     def get_current_branch_name(self):
         from git import Repo
         repo = Repo(path=self.__get_git_path())       
-        return = repo.active_branch.name
+        return repo.active_branch.name
     
     def export(self):
         print("In export")


### PR DESCRIPTION
For `release` branches (all branches starting with `release/`), turn OFF `MV_PRECOMPILE_HEADERS` and `MV_UNITY_BUILD`.
This will occasionally - before tagging releases - help remind us about possible build failures due to missing includes.

We may keep these build options on the master and feature branches since it speeds up compile time and ensures that unity builds compile successfully as well.