### PR TITLE
Add project version action to publish workflow

### DIFF
--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -1162,6 +1162,7 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
                     settingsGroupAction.addAction(&currentProject->getDescriptionAction());
                     settingsGroupAction.addAction(&currentProject->getTagsAction());
                     settingsGroupAction.addAction(&currentProject->getCommentsAction());
+                    settingsGroupAction.addAction(&currentProject->getProjectVersionAction());
                     //settingsGroupAction.addAction(&currentProject->getSplashScreenAction());
                     //settingsGroupAction.addAction(&currentProject->getOverrideApplicationStatusBarAction());
                     //settingsGroupAction.addAction(&currentProject->getStatusBarVisibleAction());


### PR DESCRIPTION
Includes the project version action in the settings group during project publishing, ensuring version information is handled alongside other project metadata.