### PR TITLE
Stop error logging before shutdown to prevent crash dialog

### DIFF
--- a/ManiVault/src/AbstractErrorLogger.h
+++ b/ManiVault/src/AbstractErrorLogger.h
@@ -83,6 +83,12 @@ public:
         }
     }
 
+    /** Stops the error logger if it exists */
+    void requestStop()
+    {
+        stop();
+    }
+
     /**
      * Get whether the error logger is initialized or not
      * @return Boolean determining whether the error logger is initialized or not
@@ -147,6 +153,9 @@ private:
 
     /** Starts the error logger */
     virtual void start() = 0;
+
+    /** Shuts down the error logger */
+    virtual void stop() = 0;
 
     /**
      * Get whether the Sentry data source name (DSN) is valid

--- a/ManiVault/src/private/ErrorManager.cpp
+++ b/ManiVault/src/private/ErrorManager.cpp
@@ -106,6 +106,8 @@ void ErrorManager::reset()
 
     beginReset();
     {
+        if (getErrorLogger())
+            getErrorLogger()->requestStop();
     }
     endReset();
 }

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -127,7 +127,7 @@ void SentryErrorLogger::start()
         qDebug() << "Sentry error logging is running, crash reports will send to: " + dsn;
     else
         qDebug() << "Sentry error logging is not running";
-
+    
     addNotification("Started", {
         QString("%1 error logging").arg(getLoggerName()),
         "Error logging using <a href='https://sentry.io/'>Sentry</a> is active, crash reports will be logged to improve the application.",
@@ -137,6 +137,11 @@ void SentryErrorLogger::start()
 
     //sentry_flush(2000);
     //sentry_shutdown();
+}
+
+void SentryErrorLogger::stop()
+{
+    sentry_close();
 }
 
 QString SentryErrorLogger::getReleaseString()

--- a/ManiVault/src/private/SentryErrorLogger.h
+++ b/ManiVault/src/private/SentryErrorLogger.h
@@ -37,6 +37,8 @@ private:
     /** Start error logging to */
     void start() override;
 
+    void stop() override;
+
     /**
      * Get release string for Sentry
      * @return Release string


### PR DESCRIPTION
There are still a lot of issues to solve for a clean shutdown of the software.
I added some functions to the ErrorManager and SentryErrorLogger to stop it before going into the whole shutdown process.
This to prevent a crash dialog from showing everytime someone tries to close the software.
