### PR TITLE
Add API and UI to restrict allowed plugins for published projects

### DIFF
--- a/ManiVault/src/AbstractPluginManager.h
+++ b/ManiVault/src/AbstractPluginManager.h
@@ -182,6 +182,13 @@ public: // Plugin getters
      */
     virtual QStringList getLoadedPluginKinds(const plugin::Types& pluginTypes = plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }) const = 0;
 
+    /**
+     * Get used plugin kinds by \p pluginType
+     * @param pluginTypes Plugin type(s), all plugin types if empty
+     * @return List of used plugin kinds
+     */
+    virtual QStringList getUsedPluginKinds(const plugin::Types& pluginTypes = plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }) const = 0;
+
 public: // Plugin trigger actions
 
     /**

--- a/ManiVault/src/AbstractPluginManager.h
+++ b/ManiVault/src/AbstractPluginManager.h
@@ -169,11 +169,18 @@ public: // Plugin getters
     virtual std::vector<plugin::Plugin*> getPluginsByTypes(const plugin::Types& pluginTypes = plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }) const = 0;
 
     /**
-     * Get plugin kinds by plugin type(s)
-     * @param pluginTypes Plugin type(s)
-     * @return Plugin kinds
+     * Get plugin kinds by \p pluginType
+     * @param pluginTypes Plugin type(s), all plugin types if empty
+     * @return List of plugin kinds
      */
-    virtual QStringList getPluginKindsByPluginTypes(const plugin::Types& pluginTypes) const = 0;
+    virtual QStringList getPluginKindsByPluginTypes(const plugin::Types& pluginTypes = plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }) const = 0;
+
+    /**
+     * Get loaded plugin kinds by \p pluginType
+     * @param pluginTypes Plugin type(s), all plugin types if empty
+     * @return List of loaded plugin kinds
+     */
+    virtual QStringList getLoadedPluginKinds(const plugin::Types& pluginTypes = plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }) const = 0;
 
 public: // Plugin trigger actions
 

--- a/ManiVault/src/Project.cpp
+++ b/ManiVault/src/Project.cpp
@@ -120,6 +120,7 @@ void Project::fromVariantMap(const QVariantMap& variantMap)
     _projectMetaAction.getCommentsAction().fromParentVariantMap(variantMap);
     _projectMetaAction.getContributorsAction().fromParentVariantMap(variantMap);
     _projectMetaAction.getCompressionAction().fromParentVariantMap(variantMap);
+    _projectMetaAction.getAllowProjectSwitchingAction().fromParentVariantMap(variantMap, true);
     _projectMetaAction.getAllowedPluginsOnlyAction().fromParentVariantMap(variantMap, true);
     _projectMetaAction.getAllowedPluginsAction().fromParentVariantMap(variantMap, true);
     _projectMetaAction.getSplashScreenAction().fromParentVariantMap(variantMap);
@@ -163,6 +164,7 @@ QVariantMap Project::toVariantMap() const
     _projectMetaAction.getCommentsAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getContributorsAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getCompressionAction().insertIntoVariantMap(variantMap);
+    _projectMetaAction.getAllowProjectSwitchingAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getAllowedPluginsOnlyAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getAllowedPluginsAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getSplashScreenAction().insertIntoVariantMap(variantMap);

--- a/ManiVault/src/Project.cpp
+++ b/ManiVault/src/Project.cpp
@@ -139,6 +139,13 @@ void Project::fromVariantMap(const QVariantMap& variantMap)
     actions().fromParentVariantMap(variantMap);
     plugins().fromParentVariantMap(variantMap);
     events().fromParentVariantMap(variantMap);
+
+    if (getReadOnlyAction().isChecked() && getAllowedPluginsOnlyAction().isChecked()) {
+        for (auto pluginFactory : mv::plugins().getPluginFactoriesByTypes())
+            pluginFactory->setAllowPluginCreationFromStandardGui(_projectMetaAction.getAllowedPluginsAction().getStrings().contains(pluginFactory->getKind()));
+
+        qDebug() << _projectMetaAction.getAllowedPluginsAction().getStrings();
+    }
 }
 
 QVariantMap Project::toVariantMap() const

--- a/ManiVault/src/Project.cpp
+++ b/ManiVault/src/Project.cpp
@@ -120,6 +120,8 @@ void Project::fromVariantMap(const QVariantMap& variantMap)
     _projectMetaAction.getCommentsAction().fromParentVariantMap(variantMap);
     _projectMetaAction.getContributorsAction().fromParentVariantMap(variantMap);
     _projectMetaAction.getCompressionAction().fromParentVariantMap(variantMap);
+    _projectMetaAction.getAllowedPluginsOnlyAction().fromParentVariantMap(variantMap, true);
+    _projectMetaAction.getAllowedPluginsAction().fromParentVariantMap(variantMap, true);
     _projectMetaAction.getSplashScreenAction().fromParentVariantMap(variantMap);
     _projectMetaAction.getStudioModeAction().fromParentVariantMap(variantMap);
     _projectMetaAction.getApplicationIconAction().fromParentVariantMap(variantMap);
@@ -154,6 +156,8 @@ QVariantMap Project::toVariantMap() const
     _projectMetaAction.getCommentsAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getContributorsAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getCompressionAction().insertIntoVariantMap(variantMap);
+    _projectMetaAction.getAllowedPluginsOnlyAction().insertIntoVariantMap(variantMap);
+    _projectMetaAction.getAllowedPluginsAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getSplashScreenAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getStudioModeAction().insertIntoVariantMap(variantMap);
     _projectMetaAction.getApplicationIconAction().insertIntoVariantMap(variantMap);

--- a/ManiVault/src/Project.h
+++ b/ManiVault/src/Project.h
@@ -125,6 +125,7 @@ public: // Project meta action getters facade
     const gui::StringAction& getCommentsAction() const { return _projectMetaAction.getCommentsAction(); }
     const gui::StringsAction& getContributorsAction() const { return _projectMetaAction.getContributorsAction(); }
     const ProjectCompressionAction& getCompressionAction() const { return _projectMetaAction.getCompressionAction(); }
+    const gui::ToggleAction& getAllowProjectSwitchingAction() const { return _projectMetaAction.getAllowProjectSwitchingAction(); }
     const gui::ToggleAction& getAllowedPluginsOnlyAction() const { return _projectMetaAction.getAllowedPluginsOnlyAction(); }
     const gui::StringsAction& getAllowedPluginsAction() const { return _projectMetaAction.getAllowedPluginsAction(); }
     const gui::SplashScreenAction& getSplashScreenAction() const { return _projectMetaAction.getSplashScreenAction(); }
@@ -144,6 +145,7 @@ public: // Project meta action getters facade
     gui::StringAction& getCommentsAction() { return _projectMetaAction.getCommentsAction(); }
     gui::StringsAction& getContributorsAction() { return _projectMetaAction.getContributorsAction(); }
     ProjectCompressionAction& getCompressionAction() { return _projectMetaAction.getCompressionAction(); }
+    gui::ToggleAction& getAllowProjectSwitchingAction() { return _projectMetaAction.getAllowProjectSwitchingAction(); }
     gui::ToggleAction& getAllowedPluginsOnlyAction() { return _projectMetaAction.getAllowedPluginsOnlyAction(); }
     gui::StringsAction& getAllowedPluginsAction() { return _projectMetaAction.getAllowedPluginsAction(); }
     gui::SplashScreenAction& getSplashScreenAction() { return _projectMetaAction.getSplashScreenAction(); }
@@ -163,14 +165,14 @@ signals:
     void filePathChanged(const QString& filePath);
 
 private:
