### PR TITLE
Do not download unused submodules for CPM package

### DIFF
--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -168,6 +168,8 @@ CPMAddPackage(
   NAME              valijson
   GITHUB_REPOSITORY tristanpenman/valijson
   GIT_TAG           v1.0.6 
+  #GIT_SUBMODULES   ""                  # Does not yet work with CPM, see workaround from https://github.com/cpm-cmake/CPM.cmake/pull/461#issuecomment-1665044141
+  GIT_SUBMODULES    "doc"               # list an existing subdir from the repo to not download any submodules
   DOWNLOAD_ONLY     YES
   OPTIONS "VALIJSON_BUILD_TESTS OFF" "VALIJSON_USE_EXCEPTIONS ON"
 )


### PR DESCRIPTION
CMake let's you define a list of submodules that should be downloaded when fetching remote repos, see [ExternalProject docs](https://cmake.org/cmake/help/latest/module/ExternalProject.html#git) (same mechanism is used for the FetchContent commands, see [here](https://cmake.org/cmake/help/latest/policy/CMP0097.html). 

For valijson we do not want any submodules to be downloaded, but [CPM does not currently parse the option](https://github.com/cpm-cmake/CPM.cmake/issues/467) `GIT_SUBMODULES   ""` correctly. There seems to be issues with handling empty strings.

However, there is a [workaround](https://github.com/cpm-cmake/CPM.cmake/pull/461#issuecomment-1665044141): specify an existing subdir from the repo to not download any submodules.

This small change will speed up the CMake config a bit and reduce the size of the build folder, as we skip downloading **seven** remote projects.