### PR TITLE
Initialize zoom after project open in Navigator2D

### DIFF
--- a/ManiVault/src/renderers/Navigator2D.cpp
+++ b/ManiVault/src/renderers/Navigator2D.cpp
@@ -177,6 +177,12 @@ void Navigator2D::initialize(QWidget* sourceWidget)
 
     connect(&_navigationAction.getZoomMarginAction().getZoomMarginDataAction(), &DecimalAction::valueChanged, this, updateZoomMarginData);
 
+    const auto initZoomAfterProjectOpen = [this]() -> void {
+        setZoomPercentage(_navigationAction.getZoomPercentageAction().getValue());
+	};
+
+    connect(&mv::projects(), &mv::AbstractProjectManager::projectOpened, this, initZoomAfterProjectOpen);
+
     _sourceWidget->addAction(&_navigationAction.getZoomInAction());
     _sourceWidget->addAction(&_navigationAction.getZoomExtentsAction());
     _sourceWidget->addAction(&_navigationAction.getZoomOutAction());


### PR DESCRIPTION
- [x] Adds a lambda to set the zoom percentage when a project is opened and connects it to the `projectOpened` signal. This ensures the navigator's zoom is correctly initialized for each project.