### PR TITLE
Fix zoom percentage action linkage crash

### DIFF
--- a/ManiVault/src/actions/DecimalAction.cpp
+++ b/ManiVault/src/actions/DecimalAction.cpp
@@ -54,6 +54,16 @@ void DecimalAction::setSingleStep(float singleStep)
     emit singleStepChanged(_singleStep);
 }
 
+WidgetAction* DecimalAction::getPublicCopy() const
+{
+    if (auto publicCopy = dynamic_cast<NumericalAction<float>*>(WidgetAction::getPublicCopy())) {
+        publicCopy->setRange(getRange());
+        return publicCopy;
+    }
+
+    return nullptr;
+}
+
 void DecimalAction::connectToPublicAction(WidgetAction* publicAction, bool recursive)
 {
     auto publicDecimalAction = dynamic_cast<DecimalAction*>(publicAction);

--- a/ManiVault/src/actions/DecimalAction.cpp
+++ b/ManiVault/src/actions/DecimalAction.cpp
@@ -112,7 +112,7 @@ void DecimalAction::fromVariantMap(const QVariantMap& variantMap)
 
     setValue(static_cast<float>(variantMap["Value"].toDouble()));
 
-    if (isPublic()) {
+    if (variantMap.contains("IsPublic") && variantMap["IsPublic"].toBool()) {
         if (variantMap.contains("Minimum"))
 			setMinimum(static_cast<float>(variantMap["Minimum"].toDouble()));
 

--- a/ManiVault/src/actions/DecimalAction.cpp
+++ b/ManiVault/src/actions/DecimalAction.cpp
@@ -107,7 +107,7 @@ void DecimalAction::fromVariantMap(const QVariantMap& variantMap)
 			setMinimum(static_cast<float>(variantMap["Minimum"].toDouble()));
 
         if (variantMap.contains("Maximum"))
-            setMinimum(static_cast<float>(variantMap["Maximum"].toDouble()));
+            setMaximum(static_cast<float>(variantMap["Maximum"].toDouble()));
     }
 }
 

--- a/ManiVault/src/actions/DecimalAction.cpp
+++ b/ManiVault/src/actions/DecimalAction.cpp
@@ -101,6 +101,14 @@ void DecimalAction::fromVariantMap(const QVariantMap& variantMap)
     variantMapMustContain(variantMap, "Value");
 
     setValue(static_cast<float>(variantMap["Value"].toDouble()));
+
+    if (isPublic()) {
+        if (variantMap.contains("Minimum"))
+			setMinimum(static_cast<float>(variantMap["Minimum"].toDouble()));
+
+        if (variantMap.contains("Maximum"))
+            setMinimum(static_cast<float>(variantMap["Maximum"].toDouble()));
+    }
 }
 
 QVariantMap DecimalAction::toVariantMap() const
@@ -110,6 +118,13 @@ QVariantMap DecimalAction::toVariantMap() const
     variantMap.insert({
         { "Value", QVariant::fromValue(static_cast<double>(getValue())) }
     });
+
+    if (isPublic()) {
+        variantMap.insert({
+			{ "Minimum", QVariant::fromValue(static_cast<double>(getMinimum())) },
+            { "Maximum", QVariant::fromValue(static_cast<double>(getMaximum())) }
+        });
+    }
 
     return variantMap;
 }

--- a/ManiVault/src/actions/DecimalAction.h
+++ b/ManiVault/src/actions/DecimalAction.h
@@ -116,6 +116,12 @@ public:
      */
     void setSingleStep(float singleStep);
 
+    /**
+     * Get public copy of the action (other compatible actions can connect to it)
+     * @return Pointer to public copy of the action
+     */
+    WidgetAction* getPublicCopy() const override;
+
 protected: // Linking
 
     /**

--- a/ManiVault/src/actions/DecimalAction.h
+++ b/ManiVault/src/actions/DecimalAction.h
@@ -103,6 +103,7 @@ public:
      * @param minimum Minimum value
      * @param maximum Maximum value
      * @param value Value
+     * @param numberOfDecimals Number of decimals
      */
     void initialize(float minimum, float maximum, float value, std::uint32_t numberOfDecimals = INIT_NUMBER_OF_DECIMALS);
 

