### PR TITLE
Enable splash screen by default on startup

### DIFF
--- a/ManiVault/src/Application.cpp
+++ b/ManiVault/src/Application.cpp
@@ -72,6 +72,7 @@ Application::Application(int& argc, char** argv) :
 
         brandingConfigurationAction.getBaseNameAction().setString(baseName);
         brandingConfigurationAction.getFullNameAction().setString(QString("%1 %2").arg(baseName, QString::fromStdString(current()->getVersion().getVersionString())));
+        brandingConfigurationAction.getSplashScreenAction().getEnabledAction().setChecked(true);
 
         Application::setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
 	}


### PR DESCRIPTION
- [x] Sets the splash screen enabled state to true during application initialization to ensure it is shown by default.