### PR TITLE
Refactor suffix check for version string generation

### DIFF
--- a/ManiVault/src/util/Version.cpp
+++ b/ManiVault/src/util/Version.cpp
@@ -85,7 +85,7 @@ std::string Version::getVersionString() const
     if (!isValid())
         return {};
 
-    if(_suffix == " ")
+    if(_suffix.empty() || _suffix.find_first_not_of(" ") == std::string::npos)
         return std::to_string(_major) + "." + std::to_string(_minor) + "." + std::to_string(_patch);
     else
         return std::to_string(_major) + "." + std::to_string(_minor) + "." + std::to_string(_patch) + "-" + _suffix;


### PR DESCRIPTION
We should check if the suffix is empty or contains only empty spaces.

This prevents accidental versions like "1.5.0- ".

Example: https://godbolt.org/z/c6qnd5z6o