### PR TITLE
Enable start page customization toggle by default

### DIFF
--- a/ManiVault/src/Application.cpp
+++ b/ManiVault/src/Application.cpp
@@ -74,6 +74,8 @@ Application::Application(int& argc, char** argv) :
         brandingConfigurationAction.getFullNameAction().setString(QString("%1 %2").arg(baseName, QString::fromStdString(current()->getVersion().getVersionString())));
         brandingConfigurationAction.getSplashScreenAction().getEnabledAction().setChecked(true);
 
+        _configurationAction.getStartPageConfigurationAction().getToggleCustomizationAction().setChecked(true);
+
         Application::setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
 	}
 }

--- a/ManiVault/src/actions/StartPageConfigurationAction.cpp
+++ b/ManiVault/src/actions/StartPageConfigurationAction.cpp
@@ -19,7 +19,7 @@ StartPageConfigurationAction::StartPageConfigurationAction(QObject* parent, cons
     _toggleProjectFromWorkspaceAction(this, "Project From Workspace"),
     _toggleTutorialsAction(this, "Tutorials", true),
     _settingsGroupAction(this, "Settings", true),
-    _toggleCustomizationAction(this, "Customization")
+    _toggleCustomizationAction(this, "Customization", false)
 {
     setIconByName("gear");
 
@@ -40,8 +40,6 @@ StartPageConfigurationAction::StartPageConfigurationAction(QObject* parent, cons
         //setVisible(false);
         //_toLearningCenterAction.setVisible(false);
     }
-
-    _toggleProjectFromWorkspaceAction.setEnabled(false);
 
     addAction(&_compactViewAction);
     addAction(&_toggleOpenCreateProjectAction);


### PR DESCRIPTION
- [x] The start page customization toggle is now checked by default in the application constructor. Also, the toggle is initialized as unchecked in StartPageConfigurationAction, ensuring explicit state management.