### PR TITLE
Show plugin help if available

### DIFF
--- a/ManiVault/src/private/HelpMenu.cpp
+++ b/ManiVault/src/private/HelpMenu.cpp
@@ -63,7 +63,7 @@ void HelpMenu::populate()
     sortActions(actions);
 
     if (!actions.isEmpty()) {
-        auto pluginHelpMenu = new QMenu("Plugin");
+        auto pluginHelpMenu = new QMenu("Plugins");
 
         pluginHelpMenu->setToolTip("ManiVault plugin documentation");
         pluginHelpMenu->setIcon(StyledIcon("plug"));

--- a/ManiVault/src/private/HelpMenu.cpp
+++ b/ManiVault/src/private/HelpMenu.cpp
@@ -57,7 +57,7 @@ void HelpMenu::populate()
     QVector<QPointer<TriggerAction>> actions;
 
     for (auto& pluginFactory : plugins().getPluginFactoriesByTypes({ Type::ANALYSIS, Type::DATA, Type::LOADER, Type::WRITER, Type::TRANSFORMATION, Type::VIEW }))
-        if (pluginFactory->hasHelp() && pluginFactory->getNumberOfInstances() >= 1)
+        if (pluginFactory->hasHelp())
             actions << &pluginFactory->getPluginMetadata().getTriggerHelpAction();
 
     sortActions(actions);


### PR DESCRIPTION
Help entries for plugins would only if a plugin is open. The entries should always be available when a plugin factory made them available.

Drive-by:
- Change entry `Plugin` to `Plugins`