### PR TITLE
Update ads to 4.4.1

### DIFF
--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -178,7 +178,7 @@ CPMAddPackage(
 CPMAddPackage(
   NAME              advanced_docking
   GITHUB_REPOSITORY githubuser0xFFFF/Qt-Advanced-Docking-System
-  GIT_TAG           4.4.0
+  GIT_TAG           4.4.1
   OPTIONS "BUILD_EXAMPLES OFF"
 )
 


### PR DESCRIPTION
https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/releases

Important for us:
- In the current `4.4.0` the minimum required cmake version is set to `3.5`. Newer CMake versions (>`4`) have removed compatibility with these old settings. ads `4.4.1` updated their minimum required cmake version 
- Some bug fixes