-    QString                     _filePath;                              /** Location on disk where the project resides */
-    bool                        _startupProject;                        /** Boolean determining whether this project is loaded at startup of ManiVault */
-    util::Version               _applicationVersion;                    /** Version of the application with which the project is created */
-    ProjectMetaAction           _projectMetaAction;                     /** Project meta info action (i.e. title and version) */
-    gui::ToggleAction           _selectionGroupingAction;               /** Action for toggling whether dataset selection grouping is enabled or not */
-    gui::ToggleAction           _overrideApplicationStatusBarAction;    /** Action for toggling whether the project inherits the status bar settings from the application or not */
-    gui::ToggleAction           _statusBarVisibleAction;                /** Action for toggling the status bar visibility */
-    gui::OptionsAction          _statusBarOptionsAction;                /** Options action for toggling status bar items on/off */
+    QString                 _filePath;                              /** Location on disk where the project resides */
+    bool                    _startupProject;                        /** Boolean determining whether this project is loaded at startup of ManiVault */
+    util::Version           _applicationVersion;                    /** Version of the application with which the project is created */
+    ProjectMetaAction       _projectMetaAction;                     /** Project meta info action (i.e. title and version) */
+    gui::ToggleAction       _selectionGroupingAction;               /** Action for toggling whether dataset selection grouping is enabled or not */
+    gui::ToggleAction       _overrideApplicationStatusBarAction;    /** Action for toggling whether the project inherits the status bar settings from the application or not */
+    gui::ToggleAction       _statusBarVisibleAction;                /** Action for toggling the status bar visibility */
+    gui::OptionsAction      _statusBarOptionsAction;                /** Options action for toggling status bar items on/off */
 
 protected:
     static constexpr bool           DEFAULT_ENABLE_COMPRESSION  = false;    /** No compression by default */

--- a/ManiVault/src/Project.h
+++ b/ManiVault/src/Project.h
@@ -125,7 +125,8 @@ public: // Project meta action getters facade
     const gui::StringAction& getCommentsAction() const { return _projectMetaAction.getCommentsAction(); }
     const gui::StringsAction& getContributorsAction() const { return _projectMetaAction.getContributorsAction(); }
     const ProjectCompressionAction& getCompressionAction() const { return _projectMetaAction.getCompressionAction(); }
-    const gui::StringsAction& getAllowedPlugins() const { return _projectMetaAction.getAllowedPlugins(); }
+    const gui::ToggleAction& getAllowedPluginsOnlyAction() const { return _projectMetaAction.getAllowedPluginsOnlyAction(); }
+    const gui::StringsAction& getAllowedPluginsAction() const { return _projectMetaAction.getAllowedPluginsAction(); }
     const gui::SplashScreenAction& getSplashScreenAction() const { return _projectMetaAction.getSplashScreenAction(); }
     const gui::ToggleAction& getStudioModeAction() const { return _projectMetaAction.getStudioModeAction(); }
     const gui::ApplicationIconAction& getApplicationIconAction() const { return _projectMetaAction.getApplicationIconAction(); }
@@ -143,7 +144,8 @@ public: // Project meta action getters facade
     gui::StringAction& getCommentsAction() { return _projectMetaAction.getCommentsAction(); }
     gui::StringsAction& getContributorsAction() { return _projectMetaAction.getContributorsAction(); }
     ProjectCompressionAction& getCompressionAction() { return _projectMetaAction.getCompressionAction(); }
-    gui::StringsAction& getAllowedPlugins() { return _projectMetaAction.getAllowedPlugins(); }
+    gui::ToggleAction& getAllowedPluginsOnlyAction() { return _projectMetaAction.getAllowedPluginsOnlyAction(); }
+    gui::StringsAction& getAllowedPluginsAction() { return _projectMetaAction.getAllowedPluginsAction(); }
     gui::SplashScreenAction& getSplashScreenAction() { return _projectMetaAction.getSplashScreenAction(); }
     gui::ToggleAction& getStudioModeAction() { return _projectMetaAction.getStudioModeAction(); }
     gui::ApplicationIconAction& getApplicationIconAction() { return _projectMetaAction.getApplicationIconAction(); }

--- a/ManiVault/src/Project.h
+++ b/ManiVault/src/Project.h
@@ -125,6 +125,7 @@ public: // Project meta action getters facade
     const gui::StringAction& getCommentsAction() const { return _projectMetaAction.getCommentsAction(); }
     const gui::StringsAction& getContributorsAction() const { return _projectMetaAction.getContributorsAction(); }
     const ProjectCompressionAction& getCompressionAction() const { return _projectMetaAction.getCompressionAction(); }
+    const gui::StringsAction& getAllowedPlugins() const { return _projectMetaAction.getAllowedPlugins(); }
     const gui::SplashScreenAction& getSplashScreenAction() const { return _projectMetaAction.getSplashScreenAction(); }
     const gui::ToggleAction& getStudioModeAction() const { return _projectMetaAction.getStudioModeAction(); }
     const gui::ApplicationIconAction& getApplicationIconAction() const { return _projectMetaAction.getApplicationIconAction(); }
@@ -142,6 +143,7 @@ public: // Project meta action getters facade
     gui::StringAction& getCommentsAction() { return _projectMetaAction.getCommentsAction(); }
     gui::StringsAction& getContributorsAction() { return _projectMetaAction.getContributorsAction(); }
     ProjectCompressionAction& getCompressionAction() { return _projectMetaAction.getCompressionAction(); }
+    gui::StringsAction& getAllowedPlugins() { return _projectMetaAction.getAllowedPlugins(); }
     gui::SplashScreenAction& getSplashScreenAction() { return _projectMetaAction.getSplashScreenAction(); }
     gui::ToggleAction& getStudioModeAction() { return _projectMetaAction.getStudioModeAction(); }
     gui::ApplicationIconAction& getApplicationIconAction() { return _projectMetaAction.getApplicationIconAction(); }

--- a/ManiVault/src/ProjectMetaAction.cpp
+++ b/ManiVault/src/ProjectMetaAction.cpp
@@ -4,8 +4,10 @@
 
 #include "ProjectMetaAction.h"
 
+#include "CoreInterface.h"
 #include "Application.h"
 #include "Project.h"
+
 #include "util/Serialization.h"
 
 using namespace mv::gui;

