### PR TITLE
Prevents Customization directory from being created in the root directory

### DIFF
--- a/ManiVault/src/util/StandardPaths.cpp
+++ b/ManiVault/src/util/StandardPaths.cpp
@@ -65,18 +65,14 @@ QString StandardPaths::getCustomizationDirectory()
 
     QString pathSuffix = QString("/%1").arg(dirName);
 
-    if (isMacOS()){
+    if (isMacOS())
         pathSuffix = applicationDir.dirName() == "MacOS" ? QString("../../../../%1").arg(dirName) : QString("/../%1").arg(dirName);
-        const auto finalPath = QDir::cleanPath(applicationDir.path() + pathSuffix);
 
-        [[maybe_unused]] auto result = QDir().mkpath(finalPath);
+    const auto finalPath = QDir::cleanPath(applicationDir.path() + pathSuffix);
 
-        return finalPath;
-    }
+    [[maybe_unused]] auto result = QDir().mkpath(finalPath);
 
-    [[maybe_unused]] auto result = applicationDir.mkpath(pathSuffix);
-
-    return QDir::cleanPath(applicationDir.path() + pathSuffix);
+    return finalPath;
 }
 
 QString StandardPaths::getProjectsDirectory()


### PR DESCRIPTION
The issue was that:

`auto result = applicationDir.mkpath(pathSuffix);`

the slash in pathSuffix causes pathSuffix to be treated as its own path, not appended to the parent directory. Removing the slash so it's just 'Customization' makes it work.

But could shorten the function a bit in general, by first appending pathSuffix to the parent directory and then trying to create that whole path in one go, which merges the MacOS and non-MacOS paths. Hence the other changes.