--- a/ManiVault/src/actions/IntegralAction.cpp
+++ b/ManiVault/src/actions/IntegralAction.cpp
@@ -91,7 +91,7 @@ void IntegralAction::fromVariantMap(const QVariantMap& variantMap)
 
     setValue(variantMap["Value"].toInt());
 
-    if (isPublic()) {
+    if (variantMap.contains("IsPublic") && variantMap["IsPublic"].toBool()) {
         if (variantMap.contains("Minimum"))
             setMinimum(variantMap["Minimum"].toInt());
 

--- a/ManiVault/src/actions/IntegralAction.cpp
+++ b/ManiVault/src/actions/IntegralAction.cpp
@@ -80,6 +80,14 @@ void IntegralAction::fromVariantMap(const QVariantMap& variantMap)
     variantMapMustContain(variantMap, "Value");
 
     setValue(variantMap["Value"].toInt());
+
+    if (isPublic()) {
+        if (variantMap.contains("Minimum"))
+            setMinimum(variantMap["Minimum"].toInt());
+
+        if (variantMap.contains("Maximum"))
+            setMaximum(variantMap["Maximum"].toInt());
+    }
 }
 
 QVariantMap IntegralAction::toVariantMap() const
@@ -89,6 +97,13 @@ QVariantMap IntegralAction::toVariantMap() const
     variantMap.insert({
         { "Value", QVariant::fromValue(getValue()) }
     });
+
+    if (isPublic()) {
+        variantMap.insert({
+            { "Minimum", QVariant::fromValue(getMinimum()) },
+            { "Maximum", QVariant::fromValue(getMaximum()) }
+        });
+    }
 
     return variantMap;
 }

--- a/ManiVault/src/actions/IntegralAction.cpp
+++ b/ManiVault/src/actions/IntegralAction.cpp
@@ -33,6 +33,16 @@ void IntegralAction::initialize(std::int32_t minimum, std::int32_t maximum, std:
     _valueChanged();
 }
 