--- a/ManiVault/src/ProjectMetaAction.cpp
+++ b/ManiVault/src/ProjectMetaAction.cpp
@@ -28,7 +28,7 @@ ProjectMetaAction::ProjectMetaAction(Project* project, QObject* parent /*= nullp
     _studioModeAction(this, "Studio Mode"),
     _applicationIconAction(this, "Application icon"),
     _compressionAction(this),
-    _allowedPlugins(this, "Allowed Plugins")
+    _allowedPluginsAction(this, "Allowed Plugins")
 {
     _splashScreenAction.setProjectMetaAction(this);
 }
@@ -80,7 +80,7 @@ void ProjectMetaAction::fromVariantMap(const QVariantMap& variantMap)
     _studioModeAction.fromParentVariantMap(variantMap);
     _applicationIconAction.fromParentVariantMap(variantMap);
     _compressionAction.fromParentVariantMap(variantMap);
-    _allowedPlugins.fromParentVariantMap(variantMap, true);
+    _allowedPluginsAction.fromParentVariantMap(variantMap, true);
 }
 
 QVariantMap ProjectMetaAction::toVariantMap() const
@@ -99,7 +99,7 @@ QVariantMap ProjectMetaAction::toVariantMap() const
     _studioModeAction.insertIntoVariantMap(variantMap);
     _applicationIconAction.insertIntoVariantMap(variantMap);
     _compressionAction.insertIntoVariantMap(variantMap);
-    _allowedPlugins.insertIntoVariantMap(variantMap);
+    _allowedPluginsAction.insertIntoVariantMap(variantMap);
 
     return variantMap;
 }
@@ -130,6 +130,15 @@ void ProjectMetaAction::initialize()
     _contributorsAction.setDefaultWidgetFlags(StringsAction::ListView);
 
     _applicationIconAction.setToolTip("Application icon settings");
+
+    _allowedPluginsAction.setCategory("Plugin name");
+
+    _allowedPluginsCompleter.setCompletionMode(QCompleter::PopupCompletion);
+    _allowedPluginsCompleter.setCaseSensitivity(Qt::CaseInsensitive);
+    _allowedPluginsCompleter.setModelSorting(QCompleter::CaseInsensitivelySortedModel);
+    _allowedPluginsCompleter.setModel(new QStringListModel(mv::plugins().getLoadedPluginKinds()));
+
+    _allowedPluginsAction.getNameAction().setCompleter(&_allowedPluginsCompleter);
 }
 
 Project* ProjectMetaAction::getProject() const

--- a/ManiVault/src/ProjectMetaAction.cpp
+++ b/ManiVault/src/ProjectMetaAction.cpp
@@ -28,10 +28,40 @@ ProjectMetaAction::ProjectMetaAction(Project* project, QObject* parent /*= nullp
     _studioModeAction(this, "Studio Mode"),
     _applicationIconAction(this, "Application icon"),
     _compressionAction(this),
+    _allowProjectSwitchingAction(this, "Allow project switching"),
     _allowedPluginsOnlyAction(this, "Limit use of plugins"),
     _allowedPluginsAction(this, "Allowed Plugins")
 {
     _splashScreenAction.setProjectMetaAction(this);
+
+    _readOnlyAction.setToolTip("Whether the project is in read-only mode or not");
+
+    _titleAction.setPlaceHolderString("Enter project title here...");
+    _titleAction.setClearable(true);
+
+    _descriptionAction.setPlaceHolderString("Enter project description here...");
+    _descriptionAction.setClearable(true);
+
+    _tagsAction.setIconByName("tag");
+    _tagsAction.setCategory("Tag");
+    _tagsAction.setStretch(2);
+
+    _commentsAction.setPlaceHolderString("Enter project comments here...");
+    _commentsAction.setClearable(true);
+    _commentsAction.setStretch(2);
+    _commentsAction.setDefaultWidgetFlags(StringAction::TextEdit);
+
+    _contributorsAction.setIconByName("user");
+    _contributorsAction.setCategory("Contributor");
+    _contributorsAction.setEnabled(false);
+    _contributorsAction.setStretch(1);
+    _contributorsAction.setDefaultWidgetFlags(StringsAction::ListView);
+
+    _applicationIconAction.setToolTip("Application icon settings");
+
+    _allowProjectSwitchingAction.setToolTip("Allow switching to another database project from the main menu");
+    _allowedPluginsOnlyAction.setToolTip("Only plugins in the allowed list may be created from the UI.");
+    _allowedPluginsAction.setToolTip("Only plugins in this list may be created from the UI.");
 
     _allowedPluginsAction.setCategory("Plugin name");
 
@@ -108,6 +138,7 @@ void ProjectMetaAction::fromVariantMap(const QVariantMap& variantMap)
     _studioModeAction.fromParentVariantMap(variantMap);
     _applicationIconAction.fromParentVariantMap(variantMap);
     _compressionAction.fromParentVariantMap(variantMap);
+    _allowProjectSwitchingAction.fromParentVariantMap(variantMap, true);
     _allowedPluginsOnlyAction.fromParentVariantMap(variantMap, true);
     _allowedPluginsAction.fromParentVariantMap(variantMap, true);
 }
@@ -128,41 +159,11 @@ QVariantMap ProjectMetaAction::toVariantMap() const
     _studioModeAction.insertIntoVariantMap(variantMap);
     _applicationIconAction.insertIntoVariantMap(variantMap);
     _compressionAction.insertIntoVariantMap(variantMap);
+    _allowProjectSwitchingAction.insertIntoVariantMap(variantMap);
     _allowedPluginsOnlyAction.insertIntoVariantMap(variantMap);
     _allowedPluginsAction.insertIntoVariantMap(variantMap);
 
     return variantMap;
-}
-
-void ProjectMetaAction::initialize()
-{
-    _readOnlyAction.setToolTip("Whether the project is in read-only mode or not");
-
-    _titleAction.setPlaceHolderString("Enter project title here...");
-    _titleAction.setClearable(true);
-
-    _descriptionAction.setPlaceHolderString("Enter project description here...");
-    _descriptionAction.setClearable(true);
-
-    _tagsAction.setIconByName("tag");
-    _tagsAction.setCategory("Tag");
-    _tagsAction.setStretch(2);
-
-    _commentsAction.setPlaceHolderString("Enter project comments here...");
-    _commentsAction.setClearable(true);
-    _commentsAction.setStretch(2);
-    _commentsAction.setDefaultWidgetFlags(StringAction::TextEdit);
-
-    _contributorsAction.setIconByName("user");
-    _contributorsAction.setCategory("Contributor");
-    _contributorsAction.setEnabled(false);
-    _contributorsAction.setStretch(1);
-    _contributorsAction.setDefaultWidgetFlags(StringsAction::ListView);
-
-    _applicationIconAction.setToolTip("Application icon settings");
-
-    _allowedPluginsOnlyAction.setToolTip("Only plugins in the allowed list may be created from the UI.");
-    _allowedPluginsAction.setToolTip("Only plugins in this list may be created from the UI.");
 }
 
 Project* ProjectMetaAction::getProject() const

--- a/ManiVault/src/ProjectMetaAction.cpp
+++ b/ManiVault/src/ProjectMetaAction.cpp
@@ -80,7 +80,7 @@ void ProjectMetaAction::fromVariantMap(const QVariantMap& variantMap)
     _studioModeAction.fromParentVariantMap(variantMap);
     _applicationIconAction.fromParentVariantMap(variantMap);
     _compressionAction.fromParentVariantMap(variantMap);
-    _allowedPlugins.fromParentVariantMap(variantMap);
+    _allowedPlugins.fromParentVariantMap(variantMap, true);
 }
 
 QVariantMap ProjectMetaAction::toVariantMap() const

--- a/ManiVault/src/ProjectMetaAction.cpp
+++ b/ManiVault/src/ProjectMetaAction.cpp
@@ -27,7 +27,8 @@ ProjectMetaAction::ProjectMetaAction(Project* project, QObject* parent /*= nullp
     _splashScreenAction(this, true),
     _studioModeAction(this, "Studio Mode"),
     _applicationIconAction(this, "Application icon"),
-    _compressionAction(this)
+    _compressionAction(this),
+    _allowedPlugins(this, "Allowed Plugins")
 {
     _splashScreenAction.setProjectMetaAction(this);
 }
@@ -79,6 +80,7 @@ void ProjectMetaAction::fromVariantMap(const QVariantMap& variantMap)
     _studioModeAction.fromParentVariantMap(variantMap);
     _applicationIconAction.fromParentVariantMap(variantMap);
     _compressionAction.fromParentVariantMap(variantMap);
+    _allowedPlugins.fromParentVariantMap(variantMap);
 }
 
 QVariantMap ProjectMetaAction::toVariantMap() const
@@ -97,6 +99,7 @@ QVariantMap ProjectMetaAction::toVariantMap() const
     _studioModeAction.insertIntoVariantMap(variantMap);
     _applicationIconAction.insertIntoVariantMap(variantMap);
     _compressionAction.insertIntoVariantMap(variantMap);
+    _allowedPlugins.insertIntoVariantMap(variantMap);
 
     return variantMap;
 }

--- a/ManiVault/src/ProjectMetaAction.h
+++ b/ManiVault/src/ProjectMetaAction.h
@@ -57,7 +57,7 @@ public: // Serialization
 
     /**
      * Load project from variant
-     * @param Variant representation of the project
+     * @param variantMap Variant representation of the project
      */
     void fromVariantMap(const QVariantMap& variantMap) override;
 
@@ -66,11 +66,6 @@ public: // Serialization
      * @return Variant representation of the project
      */
     QVariantMap toVariantMap() const override;
-
-private:
-
-    /** IsStartup initialization */
-    void initialize();
 
 public: // Action getters
 
@@ -86,6 +81,7 @@ public: // Action getters
     const gui::ToggleAction& getStudioModeAction() const { return _studioModeAction; }
     const gui::ApplicationIconAction& getApplicationIconAction() const { return _applicationIconAction; }
     const ProjectCompressionAction& getCompressionAction() const { return _compressionAction; }
+    const gui::ToggleAction& getAllowProjectSwitchingAction() const { return _allowProjectSwitchingAction; }
     const gui::ToggleAction& getAllowedPluginsOnlyAction() const { return _allowedPluginsOnlyAction; }
     const gui::StringsAction& getAllowedPluginsAction() const { return _allowedPluginsAction; }
 
@@ -101,6 +97,7 @@ public: // Action getters
     gui::ToggleAction& getStudioModeAction() { return _studioModeAction; }
     gui::ApplicationIconAction& getApplicationIconAction() { return _applicationIconAction; }
     ProjectCompressionAction& getCompressionAction() { return _compressionAction; }
+    gui::ToggleAction& getAllowProjectSwitchingAction() { return _allowProjectSwitchingAction; }
     gui::ToggleAction& getAllowedPluginsOnlyAction() { return _allowedPluginsOnlyAction; }
     gui::StringsAction& getAllowedPluginsAction() { return _allowedPluginsAction; }
 
@@ -118,6 +115,7 @@ private:
     gui::ToggleAction               _studioModeAction;                  /** Toggle between view- and studio mode action */
     gui::ApplicationIconAction      _applicationIconAction;             /** Application icon action (only used in application mode) */
     ProjectCompressionAction        _compressionAction;                 /** Project compression action */
+    gui::ToggleAction               _allowProjectSwitchingAction;       /** Allow project switching action (only used in application mode) */
     gui::ToggleAction               _allowedPluginsOnlyAction;          /** Restrict to allowed plugins only action (only used in application mode) */
     gui::StringsAction              _allowedPluginsAction;              /** Allowed plugins action (only used in application mode) */
     QCompleter                      _allowedPluginsCompleter;           /** Completer for allowed plugins action */

--- a/ManiVault/src/ProjectMetaAction.h
+++ b/ManiVault/src/ProjectMetaAction.h
@@ -13,6 +13,8 @@
 
 #include "ProjectCompressionAction.h"
 
+#include <QCompleter>
+
 namespace mv {
 
 class Project;
@@ -83,7 +85,7 @@ public: // Action getters
     const gui::ToggleAction& getStudioModeAction() const { return _studioModeAction; }
     const gui::ApplicationIconAction& getApplicationIconAction() const { return _applicationIconAction; }
     const ProjectCompressionAction& getCompressionAction() const { return _compressionAction; }
-    const gui::StringsAction& getAllowedPlugins() const { return _allowedPlugins; }
+    const gui::StringsAction& getAllowedPlugins() const { return _allowedPluginsAction; }
 
     gui::VersionAction& getApplicationVersionAction() { return _applicationVersionAction; }
     gui::VersionAction& getProjectVersionAction() { return _projectVersionAction; }
@@ -97,7 +99,7 @@ public: // Action getters
     gui::ToggleAction& getStudioModeAction() { return _studioModeAction; }
     gui::ApplicationIconAction& getApplicationIconAction() { return _applicationIconAction; }
     ProjectCompressionAction& getCompressionAction() { return _compressionAction; }
-    gui::StringsAction& getAllowedPlugins() { return _allowedPlugins; }
+    gui::StringsAction& getAllowedPlugins() { return _allowedPluginsAction; }
 
 private:
     Project*                        _project;                           /** Pointer to source project to get the meta data from */
@@ -113,7 +115,8 @@ private:
     gui::ToggleAction               _studioModeAction;                  /** Toggle between view- and studio mode action */
     gui::ApplicationIconAction      _applicationIconAction;             /** Application icon action (only used in application mode) */
     ProjectCompressionAction        _compressionAction;                 /** Project compression action */
-    gui::StringsAction              _allowedPlugins;                    /** Allowed plugins action (only used in application mode) */
+    gui::StringsAction              _allowedPluginsAction;              /** Allowed plugins action (only used in application mode) */
+    QCompleter                      _allowedPluginsCompleter;           /** Completer for allowed plugins action */
 };
 
 }

