### PR TITLE
Remove remaining base file suffix

### DIFF
--- a/ManiVault/src/private/PluginManager.cpp
+++ b/ManiVault/src/private/PluginManager.cpp
@@ -130,8 +130,14 @@ void PluginManager::loadPluginFactories()
 
     auto getLibraryName = [](const QString& libFileName) -> QString {
         // Use QFileInfo to get the base name without the suffix (.dll, .so, .dylib)
-        QFileInfo fileInfo(libFileName);
-        QString baseName = fileInfo.baseName();
+        const QFileInfo fileInfo(libFileName);
+
+        QString baseName = fileInfo.baseName();         // all characters in the file up to (but not including) the first '.' character
+
+        const int index = baseName.lastIndexOf("_p");   // plugins are suffixed with _p1.x_c_1.x (plugin and core version)
+        if (index != -1) {
+            baseName = baseName.left(index);
+        }
 
         // Check for common "lib" prefix on UNIX systems and remove it
         if (baseName.startsWith("lib")) {


### PR DESCRIPTION
We need to remove an extra suffix when extracting the file name from a library path when using [Plugin Config Files](https://github.com/ManiVaultStudio/DeveloperWiki/wiki/Plugin-Structure#plugin-config-file) and dependencies in the `PluginDependencies` folder.

I encountered this while adding a `PluginInfo.json` to the ImageLoader plugin. 
The new plugin library file is called `ImageLoaderPlugin_p0.1.0_c1.4.0.dll` and ManiVault would look for its `FreeImage` dependency in `PluginDependencies/ImageLoaderPlugin_p0` as the `[baseName](https://doc.qt.io/qt-6/qfileinfo.html#baseName)` simply cuts of everything after the first `.`