### PR TITLE
Refactor rootDir initialization for asset path

### DIFF
--- a/ManiVault/src/util/CustomAssetsUrlSchemeHandler.cpp
+++ b/ManiVault/src/util/CustomAssetsUrlSchemeHandler.cpp
@@ -4,6 +4,8 @@
 
 #include "CustomAssetsUrlSchemeHandler.h"
 
+#include "util/StandardPaths.h"
+
 #include <QWebEngineUrlRequestJob>
 #include <QCoreApplication>
 #include <QDir>
@@ -18,28 +20,7 @@ namespace mv::util
 
 CustomAssetsUrlSchemeHandler::CustomAssetsUrlSchemeHandler(QObject* parent):
 	QWebEngineUrlSchemeHandler(parent),
-	_rootDir([]() -> QString {
-		const QDir appDir(QCoreApplication::applicationDirPath());
-
-		QString candidate;
-
-#if defined(Q_OS_MAC)
-		QDir d(appDir);
-		while (!d.dirName().endsWith(".app") && d.cdUp()) {}
-
-		if (d.dirName().endsWith(".app")) {
-			QDir parent = d;
-			if (parent.cdUp()) {
-				candidate = parent.filePath("Customization/assets");
-			}
-		}
-#endif
-		if (!candidate.isEmpty() && QFileInfo::exists(candidate)) {
-			return QDir::cleanPath(candidate);
-		}
-
-		return QDir::cleanPath(appDir.filePath("Customization/assets"));
-	}())
+	_rootDir(QDir::cleanPath(StandardPaths::getCustomizationDirectory() + "/assets"))
 {
 }
 


### PR DESCRIPTION
This change fixes the macos splash screen images not appearing issue (https://github.com/ManiVaultStudio/core/issues/1151):
See image below:
<img width="1454" height="1150" alt="image" src="https://github.com/user-attachments/assets/3aa8157c-51d4-48b8-8911-d772f6ef9620" />