--- a/ManiVault/src/ProjectMetaAction.h
+++ b/ManiVault/src/ProjectMetaAction.h
@@ -14,6 +14,7 @@
 #include "ProjectCompressionAction.h"
 
 #include <QCompleter>
+#include <QStringListModel>
 
 namespace mv {
 
@@ -85,7 +86,8 @@ public: // Action getters
     const gui::ToggleAction& getStudioModeAction() const { return _studioModeAction; }
     const gui::ApplicationIconAction& getApplicationIconAction() const { return _applicationIconAction; }
     const ProjectCompressionAction& getCompressionAction() const { return _compressionAction; }
-    const gui::StringsAction& getAllowedPlugins() const { return _allowedPluginsAction; }
+    const gui::ToggleAction& getAllowedPluginsOnlyAction() const { return _allowedPluginsOnlyAction; }
+    const gui::StringsAction& getAllowedPluginsAction() const { return _allowedPluginsAction; }
 
     gui::VersionAction& getApplicationVersionAction() { return _applicationVersionAction; }
     gui::VersionAction& getProjectVersionAction() { return _projectVersionAction; }
@@ -99,7 +101,8 @@ public: // Action getters
     gui::ToggleAction& getStudioModeAction() { return _studioModeAction; }
     gui::ApplicationIconAction& getApplicationIconAction() { return _applicationIconAction; }
     ProjectCompressionAction& getCompressionAction() { return _compressionAction; }
-    gui::StringsAction& getAllowedPlugins() { return _allowedPluginsAction; }
+    gui::ToggleAction& getAllowedPluginsOnlyAction() { return _allowedPluginsOnlyAction; }
+    gui::StringsAction& getAllowedPluginsAction() { return _allowedPluginsAction; }
 
 private:
     Project*                        _project;                           /** Pointer to source project to get the meta data from */
@@ -115,8 +118,10 @@ private:
     gui::ToggleAction               _studioModeAction;                  /** Toggle between view- and studio mode action */
     gui::ApplicationIconAction      _applicationIconAction;             /** Application icon action (only used in application mode) */
     ProjectCompressionAction        _compressionAction;                 /** Project compression action */
+    gui::ToggleAction               _allowedPluginsOnlyAction;          /** Restrict to allowed plugins only action (only used in application mode) */
     gui::StringsAction              _allowedPluginsAction;              /** Allowed plugins action (only used in application mode) */
     QCompleter                      _allowedPluginsCompleter;           /** Completer for allowed plugins action */
+    QStringListModel                _allowedPluginsModel;               /** Model for allowed plugins action */
 };
 
 }

--- a/ManiVault/src/ProjectMetaAction.h
+++ b/ManiVault/src/ProjectMetaAction.h
@@ -83,6 +83,7 @@ public: // Action getters
     const gui::ToggleAction& getStudioModeAction() const { return _studioModeAction; }
     const gui::ApplicationIconAction& getApplicationIconAction() const { return _applicationIconAction; }
     const ProjectCompressionAction& getCompressionAction() const { return _compressionAction; }
+    const gui::StringsAction& getAllowedPlugins() const { return _allowedPlugins; }
 
     gui::VersionAction& getApplicationVersionAction() { return _applicationVersionAction; }
     gui::VersionAction& getProjectVersionAction() { return _projectVersionAction; }
