### PR TITLE
HTML foundation API for support HTML splash screen body

### DIFF
--- a/ManiVault/src/actions/SplashScreenAction.cpp
+++ b/ManiVault/src/actions/SplashScreenAction.cpp
@@ -87,6 +87,7 @@ SplashScreenAction::SplashScreenAction(QObject* parent, bool mayClose /*= false*
     _enabledAction(this, "Enable splash screen"),
     _projectImageAction(this, "Project Image", false),
     _affiliateLogosImageAction(this, "Affiliate Logos", false),
+    _htmlOverrideAction(this, "HTML Override"),
     _editAction(this, "Edit"),
     _openAction(this, "Open splash screen"),
     _closeAction(this, "Close splash screen"),
@@ -172,6 +173,14 @@ void SplashScreenAction::setMayCloseSplashScreenWidget(bool mayCloseSplashScreen
     _mayCloseSplashScreenWidget = mayCloseSplashScreenWidget;
 }
 
+QString SplashScreenAction::getHtmlBody() const
+{
+    if (!_htmlOverrideAction.getString().isEmpty())
+        return _htmlOverrideAction.getString();
+
+    return {};
+}
+
 ProjectMetaAction* SplashScreenAction::getProjectMetaAction()
 {
     return _projectMetaAction;
@@ -212,6 +221,7 @@ void SplashScreenAction::fromVariantMap(const QVariantMap& variantMap)
     _enabledAction.fromParentVariantMap(variantMap);
     _projectImageAction.fromParentVariantMap(variantMap);
     _affiliateLogosImageAction.fromParentVariantMap(variantMap);
+    _htmlOverrideAction.fromParentVariantMap(variantMap, true);
 }
 
 QVariantMap SplashScreenAction::toVariantMap() const
@@ -221,6 +231,7 @@ QVariantMap SplashScreenAction::toVariantMap() const
     _enabledAction.insertIntoVariantMap(variantMap);
     _projectImageAction.insertIntoVariantMap(variantMap);
     _affiliateLogosImageAction.insertIntoVariantMap(variantMap);
+    _htmlOverrideAction.insertIntoVariantMap(variantMap);
 
     return variantMap;
 }

--- a/ManiVault/src/actions/SplashScreenAction.h
+++ b/ManiVault/src/actions/SplashScreenAction.h
@@ -8,6 +8,7 @@
 #include "actions/TaskAction.h"
 #include "actions/ToggleAction.h"
 #include "actions/TriggerAction.h"
+#include "actions/StringAction.h"
 #include "actions/VerticalGroupAction.h"
 
 namespace mv {
@@ -149,6 +150,12 @@ public:
      */
     void setMayCloseSplashScreenWidget(bool mayCloseSplashScreenWidget);
 
+    /**
+     * Get HTML body
+     * @return HTML body, empty string if not available
+     */
+    QString getHtmlBody() const;
+
 public:
 
     /**
@@ -175,7 +182,7 @@ public: // Serialization
 
     /**
      * Load splash screen action from variant
-     * @param Variant representation of the project
+     * @param variantMap Variant representation of the project
      */
     void fromVariantMap(const QVariantMap& variantMap) override;
 
@@ -193,6 +200,7 @@ public: // Action getters
     const VerticalGroupAction& getEditAction() const { return _editAction; }
     const ImageAction& getProjectImageAction() const { return _projectImageAction; }
     const ImageAction& getAffiliateLogosImageAction() const { return _affiliateLogosImageAction; }
+    const StringAction& getHtmlOverrideAction() const { return _htmlOverrideAction; }
     const TaskAction& getTaskAction() const { return _taskAction; }
 
     ToggleAction& getEnabledAction() { return _enabledAction; }
@@ -201,6 +209,7 @@ public: // Action getters
     VerticalGroupAction& getEditAction() { return _editAction; }
     ImageAction& getProjectImageAction() { return _projectImageAction; }
     ImageAction& getAffiliateLogosImageAction() { return _affiliateLogosImageAction; }
+    StringAction& getHtmlOverrideAction() { return _htmlOverrideAction; }
     TaskAction& getTaskAction() { return _taskAction; }
 
 private:
@@ -209,6 +218,7 @@ private:
     ToggleAction                        _enabledAction;                 /** Action to setEnabled the splash screen on/off */
     ImageAction                         _projectImageAction;            /** Image action for the project image */
     ImageAction                         _affiliateLogosImageAction;     /** Image action for the affiliate logo's image */
+    StringAction                        _htmlOverrideAction;            /** String action for custom html content */
     VerticalGroupAction                 _editAction;                    /** Vertical group action for editing the splash screen */
     TriggerAction                       _openAction;                    /** Trigger action to show the splash screen */
     TriggerAction                       _closeAction;                   /** Trigger action to manually close the splash screen */


### PR DESCRIPTION
This pull request adds support for custom HTML content in the splash screen by introducing a new `StringAction` member to the `SplashScreenAction` class. It also ensures that this new field is properly serialized and deserialized, and exposes it through getter methods and a convenience function.

**Custom HTML override support:**

* Added a new private member `_htmlOverrideAction` of type `StringAction` to `SplashScreenAction` for storing custom HTML content.
* Included the new `StringAction` in the serialization (`toVariantMap`) and deserialization (`fromVariantMap`) logic to ensure custom HTML is persisted. [[1]](diffhunk://#diff-0be3e321fed5e1df437f9de016ad87a3a02aee7b89a58f71ee755f60b4173a26R224) [[2]](diffhunk://#diff-0be3e321fed5e1df437f9de016ad87a3a02aee7b89a58f71ee755f60b4173a26R234)
* Exposed the new action via `getHtmlOverrideAction()` getter methods (const and non-const). [[1]](diffhunk://#diff-8b81d86e56ea17508ded86dc6c0ebfeb0d062cf9026a760e0990444e6baeed6fR203) [[2]](diffhunk://#diff-8b81d86e56ea17508ded86dc6c0ebfeb0d062cf9026a760e0990444e6baeed6fR212)
* Added a convenience method `getHtmlBody()` to retrieve the custom HTML content if available. [[1]](diffhunk://#diff-8b81d86e56ea17508ded86dc6c0ebfeb0d062cf9026a760e0990444e6baeed6fR153-R158) [[2]](diffhunk://#diff-0be3e321fed5e1df437f9de016ad87a3a02aee7b89a58f71ee755f60b4173a26R176-R183)
* Updated the constructor to initialize `_htmlOverrideAction` and included the necessary header. [[1]](diffhunk://#diff-0be3e321fed5e1df437f9de016ad87a3a02aee7b89a58f71ee755f60b4173a26R90) [[2]](diffhunk://#diff-8b81d86e56ea17508ded86dc6c0ebfeb0d062cf9026a760e0990444e6baeed6fR11)