### PR TITLE
Add web widget accessors

### DIFF
--- a/ManiVault/src/widgets/WebWidget.cpp
+++ b/ManiVault/src/widgets/WebWidget.cpp
@@ -95,22 +95,30 @@ void WebWidget::onJsBridgeIsAvailable()
     _communicationAvailable = true;
 
     emit communicationBridgeReady();
-    if (_webPageLoaded)
-        emit webPageFullyLoaded();
+
+    if (_communicationAvailable && _webPageLoaded) {
+        emit fullyInitialized();
+    }
 }
 
 void WebWidget::onWebPageLoaded(bool ok)
 {
-    if (ok)
+    _webPageLoaded = ok;
+
+    if (_webPageLoaded)
     {
         qDebug() << "WebWidget: Web page finished loading.";
-        _webPageLoaded = true;
 
         if (_communicationAvailable)
             emit webPageFullyLoaded();
     }
-    else
+    else {
         qWarning() << "WebWidget: Web page failed to load properly.";
+    }
+
+    if (_communicationAvailable && _webPageLoaded) {
+        emit fullyInitialized();
+    }
 }
 
 } // namespace gui

--- a/ManiVault/src/widgets/WebWidget.cpp
+++ b/ManiVault/src/widgets/WebWidget.cpp
@@ -9,7 +9,7 @@
 #include <QWebEngineView>
 #include <QWebEnginePage>
 #include <QWebChannel>
-
+#include <QDebug>
 #include <QVBoxLayout>
 
 #include <cassert>
