### PR TITLE
Emit `actionsChanged` after removing an action from a `GroupAction`

### DIFF
--- a/ManiVault/src/actions/GroupAction.cpp
+++ b/ManiVault/src/actions/GroupAction.cpp
@@ -171,6 +171,8 @@ void GroupAction::removeAction(WidgetAction* action)
 
     disconnect(action, &WidgetAction::configurationFlagToggled, this, nullptr);
     disconnect(action, &WidgetAction::sortIndexChanged, this, nullptr);
+
+    emit actionsChanged(getActions());
 }
 
 WidgetActions GroupAction::getActions()


### PR DESCRIPTION
We should emit `actionsChanged` after removing an action from a `GroupAction`.

This is already done in other similar places like [`ToolbarAction::removeAction`](https://github.com/ManiVaultStudio/core/blob/e7c455c22ab8aa7f50571c596d3e1ef4ad4dc8c2/ManiVault/src/actions/ToolbarAction.cpp#L46) and mirrors the behavior of [`GroupAction::addAction`](https://github.com/ManiVaultStudio/core/blob/e7c455c22ab8aa7f50571c596d3e1ef4ad4dc8c2/ManiVault/src/actions/GroupAction.cpp#L118).

I ran into an issue with this [in this PR](https://github.com/ManiVaultStudio/SparseH5DataAccessPlugin/pull/9) where I add and remove `OptionActions` from a `GroupAction`. Adding them was working fine, but upon removal, I'd run into null pointer de-referencing problems.