@@ -96,6 +97,7 @@ public: // Action getters
     gui::ToggleAction& getStudioModeAction() { return _studioModeAction; }
     gui::ApplicationIconAction& getApplicationIconAction() { return _applicationIconAction; }
     ProjectCompressionAction& getCompressionAction() { return _compressionAction; }
+    gui::StringsAction& getAllowedPlugins() { return _allowedPlugins; }
 
 private:
     Project*                        _project;                           /** Pointer to source project to get the meta data from */
@@ -111,6 +113,7 @@ private:
     gui::ToggleAction               _studioModeAction;                  /** Toggle between view- and studio mode action */
     gui::ApplicationIconAction      _applicationIconAction;             /** Application icon action (only used in application mode) */
     ProjectCompressionAction        _compressionAction;                 /** Project compression action */
+    gui::StringsAction              _allowedPlugins;                    /** Allowed plugins action (only used in application mode) */
 };
 
 }

--- a/ManiVault/src/actions/StringAction.h
+++ b/ManiVault/src/actions/StringAction.h
@@ -193,7 +193,6 @@ public:
      * @param parent Pointer to parent object
      * @param title Title of the action
      * @param string String
-     * @param defaultString Default string
      */
     Q_INVOKABLE explicit StringAction(QObject* parent, const QString& title, const QString& string = "");
 

--- a/ManiVault/src/actions/StringsAction.cpp
+++ b/ManiVault/src/actions/StringsAction.cpp
@@ -245,9 +245,11 @@ StringsAction::ListWidget::ListWidget(QWidget* parent, StringsAction* stringsAct
         }
 
         if (selectedRows.count() == 1) {
-            stringsAction->getNameAction().setEnabled(!isStringLocked(selectedRows.first().data().toString()));
+            const auto stringIsLocked = isStringLocked(selectedRows.first().data(Qt::DisplayRole).toString());
+
+            stringsAction->getNameAction().setEnabled(!stringIsLocked);
             stringsAction->getNameAction().setString(selectedRows.first().data(Qt::DisplayRole).toString());
-            stringsAction->getAddAction().setEnabled(false);
+            stringsAction->getAddAction().setEnabled(!stringIsLocked);
             stringsAction->getRemoveAction().setEnabled(true);
         }
 

--- a/ManiVault/src/actions/StringsAction.cpp
+++ b/ManiVault/src/actions/StringsAction.cpp
@@ -160,6 +160,36 @@ void StringsAction::addString(const QString& string)
     emit stringsAdded({ string });
 }
 
