### PR TITLE
Print project load time

### DIFF
--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -18,6 +18,7 @@
 
 #include <util/Exception.h>
 #include <util/Serialization.h>
+#include <util/Timer.h>
 
 #include <widgets/FileDialog.h>
 
@@ -353,6 +354,8 @@ void ProjectManager::newBlankProject()
 void ProjectManager::openProject(QString filePath /*= ""*/, bool importDataOnly /*= false*/, bool loadWorkspace /*= true*/)
 {
     Application::requestOverrideCursor(Qt::WaitCursor);
+
+    Timer openProjectTimer("Open project");
 
     try
     {


### PR DESCRIPTION
This pull request introduces a minor improvement to the `ProjectManager` module by adding performance instrumentation for project opening operations.

Performance monitoring:

* Added a `Timer` instance (`openProjectTimer`) to the beginning of the `openProject` method in `ProjectManager.cpp` to measure how long it takes to open a project.
* Included the `Timer` header (`#include <util/Timer.h>`) in `ProjectManager.cpp` to support the new timing functionality.…of scope