### PR TITLE
Do not duplicate tutorials

### DIFF
--- a/ManiVault/src/models/LearningCenterTutorialsModel.cpp
+++ b/ManiVault/src/models/LearningCenterTutorialsModel.cpp
@@ -10,6 +10,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
+
 #include <QtConcurrent>
 
 #ifdef _DEBUG
@@ -162,6 +164,15 @@ void LearningCenterTutorialsModel::addTutorial(const LearningCenterTutorial* tut
     Q_ASSERT(tutorial);
 
     if (!tutorial)
+        return;
+
+    // Only add tutorial if it's title is unique
+    auto it = std::ranges::find_if(_tutorials,
+        [&tutorial](const LearningCenterTutorial* ptr) {
+            return ptr->getTitle() == tutorial->getTitle();
+        });
+
+    if (it != _tutorials.end())
         return;
 
     appendRow(Row(tutorial));

--- a/ManiVault/src/models/LearningCenterTutorialsModel.cpp
+++ b/ManiVault/src/models/LearningCenterTutorialsModel.cpp
@@ -43,6 +43,7 @@ LearningCenterTutorialsModel::LearningCenterTutorialsModel(QObject* parent /*= n
     _dsnsAction(this, "Data Source Names")
 {
     setColumnCount(static_cast<int>(Column::Count));
+    setRowCount(0);
 
     _dsnsAction.setIconByName("globe");
     _dsnsAction.setToolTip("Tutorials Data Source Names (DSN)");
@@ -51,8 +52,6 @@ LearningCenterTutorialsModel::LearningCenterTutorialsModel(QObject* parent /*= n
     _dsnsAction.setPopupSizeHint(QSize(550, 100));
 
     connect(&_dsnsAction, &StringsAction::stringsChanged, this, [this]() -> void {
-        setRowCount(0);
-
         for (const auto& dsn : _dsnsAction.getStrings()) {
             const auto dsnIndex = _dsnsAction.getStrings().indexOf(dsn);
 


### PR DESCRIPTION
When adding a tutorial JSON from a plugin factory via `getTutorialsDsnsAction().addString(url);` [this for loop](https://github.com/ManiVaultStudio/core/blob/3d60ea1db082d0b1d69ad1a3a6da83cf2c2a4745/ManiVault/src/models/LearningCenterTutorialsModel.cpp#L86) ends up calling `addTutorial` multiple times. 

By checking if a tutorial title already exists we prevent duplicates and will preempt confusion in case two different tutorials try to claim the same title.

Additionally, setting `setRowCount(0)` on every change of `_dsnsAction` clashes with using `addTutorial` directly.
A plugin can e.g. do
```cpp
auto tutorial_json = readJSON(tutorial_file);
mv::help().addTutorial(new LearningCenterTutorial(tutorial_json.value()["tutorials"].toArray().first().toObject().toVariantMap()));
```
in its plugin factory, but that entry could then be deleted by the `setRowCount(0)` when updating the dsnsAction.