### PR TITLE
Fix simultaneous project launch crash (#1031)

### DIFF
--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -359,6 +359,21 @@ void ProjectManager::openProject(QString filePath /*= ""*/, bool importDataOnly 
         //        startupProjectMetaAction->getSplashScreenAction().getOpenAction().trigger();
         //}
 
+        if (hasProject() && getCurrentProject()->getFilePath() == filePath) {
+            qCritical() << "Project is already open";
+            return;
+        }
+
+        if (isImportingProject()) {
+            qCritical() << "Cannot open project while importing another project";
+            return;
+        }
+
+        if (isOpeningProject()) {
+            qCritical() << "Cannot open project while another project is being opened";
+            return;
+        }
+
         const auto scopedState = ScopedState(this, State::OpeningProject);
 
         if (QFileInfo(filePath).isDir())


### PR DESCRIPTION
* Do not allow opening a project while importin or opening another project

* Als do not open when project is already open