### PR TITLE
Mark Markdown classes as export

### DIFF
--- a/ManiVault/src/widgets/MarkdownDialog.h
+++ b/ManiVault/src/widgets/MarkdownDialog.h
@@ -22,7 +22,7 @@ namespace mv::util {
  *
  * @author Thomas Kroes
  */
-class MarkdownWebEnginePage : public QWebEnginePage
+class CORE_EXPORT MarkdownWebEnginePage : public QWebEnginePage
 {
 public:
 
@@ -48,7 +48,7 @@ public:
  * 
  * @author Thomas Kroes
  */
-class MarkdownDialog : public QDialog
+class CORE_EXPORT MarkdownDialog : public QDialog
 {
 public:
 

--- a/ManiVault/src/widgets/MarkdownDocument.h
+++ b/ManiVault/src/widgets/MarkdownDocument.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "ManiVaultGlobals.h"
+
 #include <QObject>
 
 namespace mv::util {
@@ -15,7 +17,7 @@ namespace mv::util {
  * 
  * @author Thomas Kroes
  */
-class MarkdownDocument : public QObject
+class CORE_EXPORT MarkdownDocument : public QObject
 {
     Q_OBJECT
 


### PR DESCRIPTION
These header files are installed and the classes part of the public link library. But as of now plugins cannot use these clases since they are not marked for export.