### PR TITLE
Refactor DatasetPrivate reset logic and API

### DIFF
--- a/ManiVault/src/DatasetPrivate.cpp
+++ b/ManiVault/src/DatasetPrivate.cpp
@@ -74,18 +74,17 @@ const DatasetImpl* DatasetPrivate::getDataset() const
 
 void DatasetPrivate::setDataset(DatasetImpl* dataset)
 {
-    if (dataset == nullptr) {
+    if (!dataset) {
         reset();
     }
     else {
         if (dataset == _dataset)
             return;
 
-        if (_dataset)
-            disconnect(_dataset, &gui::WidgetAction::textChanged, this, nullptr);
+        reset(false);
 
-        _dataset        = dataset;
-        _datasetId    = _dataset->getId();
+    	_dataset    = dataset;
+        _datasetId  = _dataset->getId();
 
         connect(_dataset, &gui::WidgetAction::textChanged, this, [this]() -> void {
             emit guiNameChanged();
@@ -95,12 +94,16 @@ void DatasetPrivate::setDataset(DatasetImpl* dataset)
     }
 }
 
-void DatasetPrivate::reset()
+void DatasetPrivate::reset(bool notify /*= true*/)
 {
+    if (_dataset)
+        disconnect(_dataset, &gui::WidgetAction::textChanged, this, nullptr);
+
     _dataset    = nullptr;
     _datasetId  = "";
 
-    emit changed(_dataset);
+    if (notify)
+		emit changed(_dataset);
 }
 
 void DatasetPrivate::connectNotify(const QMetaMethod& signal)

--- a/ManiVault/src/DatasetPrivate.h
+++ b/ManiVault/src/DatasetPrivate.h
@@ -85,8 +85,11 @@ public: // Member access and reset
      */
     void setDataset(DatasetImpl* dataset);
 
-    /** Resets the smart pointer */
-    void reset();
+    /**
+     * Reset the dataset pointer and disconnect from the dataset
+     * @param notify Whether to notify listeners about the reset
+     */
+    void reset(bool notify = true);
 
 public: // Keep track of when someone connects/disconnects from our signal(s)
 


### PR DESCRIPTION
This pull request refactors how the `DatasetPrivate` class manages dataset resets and signal disconnections, improving code clarity and flexibility. The main changes include updating the reset logic to ensure proper signal handling and introducing a notification flag for more controlled behavior. Thanks to @alxvth for spotting this inconsistent behavior!

### Refactor and improve dataset reset logic

* The `reset` method in `DatasetPrivate` now accepts a `notify` parameter (defaulting to `true`), allowing callers to control whether the `changed` signal is emitted after a reset.
* The `reset` method now disconnects the `textChanged` signal from the previous dataset before clearing the pointer, ensuring proper cleanup of signal connections.

### Update dataset assignment logic

* The `setDataset` method now calls `reset(false)` when switching datasets, preventing duplicate signal emissions and ensuring signal disconnection is handled consistently.