+void StringsAction::addStrings(const QStringList& strings, bool allowDuplication /*= false*/)
+{
+    const auto& existingStrings = _strings;
+
+    _strings << strings;
+
+	if (!allowDuplication) {
+		_strings.removeDuplicates();
+    }
+	    
+    emit stringsChanged(_strings);
+
+    saveToSettings();
+
+    auto removedStrings = existingStrings;
+    auto addedStrings   = _strings;
+
+    for (const auto& string : strings)
+        removedStrings.removeAll(string);
+
+    for (const QString& existingString : existingStrings)
+        addedStrings.removeAll(existingString);
+
+    if (!addedStrings.isEmpty())
+        emit stringsAdded(addedStrings);
+
+    if (!removedStrings.isEmpty())
+        emit stringsRemoved(removedStrings);
+}
+
 void StringsAction::removeString(const QString& string)
 {
     _strings.removeOne(string);

--- a/ManiVault/src/actions/StringsAction.cpp
+++ b/ManiVault/src/actions/StringsAction.cpp
@@ -26,7 +26,12 @@ StringsAction::StringsAction(QObject* parent, const QString& title, const QStrin
 
     _toolbarAction.setShowLabels(false);
 
+    _nameAction.setEnabled(false);
     _nameAction.setStretch(1);
+
+    _addAction.setEnabled(false);
+
+    _removeAction.setEnabled(false);
 
     _toolbarAction.addAction(&_nameAction);
     _toolbarAction.addAction(&_addAction);
@@ -65,6 +70,21 @@ void StringsAction::setStrings(const QStringList& strings)
 
     if (!removedStrings.isEmpty())
         emit stringsRemoved(removedStrings);
+}
+
+QStringList StringsAction::getLockedStrings() const
+{
+    return _lockedStrings;
+}
+
+void StringsAction::setLockedStrings(const QStringList& lockedStrings)
+{
+    if (lockedStrings == _lockedStrings)
+        return;
+
+    _lockedStrings = lockedStrings;
+
+    emit lockedStringsChanged(_lockedStrings);
 }
 
 void StringsAction::connectToPublicAction(WidgetAction* publicAction, bool recursive)
@@ -211,37 +231,61 @@ StringsAction::ListWidget::ListWidget(QWidget* parent, StringsAction* stringsAct
 
     setLayout(layout);
 
-    const auto updateActions = [this, stringsAction]() -> void {
+    const auto isStringLocked = [stringsAction](const QString& string) -> bool {
+        return stringsAction->getLockedStrings().contains(string);
+    };
+
+    const auto updateActions = [this, stringsAction, isStringLocked]() -> void {
         const auto selectedRows = _hierarchyWidget.getSelectionModel().selectedRows();
 
-        stringsAction->getNameAction().setEnabled(selectedRows.count() <= 1);
+        if (selectedRows.isEmpty()) {
+            stringsAction->getNameAction().setEnabled(true);
+            stringsAction->getAddAction().setEnabled(!stringsAction->getNameAction().getString().isEmpty());
+            stringsAction->getRemoveAction().setEnabled(false);
+        }
 
-        if (selectedRows.count() == 1)
+        if (selectedRows.count() == 1) {
+            stringsAction->getNameAction().setEnabled(!isStringLocked(selectedRows.first().data().toString()));
             stringsAction->getNameAction().setString(selectedRows.first().data(Qt::DisplayRole).toString());
+            stringsAction->getAddAction().setEnabled(false);
+            stringsAction->getRemoveAction().setEnabled(true);
+        }
 
         if (selectedRows.count() >= 2) {
             QStringList selected;
 
-            for (const auto& selectedRow : selectedRows)
+            bool mayRemove = false;
+
+        	for (const auto& selectedRow : selectedRows) {
                 selected << selectedRow.data(Qt::DisplayRole).toString();
 
-            stringsAction->getNameAction().setString(selected.join(", "));
-        }
+                if (!isStringLocked(selectedRow.data().toString()))
+                    mayRemove = true;
+        	}
 
-        stringsAction->getAddAction().setEnabled(selectedRows.isEmpty() && !stringsAction->getNameAction().getString().isEmpty());
-        stringsAction->getRemoveAction().setEnabled(!selectedRows.isEmpty());
+            stringsAction->getNameAction().setEnabled(false);
+            stringsAction->getNameAction().setString("");
+            stringsAction->getAddAction().setEnabled(false);
+            stringsAction->getRemoveAction().setEnabled(mayRemove);
+        }
     };
 
-    const auto updateModel = [this, stringsAction, updateActions](const QStringList& strings) -> void {
+    const auto updateModel = [this, stringsAction, updateActions, isStringLocked](const QStringList& strings) -> void {
         _model.removeRows(0, _model.rowCount());
 
-        for (const auto& string : strings)
-            _model.appendRow(new QStandardItem(string));
+        for (const auto& string : strings) {
+            auto item = new QStandardItem(string);
+
+            item->setEnabled(!isStringLocked(string));
+
+            _model.appendRow(item);
+        }
 
         updateActions();
     };
 
     connect(stringsAction, &StringsAction::stringsChanged, this, updateModel);
+    connect(stringsAction, &StringsAction::lockedStringsChanged, this, updateModel);
     connect(&stringsAction->getNameAction(), &StringAction::stringChanged, this, updateActions);
 
     connect(&stringsAction->getAddAction(), &TriggerAction::triggered, this, [this, stringsAction]() -> void {

--- a/ManiVault/src/actions/StringsAction.h
+++ b/ManiVault/src/actions/StringsAction.h
@@ -141,7 +141,7 @@ public: // Serialization
 
     /**
      * Load widget action from variant
-     * @param Variant representation of the widget action
+     * @param variantMap Variant representation of the widget action
      */
     void fromVariantMap(const QVariantMap& variantMap) override;
 
@@ -185,6 +185,7 @@ protected:
     StringAction            _nameAction;        /** String name action */
     TriggerAction           _addAction;         /** Add string action */
     TriggerAction           _removeAction;      /** Remove string action */
+    QCompleter*             _completer;         /** Pointer to completer for auto-completion, maybe nullptr */
 
     friend class AbstractActionsManager;
 };

--- a/ManiVault/src/actions/StringsAction.h
+++ b/ManiVault/src/actions/StringsAction.h
@@ -105,6 +105,18 @@ public:
     void setStrings(const QStringList& strings);
 
     /**
+     * Get locked strings
+     * @return Locked strings as string list
+     */
+    QStringList getLockedStrings() const;
+
+    /**
+     * Set locked strings to \p lockedStrings
+     * @param lockedStrings Locked strings
+     */
+    void setLockedStrings(const QStringList& lockedStrings);
+
+    /**
      * Add string
      * @param string String to add
      */
@@ -173,6 +185,12 @@ signals:
     void stringsAdded(const QStringList& strings);
 
     /**
+     * Signals that locked string changed to \p lockedStrings
+     * @param lockedStrings Locked strings
+     */
+    void lockedStringsChanged(const QStringList& lockedStrings);
+
+    /**
      * Signals that \p strings were removed
      * @param strings Removed strings
      */
@@ -181,6 +199,7 @@ signals:
 protected:
     QString                 _category;          /** Type of string */
     QStringList             _strings;           /** Current strings */
+    QStringList             _lockedStrings;     /** Strings that are locked and cannot be removed or renamed */
     HorizontalGroupAction   _toolbarAction;     /** Toolbar action */
     StringAction            _nameAction;        /** String name action */
     TriggerAction           _addAction;         /** Add string action */

--- a/ManiVault/src/actions/StringsAction.h
+++ b/ManiVault/src/actions/StringsAction.h
@@ -123,6 +123,13 @@ public:
     void addString(const QString& string);
 
     /**
+     * Add /p strings
+     * @param strings Strings to add
+     * @param allowDuplication Whether to allow duplication of strings, defaults to false
+     */
+    void addStrings(const QStringList& strings, bool allowDuplication = false);
+
+    /**
      * Remove string
      * @param string String to remove
      */

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.cpp
@@ -118,6 +118,9 @@ void DataHierarchyWidgetContextMenu::addMenusForPluginType(plugin::Type pluginTy
     for (const auto& pluginTriggerAction : mv::plugins().getPluginTriggerActions(pluginType, _selectedDatasets)) {
         const auto titleSegments = pluginTriggerAction->getMenuLocation().split("/");
 
+        if (!pluginTriggerAction->getPluginFactory()->getAllowPluginCreationFromStandardGui())
+            continue; // Skip plugins that do not allow creation from the standard GUI
+
         QString menuPath, previousMenuPath = titleSegments.first();
 
         for (const auto& titleSegment : titleSegments) {

--- a/ManiVault/src/private/LoadSystemViewMenu.cpp
+++ b/ManiVault/src/private/LoadSystemViewMenu.cpp
@@ -91,6 +91,9 @@ QVector<QPointer<TriggerAction>> LoadSystemViewMenu::getLoadSystemViewsActions(m
         if (!viewPluginFactory->producesSystemViewPlugins())
             continue;
 
+        if (!viewPluginFactory->getAllowPluginCreationFromStandardGui())
+            continue;
+
         auto action = new TriggerAction(this, viewPluginFactory->getKind());
 
         action->setIcon(pluginTriggerAction->icon());
@@ -106,9 +109,7 @@ QVector<QPointer<TriggerAction>> LoadSystemViewMenu::getLoadSystemViewsActions(m
         if (_dockAreaWidget && _dockAreaWidget->dockWidgetsCount() >= 1) {
             auto dockWidgets = _dockAreaWidget->dockWidgets();
 
-            auto firstViewPluginDockWidget = dynamic_cast<ViewPluginDockWidget*>(_dockAreaWidget->dockWidgets().first());
-
-            if (firstViewPluginDockWidget)
+            if (auto firstViewPluginDockWidget = dynamic_cast<ViewPluginDockWidget*>(_dockAreaWidget->dockWidgets().first()))
                 dockToViewPlugin = firstViewPluginDockWidget->getViewPlugin();
         }
 

--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -192,7 +192,7 @@ void MainWindow::showEvent(QShowEvent* showEvent)
             const auto projectIsReadOnly = projects().getCurrentProject()->getReadOnlyAction().isChecked();
 
             fileMenuAction->setVisible(!projectIsReadOnly);
-            viewMenuAction->setVisible(!projectIsReadOnly);
+            //viewMenuAction->setVisible(!projectIsReadOnly);
         };
 
         connect(&projects(), &AbstractProjectManager::projectCreated, this, [this, updateMenuVisibility]() -> void {

--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -188,11 +188,11 @@ void MainWindow::showEvent(QShowEvent* showEvent)
             }
         });
 
-        const auto updateMenuVisibility = [fileMenuAction, viewMenuAction]() -> void {
+        const auto updateMenuVisibility = [fileMenuAction, projectsMenuAction]() -> void {
             const auto projectIsReadOnly = projects().getCurrentProject()->getReadOnlyAction().isChecked();
 
             fileMenuAction->setVisible(!projectIsReadOnly);
-            //viewMenuAction->setVisible(!projectIsReadOnly);
+            projectsMenuAction->setVisible(projectIsReadOnly ? projects().getCurrentProject()->getAllowProjectSwitchingAction().isChecked() : true);
         };
 
         connect(&projects(), &AbstractProjectManager::projectCreated, this, [this, updateMenuVisibility]() -> void {

--- a/ManiVault/src/private/PluginManager.cpp
+++ b/ManiVault/src/private/PluginManager.cpp
@@ -708,16 +708,26 @@ std::vector<plugin::Plugin*> PluginManager::getPluginsByTypes(const plugin::Type
     return pluginsByType;
 }
 
-QStringList PluginManager::getPluginKindsByPluginTypes(const plugin::Types& pluginTypes) const
+QStringList PluginManager::getPluginKindsByPluginTypes(const plugin::Types& pluginTypes /*= plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }*/) const
 {
     QStringList pluginKinds;
 
-    for (const auto& pluginType : pluginTypes)
-        for (auto pluginFactory : _pluginFactories)
-            if (pluginFactory->getType() == pluginType)
-                pluginKinds << pluginFactory->getKind();
-
+    if (pluginTypes.isEmpty()) {
+        for (const auto& pluginFactory : _pluginFactories)
+        	pluginKinds << pluginFactory->getKind();
+    } else {
+        for (const auto& pluginType : pluginTypes)
+            for (auto pluginFactory : _pluginFactories)
+                if (pluginFactory->getType() == pluginType)
+                    pluginKinds << pluginFactory->getKind();
+    }
+    
     return pluginKinds;
+}
+
+QStringList PluginManager::getLoadedPluginKinds(const plugin::Types& pluginTypes /*= plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }*/) const
+{
+    return getPluginKindsByPluginTypes(pluginTypes);
 }
 
 mv::gui::PluginTriggerActions PluginManager::getPluginTriggerActions(const plugin::Type& pluginType) const

--- a/ManiVault/src/private/PluginManager.cpp
+++ b/ManiVault/src/private/PluginManager.cpp
@@ -730,6 +730,25 @@ QStringList PluginManager::getLoadedPluginKinds(const plugin::Types& pluginTypes
     return getPluginKindsByPluginTypes(pluginTypes);
 }
 
+QStringList PluginManager::getUsedPluginKinds(const plugin::Types& pluginTypes) const
+{
+    QStringList pluginKinds;
+
+    if (pluginTypes.isEmpty()) {
+        for (const auto& pluginFactory : _pluginFactories)
+            if (pluginFactory->getNumberOfInstances() >= 1)
+                pluginKinds << pluginFactory->getKind();
+    }
+    else {
+        for (const auto& pluginType : pluginTypes)
+            for (auto pluginFactory : _pluginFactories)
+                if (pluginFactory->getType() == pluginType && pluginFactory->getNumberOfInstances() >= 1)
+                    pluginKinds << pluginFactory->getKind();
+    }
+
+    return pluginKinds;
+}
+
 mv::gui::PluginTriggerActions PluginManager::getPluginTriggerActions(const plugin::Type& pluginType) const
 {
     PluginTriggerActions pluginProducerActions;

--- a/ManiVault/src/private/PluginManager.h
+++ b/ManiVault/src/private/PluginManager.h
@@ -47,7 +47,8 @@ public: // Plugin creation/destruction
     /**
      * Create a plugin of \p kind with input \p datasets
      * @param kind Kind of plugin (name of the plugin)
-     * @param datasets Zero or more datasets upon which the plugin is based (e.g. analysis plugin)
+     * @param inputDatasets Zero or more datasets upon which the plugin is based (e.g. analysis plugin)
+     * @param outputDatasets Zero or more datasets that the plugin produces (e.g. analysis plugin)
      * @return Pointer to created plugin, nullptr if creation failed
      */
     plugin::Plugin* requestPlugin(const QString& kind, Datasets inputDatasets = Datasets(), Datasets outputDatasets = Datasets()) override;
@@ -139,11 +140,18 @@ public: // Plugin getters
     std::vector<plugin::Plugin*> getPluginsByTypes(const plugin::Types& pluginTypes = plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }) const override;
 
     /**
-     * Get plugin kinds by plugin type(s)
-     * @param pluginTypes Plugin type(s)
-     * @return Plugin kinds
+     * Get plugin kinds by \p pluginType
+     * @param pluginTypes Plugin type(s), all plugin types if empty
+     * @return List of plugin kinds
      */
-    QStringList getPluginKindsByPluginTypes(const plugin::Types& pluginTypes) const;
+    QStringList getPluginKindsByPluginTypes(const plugin::Types& pluginTypes = plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }) const;
+
+    /**
+     * Get loaded plugin kinds by \p pluginType
+     * @param pluginType Plugin type(s), all plugin types if empty
+     * @return List of loaded plugin kinds
+     */
+    QStringList getLoadedPluginKinds(const plugin::Types& pluginTypes = plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }) const;
 
 public: // Plugin trigger actions
 

--- a/ManiVault/src/private/PluginManager.h
+++ b/ManiVault/src/private/PluginManager.h
@@ -148,10 +148,17 @@ public: // Plugin getters
 
     /**
      * Get loaded plugin kinds by \p pluginType
-     * @param pluginType Plugin type(s), all plugin types if empty
+     * @param pluginTypes Plugin type(s), all plugin types if empty
      * @return List of loaded plugin kinds
      */
-    QStringList getLoadedPluginKinds(const plugin::Types& pluginTypes = plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }) const;
+    QStringList getLoadedPluginKinds(const plugin::Types& pluginTypes = plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }) const override;
+
+    /**
+     * Get used plugin kinds by \p pluginType
+     * @param pluginTypes Plugin type(s), all plugin types if empty
+     * @return List of used plugin kinds
+     */
+    QStringList getUsedPluginKinds(const plugin::Types& pluginTypes = plugin::Types{ plugin::Type::ANALYSIS, plugin::Type::DATA, plugin::Type::LOADER, plugin::Type::WRITER, plugin::Type::TRANSFORMATION, plugin::Type::VIEW }) const override;
 
 public: // Plugin trigger actions
 

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -907,6 +907,7 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
                     settingsGroupAction.addAction(&currentProject->getSplashScreenAction());
                     settingsGroupAction.addAction(&currentProject->getOverrideApplicationStatusBarAction());
                     settingsGroupAction.addAction(&currentProject->getStatusBarVisibleAction());
+                    settingsGroupAction.addAction(&currentProject->getAllowedPlugins());
 
                     /* TODO: Fix plugin status bar action visibility
                     settingsGroupAction.addAction(&currentProject->getStatusBarOptionsAction());

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -824,6 +824,9 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
 
             auto currentProject = getCurrentProject();
 
+            currentProject->getAllowedPluginsAction().setStrings(mv::plugins().getUsedPluginKinds());
+            currentProject->getAllowedPluginsAction().setLockedStrings(mv::plugins().getUsedPluginKinds());
+
             currentProject->getOverrideApplicationStatusBarAction().cacheState();
 
             /* TODO: Fix plugin status bar action visibility
@@ -907,7 +910,8 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
                     settingsGroupAction.addAction(&currentProject->getSplashScreenAction());
                     settingsGroupAction.addAction(&currentProject->getOverrideApplicationStatusBarAction());
                     settingsGroupAction.addAction(&currentProject->getStatusBarVisibleAction());
-                    settingsGroupAction.addAction(&currentProject->getAllowedPlugins());
+                    settingsGroupAction.addAction(&currentProject->getAllowedPluginsOnlyAction());
+                    settingsGroupAction.addAction(&currentProject->getAllowedPluginsAction());
 
                     /* TODO: Fix plugin status bar action visibility
                     settingsGroupAction.addAction(&currentProject->getStatusBarOptionsAction());

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -912,6 +912,7 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
                     settingsGroupAction.addAction(&currentProject->getStatusBarVisibleAction());
                     settingsGroupAction.addAction(&currentProject->getAllowedPluginsOnlyAction());
                     settingsGroupAction.addAction(&currentProject->getAllowedPluginsAction());
+                    settingsGroupAction.addAction(&currentProject->getAllowProjectSwitchingAction());
 
                     /* TODO: Fix plugin status bar action visibility
                     settingsGroupAction.addAction(&currentProject->getStatusBarOptionsAction());

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -824,7 +824,7 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
 
             auto currentProject = getCurrentProject();
 
-            currentProject->getAllowedPluginsAction().setStrings(mv::plugins().getUsedPluginKinds());
+            currentProject->getAllowedPluginsAction().addStrings(mv::plugins().getUsedPluginKinds());
             //currentProject->getAllowedPluginsAction().setLockedStrings(mv::plugins().getUsedPluginKinds());
 
             currentProject->getOverrideApplicationStatusBarAction().cacheState();
@@ -908,8 +908,8 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
                     settingsGroupAction.addAction(&currentProject->getTagsAction());
                     settingsGroupAction.addAction(&currentProject->getCommentsAction());
                     settingsGroupAction.addAction(&currentProject->getSplashScreenAction());
-                    settingsGroupAction.addAction(&currentProject->getOverrideApplicationStatusBarAction());
-                    settingsGroupAction.addAction(&currentProject->getStatusBarVisibleAction());
+                    //settingsGroupAction.addAction(&currentProject->getOverrideApplicationStatusBarAction());
+                    //settingsGroupAction.addAction(&currentProject->getStatusBarVisibleAction());
                     settingsGroupAction.addAction(&currentProject->getAllowedPluginsOnlyAction());
                     settingsGroupAction.addAction(&currentProject->getAllowedPluginsAction());
                     settingsGroupAction.addAction(&currentProject->getAllowProjectSwitchingAction());

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -179,7 +179,8 @@ ProjectManager::ProjectManager(QObject* parent) :
         _importDataMenu.clear();
 
         for (auto& pluginTriggerAction : plugins().getPluginTriggerActions(plugin::Type::LOADER))
-            _importDataMenu.addAction(pluginTriggerAction);
+            if (pluginTriggerAction->getPluginFactory()->getAllowPluginCreationFromStandardGui())
+				_importDataMenu.addAction(pluginTriggerAction);
 
         _importDataMenu.setEnabled(!_importDataMenu.actions().isEmpty());
     });

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -825,7 +825,7 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
             auto currentProject = getCurrentProject();
 
             currentProject->getAllowedPluginsAction().setStrings(mv::plugins().getUsedPluginKinds());
-            currentProject->getAllowedPluginsAction().setLockedStrings(mv::plugins().getUsedPluginKinds());
+            //currentProject->getAllowedPluginsAction().setLockedStrings(mv::plugins().getUsedPluginKinds());
 
             currentProject->getOverrideApplicationStatusBarAction().cacheState();
 

--- a/ManiVault/src/private/ViewMenu.cpp
+++ b/ManiVault/src/private/ViewMenu.cpp
@@ -44,8 +44,8 @@ ViewMenu::ViewMenu(QWidget *parent /*= nullptr*/, const Options& options /*= Opt
     populate();
 
     const auto updateReadOnly = [this]() -> void {
-        setEnabled(projects().hasProject() && !workspaces().getLockingAction().isLocked());
-        };
+        setEnabled(projects().hasProject());
+    };
 
     updateReadOnly();
 

--- a/ManiVault/src/util/Serializable.cpp
+++ b/ManiVault/src/util/Serializable.cpp
@@ -217,7 +217,7 @@ void Serializable::fromVariantMap(Serializable& serializable, const QVariantMap&
     }
 }
 
-void Serializable::fromParentVariantMap(const QVariantMap& parentVariantMap)
+void Serializable::fromParentVariantMap(const QVariantMap& parentVariantMap, bool ignoreLoadingErrors /*= false*/)
 {
     try
     {
@@ -227,10 +227,12 @@ void Serializable::fromParentVariantMap(const QVariantMap& parentVariantMap)
         if (!parentVariantMap.contains(getSerializationName())) {
             const auto errorMessage = QString("%1 not found in map: %2").arg(getSerializationName());
 
-            if (core() != nullptr && settings().getMiscellaneousSettings().getIgnoreLoadingErrorsAction().isChecked())
-                qCritical() << errorMessage;
-            else
-                throw std::runtime_error(errorMessage.toLatin1());
+            if (!ignoreLoadingErrors) {
+                if (core() != nullptr && settings().getMiscellaneousSettings().getIgnoreLoadingErrorsAction().isChecked())
+                    qCritical() << errorMessage;
+                else
+                    throw std::runtime_error(errorMessage.toStdString());
+            }
         }
         else {
             fromVariantMap(parentVariantMap[getSerializationName()].toMap());

--- a/ManiVault/src/util/Serializable.h
+++ b/ManiVault/src/util/Serializable.h
@@ -81,8 +81,9 @@ public:
     /**
      * Load from variant map located in \p parentVariantMap at the serialization name
      * @param parentVariantMap Parent variant map
+     * @param ignoreLoadingErrors Whether to ignore loading errors (default: false)
      */
-    virtual void fromParentVariantMap(const QVariantMap& parentVariantMap);
+    virtual void fromParentVariantMap(const QVariantMap& parentVariantMap, bool ignoreLoadingErrors = false);
 
     /**
      * Save to variant map


### PR DESCRIPTION
![PublishExample](https://github.com/user-attachments/assets/1e1828dc-b17d-4902-9c52-64f5c5679f8c)

This pull request introduces several enhancements and new features to the `ManiVault` project, focusing on plugin management, project metadata actions, and the `StringsAction` class. The most significant changes include adding new methods for managing plugins, extending project metadata actions with new options, and improving the functionality of `StringsAction` to handle locked and multiple strings.

### Plugin Management Enhancements:
* Added new methods in `AbstractPluginManager` to retrieve loaded and used plugin kinds (`getLoadedPluginKinds` and `getUsedPluginKinds`), with default plugin types specified for convenience. (`ManiVault/src/AbstractPluginManager.h`, [ManiVault/src/AbstractPluginManager.hL172-R190](diffhunk://#diff-95ad0d9398916c44ab94e1968f74697a0ec30935b3bc283b894ff1e70cfc3773L172-R190))

### Project Metadata Actions:
* Introduced new actions in `ProjectMetaAction` for allowing project switching, restricting to allowed plugins, and managing allowed plugins. These actions include tooltips, completers, and dynamic model updates for better user interaction. (`ManiVault/src/ProjectMetaAction.cpp`, [[1]](diffhunk://#diff-d32182674727a5e219c81be08ddd6f6c0a22ba29223b660d0c3c24ed91bc8379L30-R93) [[2]](diffhunk://#diff-d32182674727a5e219c81be08ddd6f6c0a22ba29223b660d0c3c24ed91bc8379R143-R145) [[3]](diffhunk://#diff-d32182674727a5e219c81be08ddd6f6c0a22ba29223b660d0c3c24ed91bc8379R164-L131)
* Updated `Project` class to integrate the new metadata actions, including reading and writing them to/from `QVariantMap`. Also added logic to enforce plugin creation restrictions based on the allowed plugins list. (`ManiVault/src/Project.cpp`, [[1]](diffhunk://#diff-c077753a7039c27eb28dae66c7a7743f258ca7c8080f864715525fab944825edR123-R125) [[2]](diffhunk://#diff-c077753a7039c27eb28dae66c7a7743f258ca7c8080f864715525fab944825edR143-R149) [[3]](diffhunk://#diff-c077753a7039c27eb28dae66c7a7743f258ca7c8080f864715525fab944825edR167-R169)

### `StringsAction` Enhancements:
* Added support for managing locked strings and emitting corresponding signals when they change. (`ManiVault/src/actions/StringsAction.cpp`, [ManiVault/src/actions/StringsAction.cppR75-R89](diffhunk://#diff-1371767584bf7205692f30868e4101cffc9a4734960f44db139d6f09b8c22992R75-R89))
* Introduced a new method `addStrings` to add multiple strings at once, with an option to allow or prevent duplication. (`ManiVault/src/actions/StringsAction.cpp`, [ManiVault/src/actions/StringsAction.cppR163-R192](diffhunk://#diff-1371767584bf7205692f30868e4101cffc9a4734960f44db139d6f09b8c22992R163-R192))

### Codebase Improvements:
* Refactored and cleaned up the `ProjectMetaAction` class by removing the unused `initialize` method and improving the organization of actions and tooltips. (`ManiVault/src/ProjectMetaAction.cpp`, [[1]](diffhunk://#diff-d32182674727a5e219c81be08ddd6f6c0a22ba29223b660d0c3c24ed91bc8379R164-L131); `ManiVault/src/ProjectMetaAction.h`, [[2]](diffhunk://#diff-cbf27e79fa8765e496bdc34a479a7519ba0a9a45db99bfb470d4b21a8d59bc92L67-L71) [[3]](diffhunk://#diff-cbf27e79fa8765e496bdc34a479a7519ba0a9a45db99bfb470d4b21a8d59bc92R84-R86)
* Added missing includes in `ProjectMetaAction.cpp` to ensure proper integration with other components. (`ManiVault/src/ProjectMetaAction.cpp`, [ManiVault/src/ProjectMetaAction.cppR7-R10](diffhunk://#diff-d32182674727a5e219c81be08ddd6f6c0a22ba29223b660d0c3c24ed91bc8379R7-R10))

These changes enhance the flexibility, usability, and maintainability of the `ManiVault` project, particularly in the areas of plugin management and project configuration.