### PR TITLE
Return value instead of local reference for Icon

### DIFF
--- a/ManiVault/src/actions/IconPickerAction.cpp
+++ b/ManiVault/src/actions/IconPickerAction.cpp
@@ -42,7 +42,7 @@ IconPickerAction::IconPickerAction(QObject* parent, const QString& title) :
     _inputFilePathPickerAction.setDefaultWidgetFlags(FilePickerAction::WidgetFlag::PushButton);
 }
 
-const QIcon& IconPickerAction::getIcon() const
+QIcon IconPickerAction::getIcon() const
 {
     return _iconAction.icon();
 }

--- a/ManiVault/src/actions/IconPickerAction.h
+++ b/ManiVault/src/actions/IconPickerAction.h
@@ -38,7 +38,7 @@ public:
      * Facade for IconAction::getLanguageIcon()
      * @return Icon
      */
-    const QIcon& getIcon() const;
+    QIcon getIcon() const;
 
     /**
      * Set the current icon to \p icon


### PR DESCRIPTION
Fixes the MSVC warning
```bash
ManiVault\src\actions\IconPickerAction.cpp(47,1): warning C4172: returning address of local variable or temporary
```

On Windows we do not see immediate issues with this but on linux with gcc this results in a segfault on startup of the application.