### PR TITLE
Set application window icon on startup

### DIFF
--- a/ManiVault/src/Application.cpp
+++ b/ManiVault/src/Application.cpp
@@ -72,6 +72,8 @@ Application::Application(int& argc, char** argv) :
 
         brandingConfigurationAction.getBaseNameAction().setString(baseName);
         brandingConfigurationAction.getFullNameAction().setString(QString("%1 %2").arg(baseName, QString::fromStdString(current()->getVersion().getVersionString())));
+
+        Application::setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
 	}
 }
 

--- a/ManiVault/src/actions/BrandingConfigurationAction.cpp
+++ b/ManiVault/src/actions/BrandingConfigurationAction.cpp
@@ -93,7 +93,6 @@ BrandingConfigurationAction::BrandingConfigurationAction(QObject* parent, const 
 
         if (logoPixmap.size().width() != logoPixmap.size().height())
             mv::help().addNotification("Logo image is not a square", "The logo is not square and will be resized to a square to fit.", StyledIcon("palette"));
-            
 
         const auto scaledLogoPixmap = logoPixmap.scaled(QSize(64, 64), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 


### PR DESCRIPTION
- [x] Added code to set the window icon using a 256px app icon in `Application.cpp`. Also removed unnecessary whitespace in `BrandingConfigurationAction.cpp`.