@@ -19,20 +19,9 @@ namespace mv
 namespace gui
 {
 
-WebWidget::WebWidget() :
-    _webView(nullptr),
-    _communicationChannel(nullptr),
-    _webCommunicationObject(nullptr),
-    _css(),
-    _communicationAvailable(false),
-    _webPageLoaded(false)
+void WebCommunicationObject::js_debug(const QString& text)
 {
-
-}
-
-WebWidget::~WebWidget()
-{
-
+    qDebug() << "WebWidget Debug Info: " << text;
 }
 
 void WebWidget::init(WebCommunicationObject* communicationObject)
@@ -82,11 +71,6 @@ void WebWidget::setPage(QString htmlPath, QString basePath)
 void WebWidget::registerFunctions()
 {
     _communicationChannel->registerObject("QtBridge", _webCommunicationObject);
-}
-
-void WebWidget::js_debug(QString text)
-{
-    qDebug() << "WebWidget Debug Info: " << text;
 }
 
 void WebWidget::onJsBridgeIsAvailable()

--- a/ManiVault/src/widgets/WebWidget.cpp
+++ b/ManiVault/src/widgets/WebWidget.cpp
@@ -39,7 +39,8 @@ void WebWidget::init(WebCommunicationObject* communicationObject)
 {
     _webCommunicationObject = communicationObject;
     connect(_webCommunicationObject, &WebCommunicationObject::notifyJsBridgeIsAvailable, this, &WebWidget::onJsBridgeIsAvailable);
-    // DEPRECATED, to be removed in any release after 1.0
+
+    // DEPRECATED, to be removed in any release after 2.0
     connect(_webCommunicationObject, &WebCommunicationObject::notifyJsBridgeIsAvailable, this, &WebWidget::initWebPage);
 
     _webView = new QWebEngineView();

--- a/ManiVault/src/widgets/WebWidget.h
+++ b/ManiVault/src/widgets/WebWidget.h
@@ -55,6 +55,9 @@ public:
     QWebEnginePage* getPage();
     void setPage(QString htmlPath, QString basePath);
 
+    bool isCommunicationAvailable() const { return _communicationAvailable; }
+    bool isWebPageLoaded() const { return _webPageLoaded; }
+
 signals:
     void communicationBridgeReady();
     void webPageFullyLoaded();

--- a/ManiVault/src/widgets/WebWidget.h
+++ b/ManiVault/src/widgets/WebWidget.h
@@ -57,10 +57,14 @@ public:
 
     bool isCommunicationAvailable() const { return _communicationAvailable; }
     bool isWebPageLoaded() const { return _webPageLoaded; }
+    bool isInitialized() const {
+        return isWebPageLoaded() && isCommunicationAvailable();
+    };
 
 signals:
     void communicationBridgeReady();
     void webPageFullyLoaded();
+    void fullyInitialized();
 
 protected:
     void registerFunctions();

--- a/ManiVault/src/widgets/WebWidget.h
+++ b/ManiVault/src/widgets/WebWidget.h
@@ -8,8 +8,8 @@
 
 #include <QWidget>
 
+#include <QString>
 #include <QObject>
-#include <QDebug>
 
 class QWebEngineView;
 class QWebEnginePage;
@@ -24,17 +24,11 @@ class CORE_EXPORT WebCommunicationObject : public QObject
 {
     Q_OBJECT
 
-public:
-
-
 signals:
     void notifyJsBridgeIsAvailable();
 
 public slots:
-    void js_debug(QString message)
-    {
-        qDebug() << "Javascript Debug Info: " << message;
-    }
+    void js_debug(const QString& message);
 
     void js_available()
     {
@@ -46,14 +40,13 @@ class CORE_EXPORT WebWidget : public QWidget
 {
     Q_OBJECT
 public:
-    WebWidget();
-    ~WebWidget() override;
 
     void init(WebCommunicationObject* communicationObject);
 
+    void setPage(QString htmlPath, QString basePath);
+
     QWebEngineView* getView();
     QWebEnginePage* getPage();
-    void setPage(QString htmlPath, QString basePath);
 
     bool isCommunicationAvailable() const { return _communicationAvailable; }
     bool isWebPageLoaded() const { return _webPageLoaded; }
@@ -69,11 +62,8 @@ signals:
 protected:
     void registerFunctions();
 
-public slots:
-    void js_debug(QString text);
-
 protected slots:
-    [[deprecated("Will be removed in 2.0. Connect to the communicationBridgeReady() signal instead.")]]
+    [[deprecated("Will be removed in 2.0. Connect to the communicationBridgeReady() or fullyInitialized() signal instead.")]]
     virtual void initWebPage() {}
 
 private slots:
@@ -81,15 +71,12 @@ private slots:
     void onWebPageLoaded(bool ok);
 
 private:
-    QWebEngineView* _webView;
-    QWebChannel* _communicationChannel;
-
-    WebCommunicationObject* _webCommunicationObject;
-
-    QString _css;
-
-    bool _communicationAvailable;
-    bool _webPageLoaded;
+    QWebEngineView*         _webView = nullptr;
+    QWebChannel*            _communicationChannel = nullptr;
+    WebCommunicationObject* _webCommunicationObject = nullptr;
+    QString                 _css = {};
+    bool                    _communicationAvailable = false;
+    bool                    _webPageLoaded = false;
 };
 
 } // namespace gui

--- a/ManiVault/src/widgets/WebWidget.h
+++ b/ManiVault/src/widgets/WebWidget.h
@@ -66,7 +66,7 @@ public slots:
     void js_debug(QString text);
 
 protected slots:
-    /** DEPRECATED, please connect to the communicationBridgeReady() signal instead. */
+    [[deprecated("Will be removed in 2.0. Connect to the communicationBridgeReady() signal instead.")]]
     virtual void initWebPage() {}
 
 private slots:


### PR DESCRIPTION
Currently classes derived from `WebWidget` cannot access the private members `_communicationAvailable` and `_webPageLoaded`.

Added:
```cpp
public:
    bool isCommunicationAvailable();
    bool isWebPageLoaded();
    bool isInitialized();
    
signals:
    void fullyInitialized();
```

Changed:
- `onJsBridgeIsAvailable` does not emit `webPageFullyLoaded` if webpage was fully loaded. This signal is already sent from `onWebPageLoaded`

Removed:
- `WebWidget::js_debug` - this function seems to be a duplicate of `WebCommunicationObject::js_debug` which is the slot that is actually called from the JS side