### PR TITLE
Move cursor override in saveProject method

### DIFF
--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -850,8 +850,6 @@ void ProjectManager::importProject(QString filePath /*= ""*/)
 
 void ProjectManager::saveProject(QString filePath /*= ""*/, const QString& password /*= ""*/)
 {
-    Application::requestOverrideCursor(Qt::WaitCursor);
-
     try
     {
 #ifdef PROJECT_MANAGER_VERBOSE
@@ -962,6 +960,8 @@ void ProjectManager::saveProject(QString filePath /*= ""*/, const QString& passw
             
             if (filePath.isEmpty() || QFileInfo(filePath).isDir())
                 return;
+
+            Application::requestOverrideCursor(Qt::WaitCursor);
 
             if (_project->getCompressionAction().getEnabledAction().isChecked())
                 qDebug().noquote() << "Saving ManiVault project to" << filePath << "with compression level" << _project->getCompressionAction().getLevelAction().getValue();


### PR DESCRIPTION
Relocated Application::requestOverrideCursor(Qt::WaitCursor) to occur only after file path validation in saveProject, ensuring the wait cursor is set only when a valid file path is provided.