### PR TITLE
Set window title using application base name

### DIFF
--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -74,6 +74,8 @@ MainWindow::MainWindow(QWidget* parent /*= nullptr*/) :
     QTimer::singleShot(1000, this, &MainWindow::checkGraphicsCapabilities);
 
     restoreWindowGeometryFromSettings();
+
+    setWindowTitle(Application::getBaseName());
 }
 
 void MainWindow::moveEvent(QMoveEvent* moveEvent)


### PR DESCRIPTION
Added a call to setWindowTitle with Application::getBaseName() in MainWindow's constructor to ensure the window title reflects the application's base name.