### PR TITLE
Feature/only last major font awesome release

### DIFF
--- a/ManiVault/cmake/DownloadFontAwesome.cmake
+++ b/ManiVault/cmake/DownloadFontAwesome.cmake
@@ -2,10 +2,8 @@
 
 set(FONT_AWESOME_VERSIONS 
     5.14.0
-    6.4.0
-    6.5.0
     6.7.2
-	7.0.0
+    7.0.0
 )
 
 set(TEMP_DIR "${CMAKE_BINARY_DIR}/Font-Awesome-Resources")

--- a/ManiVault/res/ResourcesCore.qrc
+++ b/ManiVault/res/ResourcesCore.qrc
@@ -8,18 +8,14 @@
 		<file alias="FontAwesomeRegular-5.14.0.otf">iconfonts/FontAwesomeRegular-5.14.0.otf</file>
 		<file alias="FontAwesomeSolid-5.14.0.otf">iconfonts/FontAwesomeSolid-5.14.0.otf</file>
 		<file alias="FontAwesome-5.14.0.json">iconfonts/FontAwesome-5.14.0.json</file>
-		<file alias="FontAwesomeBrandsRegular-6.4.0.otf">iconfonts/FontAwesomeBrandsRegular-6.4.0.otf</file>
-		<file alias="FontAwesomeRegular-6.4.0.otf">iconfonts/FontAwesomeRegular-6.4.0.otf</file>
-		<file alias="FontAwesomeSolid-6.4.0.otf">iconfonts/FontAwesomeSolid-6.4.0.otf</file>
-		<file alias="FontAwesome-6.4.0.json">iconfonts/FontAwesome-6.4.0.json</file>
-		<file alias="FontAwesomeBrandsRegular-6.5.0.otf">iconfonts/FontAwesomeBrandsRegular-6.5.0.otf</file>
-		<file alias="FontAwesomeRegular-6.5.0.otf">iconfonts/FontAwesomeRegular-6.5.0.otf</file>
-		<file alias="FontAwesomeSolid-6.5.0.otf">iconfonts/FontAwesomeSolid-6.5.0.otf</file>
-		<file alias="FontAwesome-6.5.0.json">iconfonts/FontAwesome-6.5.0.json</file>
 		<file alias="FontAwesomeBrandsRegular-6.7.2.otf">iconfonts/FontAwesomeBrandsRegular-6.7.2.otf</file>
 		<file alias="FontAwesomeRegular-6.7.2.otf">iconfonts/FontAwesomeRegular-6.7.2.otf</file>
 		<file alias="FontAwesomeSolid-6.7.2.otf">iconfonts/FontAwesomeSolid-6.7.2.otf</file>
 		<file alias="FontAwesome-6.7.2.json">iconfonts/FontAwesome-6.7.2.json</file>
+		<file alias="FontAwesomeBrandsRegular-7.0.0.otf">iconfonts/FontAwesomeBrandsRegular-6.7.2.otf</file>
+		<file alias="FontAwesomeRegular-7.0.0.otf">iconfonts/FontAwesomeRegular-7.0.0.otf</file>
+		<file alias="FontAwesomeSolid-7.0.0.otf">iconfonts/FontAwesomeSolid-7.0.0.otf</file>
+		<file alias="FontAwesome-7.0.0.json">iconfonts/FontAwesome-7.0.0.json</file>
 	</qresource>
     <qresource prefix="/Icons">
         <file alias="AppIcon32">icons/AppIcon32.png</file>


### PR DESCRIPTION
I suggest we should only use the last major version of FontAwesome releases:
- Let's remove `6.4.0` and `6.5.0`, since we already use `6.7.2`

Handling multiple version takes time both during application startup and build setup. We use multiple versions in the first place, since some newer versions might remove icons that were available in previous versions and could be used in plugins. But minor versions don't seem to remove icons. Below is a script that compares several versions.

Additionally, this PR updates `res/ResourcesCore.qrc` with version `7.0.0`.

```python
import json

def load_json_file(path):
    with open(path, 'r') as f:
        return json.load(f)

def compare_top_level_keys(file1_path, file2_path):
    json1 = load_json_file(file1_path)
    json2 = load_json_file(file2_path)

    keys1 = set(json1.keys())
    keys2 = set(json2.keys())

    missing_keys = keys1 - keys2

    if missing_keys:
        print(f"Number of missing keys in second file: {len(missing_keys)}")
        return False
    else:
        print("All top-level keys from the first file are present in the second file.")
        return True

compare_top_level_keys(
    './build/Font-Awesome-Resources/Font-Awesome-6.5.0/free/metadata/icons.json',
    './build/Font-Awesome-Resources/Font-Awesome-6.7.2/metadata/icons.json'
)

# > All top-level keys from the first file are present in the second file.

compare_top_level_keys(
    './build/Font-Awesome-Resources/Font-Awesome-6.4.0/metadata/icons.json',
    './build/Font-Awesome-Resources/Font-Awesome-6.7.2/metadata/icons.json'
)

# > All top-level keys from the first file are present in the second file.

compare_top_level_keys(
    './build/Font-Awesome-Resources/Font-Awesome-5.14.0/metadata/icons.json',
    './build/Font-Awesome-Resources/Font-Awesome-6.7.2/metadata/icons.json'
)

# > Number of missing keys in second file: 384
```