+WidgetAction* IntegralAction::getPublicCopy() const
+{
+    if (auto publicCopy = dynamic_cast<NumericalAction<int>*>(WidgetAction::getPublicCopy())) {
+        publicCopy->setRange(getRange());
+        return publicCopy;
+    }
+        
+	return nullptr;
+}
+
 void IntegralAction::connectToPublicAction(WidgetAction* publicAction, bool recursive)
 {
     auto publicIntegralAction = dynamic_cast<IntegralAction*>(publicAction);

--- a/ManiVault/src/actions/IntegralAction.h
+++ b/ManiVault/src/actions/IntegralAction.h
@@ -105,6 +105,12 @@ public:
      */
     void initialize(std::int32_t minimum, std::int32_t maximum, std::int32_t value);
 
+    /**
+     * Get public copy of the action (other compatible actions can connect to it)
+     * @return Pointer to public copy of the action
+     */
+    WidgetAction* getPublicCopy() const override;
+
 protected: // Linking
 
     /**

--- a/ManiVault/src/actions/NavigationAction.cpp
+++ b/ManiVault/src/actions/NavigationAction.cpp
@@ -112,6 +112,7 @@ void NavigationAction::fromVariantMap(const QVariantMap& variantMap)
 
     _zoomCenterAction.fromParentVariantMap(variantMap);
     _zoomFactorAction.fromParentVariantMap(variantMap);
+    _zoomPercentageAction.fromParentVariantMap(variantMap);
     _zoomMarginAction.fromParentVariantMap(variantMap, true);
 }
 
@@ -121,6 +122,7 @@ QVariantMap NavigationAction::toVariantMap() const
 
     _zoomCenterAction.insertIntoVariantMap(variantMap);
     _zoomFactorAction.insertIntoVariantMap(variantMap);
+    _zoomPercentageAction.insertIntoVariantMap(variantMap);
     _zoomMarginAction.insertIntoVariantMap(variantMap);
 
     return variantMap;

--- a/ManiVault/src/actions/NavigationAction.cpp
+++ b/ManiVault/src/actions/NavigationAction.cpp
@@ -45,6 +45,7 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
     _freezeNavigation.setToolTip("Freeze the navigation");
 
     _zoomPercentageAction.setOverrideSizeHint(QSize(300, 0));
+    _zoomPercentageAction.setConnectionPermissionsToAll();
 
     _zoomOutAction.setIconByName("search-minus");
     _zoomInAction.setIconByName("search-plus");
@@ -66,6 +67,7 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
     _zoomCenterAction.setIconByName("ruler");
     _zoomCenterAction.setDefaultWidgetFlags(GroupAction::WidgetFlag::Vertical);
     _zoomCenterAction.setPopupSizeHint(QSize(250, 0));
+    _zoomCenterAction.setConnectionPermissionsToAll(true);
 
     _zoomCenterAction.getXAction().setDefaultWidgetFlags(DecimalAction::WidgetFlag::SpinBox);
     _zoomCenterAction.getYAction().setDefaultWidgetFlags(DecimalAction::WidgetFlag::SpinBox);

--- a/ManiVault/src/actions/WidgetAction.h
+++ b/ManiVault/src/actions/WidgetAction.h
@@ -619,7 +619,7 @@ public:
      * Get public copy of the action (other compatible actions can connect to it)
      * @return Pointer to public copy of the action
      */
-    WidgetAction* getPublicCopy() const;
+    virtual WidgetAction* getPublicCopy() const;
 
     /**
      * Get connected actions

--- a/ManiVault/src/renderers/Navigator2D.cpp
+++ b/ManiVault/src/renderers/Navigator2D.cpp
@@ -439,10 +439,8 @@ void Navigator2D::setZoomFactor(float zoomFactor)
     if (getNavigationAction().getFreezeNavigation().isChecked())
         return;
 
-    //if (util::almostEqual(zoomFactor, _zoomFactor))
-    //    return;
-
-    qDebug() << __FUNCTION__ << zoomFactor;
+    if (util::almostEqual(zoomFactor, _zoomFactor))
+		return;
 
     const auto previousZoomFactor = _zoomFactor;
 
@@ -481,8 +479,6 @@ void Navigator2D::setZoomPercentage(float zoomPercentage)
 
     if (util::almostEqual(getZoomPercentage(), zoomPercentage))
         return;
-
-	qDebug() << __FUNCTION__ << zoomPercentage;
 
     beginZooming();
     {

--- a/ManiVault/src/renderers/Navigator2D.cpp
+++ b/ManiVault/src/renderers/Navigator2D.cpp
@@ -479,7 +479,7 @@ void Navigator2D::setZoomPercentage(float zoomPercentage)
     if (getNavigationAction().getFreezeNavigation().isChecked())
         return;
 
-    if (util::almostEqual(getZoomPercentage(), zoomPercentage, 0.01))
+    if (util::almostEqual(getZoomPercentage(), zoomPercentage))
         return;
 
 	qDebug() << __FUNCTION__ << zoomPercentage;

--- a/ManiVault/src/renderers/Navigator2D.cpp
+++ b/ManiVault/src/renderers/Navigator2D.cpp
@@ -439,8 +439,10 @@ void Navigator2D::setZoomFactor(float zoomFactor)
     if (getNavigationAction().getFreezeNavigation().isChecked())
         return;
 
-    if (zoomFactor == _zoomFactor)
-        return;
+    //if (util::almostEqual(zoomFactor, _zoomFactor))
+    //    return;
+
+    qDebug() << __FUNCTION__ << zoomFactor;
 
     const auto previousZoomFactor = _zoomFactor;
 
@@ -476,6 +478,11 @@ void Navigator2D::setZoomPercentage(float zoomPercentage)
 {
     if (getNavigationAction().getFreezeNavigation().isChecked())
         return;
+
+    if (util::almostEqual(getZoomPercentage(), zoomPercentage, 0.01))
+        return;
+
+	qDebug() << __FUNCTION__ << zoomPercentage;
 
     beginZooming();
     {

--- a/ManiVault/src/util/Math.h
+++ b/ManiVault/src/util/Math.h
@@ -15,6 +15,17 @@ namespace mv::util
 
 CORE_EXPORT float lerp(float v0, float v1, float t);
 
+/**
+ * Checks whether two floating point numbers are almost equal
+ * @param a Floating point number to compare
+ * @param b Floating point number to compare with
+ * @param eps Tolerance
+ * @return Boolean determining whether the two floating point numbers are almost equal
+ */
+inline bool almostEqual(double a, double b, double eps = 1e-9) {
+    return std::fabs(a - b) < eps;
+}
+
 inline bool arePointsEqual(const QPointF& point1, const QPointF& point2, qreal epsilon = 1e-5) {
     return qAbs(point1.x() - point2.x()) < epsilon && qAbs(point1.y() - point2.y()) < epsilon;
 }

--- a/ManiVault/src/util/Math.h
+++ b/ManiVault/src/util/Math.h
@@ -13,6 +13,13 @@
 namespace mv::util
 {
 
+/**
+ * Linearly interpolates between two values v0 and v1 by t
+ * @param v0 Start value
+ * @param v1 End value
+ * @param t Interpolation factor in the range [0, 1]
+ * @return Interpolated value
+ */
 CORE_EXPORT float lerp(float v0, float v1, float t);
 
 /**
@@ -26,14 +33,35 @@ inline bool almostEqual(double a, double b, double eps = 1e-9) {
     return std::fabs(a - b) < eps;
 }
 
+/**
+ * Checks whether two points are almost equal
+ * @param point1 Point to compare
+ * @param point2 Point to compare with
+ * @param epsilon Tolerance
+ * @return Boolean determining whether the two points are almost equal
+ */
 inline bool arePointsEqual(const QPointF& point1, const QPointF& point2, qreal epsilon = 1e-5) {
     return qAbs(point1.x() - point2.x()) < epsilon && qAbs(point1.y() - point2.y()) < epsilon;
 }
 
+/**
+ * Checks whether two sizes are almost equal
+ * @param size1 Size to compare
+ * @param size2 Size to compare with
+ * @param epsilon Tolerance
+ * @return Boolean determining whether the two sizes are almost equal
+ */
 inline bool areSizesEqual(const QSizeF& size1, const QSizeF& size2, qreal epsilon = 1e-5) {
     return qAbs(size1.width() - size2.width()) < epsilon && qAbs(size1.height() - size2.height()) < epsilon;
 }
 
+/**
+ * Checks whether two rectangles are almost equal
+ * @param rect1 Rectangle to compare
+ * @param rect2 Rectangle to compare with
+ * @param epsilon Tolerance
+ * @return Boolean determining whether the two rectangles are almost equal
+ */
 inline bool areRectanglesEqual(const QRectF& rect1, const QRectF& rect2, qreal epsilon = 1e-5) {
     return arePointsEqual(rect1.topLeft(), rect2.topLeft()) && areSizesEqual(rect1.size(), rect2.size());
 }

--- a/ManiVault/src/util/Math.h
+++ b/ManiVault/src/util/Math.h
@@ -23,14 +23,16 @@ namespace mv::util
 CORE_EXPORT float lerp(float v0, float v1, float t);
 
 /**
- * Checks whether two floating point numbers are almost equal
- * @param a Floating point number to compare
- * @param b Floating point number to compare with
- * @param eps Tolerance
- * @return Boolean determining whether the two floating point numbers are almost equal
+ * Checks whether two numerical values are almost equal
+ * @param a Numerical value to compare
+ * @param b Numerical value to compare with
+ * @param relativeTolerance Relative tolerance
+ * @param absoluteTolerance Absolute tolerance
+ * @return Boolean determining whether the numerical values are almost equal
  */
-inline bool almostEqual(double a, double b, double eps = 1e-9) {
-    return std::fabs(a - b) < eps;
+template <typename T>
+bool almostEqual(T a, T b, T relativeTolerance = T(1e-6), T absoluteTolerance = T(1e-12)) {
+    return std::fabs(a - b) <= std::max(relativeTolerance * std::max(std::fabs(a), std::fabs(b)), absoluteTolerance);
 }
 
 /**


### PR DESCRIPTION
This pull request introduces several improvements that fix issues with linking zoom percentage actions. Numerical issues led to infinite action update loops. 

### Numerical Actions: Public Copy and Serialization

* Added and overridden the `getPublicCopy()` method in both `DecimalAction` and `IntegralAction` to ensure that public copies correctly propagate range information. This allows other compatible actions to connect to these public copies reliably. (`ManiVault/src/actions/DecimalAction.cpp`, `ManiVault/src/actions/IntegralAction.cpp`, `ManiVault/src/actions/WidgetAction.h`, `ManiVault/src/actions/DecimalAction.h`, `ManiVault/src/actions/IntegralAction.h`) [[1]](diffhunk://#diff-4ae23f6202e1793b3d56593dcf250e2b81ed567ec19dfd557ccf2973cfd87bceR57-R66) [[2]](diffhunk://#diff-99008bdbda509c1558f982fa32b50cf5a92d816fb685eb4328aca83e5bf96e24R36-R45) [[3]](diffhunk://#diff-2904bad02ab44ea022df6f0ba77b117aa88c1afc22f7250ea8b718f181d4cb19L622-R622) [[4]](diffhunk://#diff-c5812cdceb9deb1100545aa1702e9bb7e70e357d88f704bde46da0354507c26fR119-R124) [[5]](diffhunk://#diff-2cd79691fa940304bd03c404bc19abbd4d5694f3a6a05818c24e49d7d0752d5bR108-R113)
* Updated serialization (`toVariantMap` and `fromVariantMap`) for both `DecimalAction` and `IntegralAction` to include `Minimum` and `Maximum` values when the action is public, ensuring consistent state transfer. (`ManiVault/src/actions/DecimalAction.cpp`, `ManiVault/src/actions/IntegralAction.cpp`) [[1]](diffhunk://#diff-4ae23f6202e1793b3d56593dcf250e2b81ed567ec19dfd557ccf2973cfd87bceR114-R121) [[2]](diffhunk://#diff-4ae23f6202e1793b3d56593dcf250e2b81ed567ec19dfd557ccf2973cfd87bceR132-R138) [[3]](diffhunk://#diff-99008bdbda509c1558f982fa32b50cf5a92d816fb685eb4328aca83e5bf96e24R93-R100) [[4]](diffhunk://#diff-99008bdbda509c1558f982fa32b50cf5a92d816fb685eb4328aca83e5bf96e24R111-R117)

### Navigation Actions

* Improved the `NavigationAction` class by ensuring that `zoomPercentageAction` and `zoomCenterAction` have connection permissions set to all, and updated their serialization/deserialization to include these actions. (`ManiVault/src/actions/NavigationAction.cpp`) [[1]](diffhunk://#diff-82d6a09909d67cb60a6ac0c259c229767f5c79ae1a7b730ed04a47f3772bf2ddR48) [[2]](diffhunk://#diff-82d6a09909d67cb60a6ac0c259c229767f5c79ae1a7b730ed04a47f3772bf2ddR70) [[3]](diffhunk://#diff-82d6a09909d67cb60a6ac0c259c229767f5c79ae1a7b730ed04a47f3772bf2ddR117) [[4]](diffhunk://#diff-82d6a09909d67cb60a6ac0c259c229767f5c79ae1a7b730ed04a47f3772bf2ddR127)

### Utility Functions

* Added a generic `almostEqual` template function to `Math.h` for robust floating-point comparisons, along with documentation for interpolation and equality functions for points, sizes, and rectangles. (`ManiVault/src/util/Math.h`)

### Zoom Logic

* Updated zoom logic in `Navigator2D` to use the new `almostEqual` utility for more reliable floating-point comparisons and added debug output for zoom changes. (`ManiVault/src/renderers/Navigator2D.cpp`) [[1]](diffhunk://#diff-d8e6069fc0c02fb7d05ffab2d33b629355d343fbdd7b99794b2263d5453259b5L442-R445) [[2]](diffhunk://#diff-d8e6069fc0c02fb7d05ffab2d33b629355d343fbdd7b99794b2263d5453259b5R482-R486)

### API Documentation

* Added documentation for parameters in method signatures, clarifying usage (e.g., `numberOfDecimals` in `DecimalAction::initialize`). (`ManiVault/src/actions/DecimalAction.h`)