### PR TITLE
Proper size calculation for task-based notifications

### DIFF
--- a/ManiVault/src/util/Notification.cpp
+++ b/ManiVault/src/util/Notification.cpp
@@ -80,11 +80,10 @@ Notification::Notification(const QString& title, const QString& description, con
 
     mainLayout->setContentsMargins(0, 0, 0, 0);
 
-    notificationWidget->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::MinimumExpanding);
     notificationWidget->setFixedWidth(fixedWidth);
     notificationWidget->setMinimumHeight(10);
     notificationWidget->setAutoFillBackground(true);
-    notificationWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
+    //notificationWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum); // Not entirely sure about this one, so leave it out for now
     notificationWidget->setAttribute(Qt::WA_TranslucentBackground);
 
     _iconLabel.setStyleSheet("padding: 3px;");
@@ -253,8 +252,15 @@ void Notification::updateMessageLabel()
 {
     _titleLabel.setText(QString("<b>%1</b>").arg(_title));
 
-    _messageLabel.setText(_description.toHtmlEscaped());
-    _messageLabel.setTextFormat(Qt::RichText);
+    if (_task.isNull()) {
+        _messageLabel.setTextFormat(Qt::RichText);
+        _messageLabel.setText(_description);
+        _messageLabel.adjustSize();
+        
+    } else {
+        _messageLabel.setText(" ");
+    }
+
     _messageLabel.adjustSize();
 }
 


### PR DESCRIPTION
This pull request makes adjustments to the notification widget's layout and message label handling in `Notification.cpp`. The main goals are to improve the display logic for notification messages and clarify widget sizing behavior.

**Notification message display logic:**

* Updated `updateMessageLabel()` to set the message label's text as rich text when no task is associated, and to display a blank space otherwise. This ensures proper formatting and prevents unwanted text from showing when a task is present.

**Widget sizing and layout:**

* Removed and commented out redundant or uncertain `setSizePolicy` calls on `notificationWidget` to avoid conflicting or unclear sizing behavior, relying instead on fixed width and minimum height settings.