### PR TITLE
Update application name in About menu

### DIFF
--- a/ManiVault/src/actions/BrandingConfigurationAction.cpp
+++ b/ManiVault/src/actions/BrandingConfigurationAction.cpp
@@ -99,20 +99,26 @@ BrandingConfigurationAction::BrandingConfigurationAction(QObject* parent, const 
         _iconAction.getIconPickerAction().setIcon(QIcon(scaledLogoPixmap));
     });
 
-    _aboutAction.setString(QString("%3 is a flexible and extensible visual analytics framework for high-dimensional data.<br> <br>"
-        "For more information, please visit: <br>"
-        "Webpage: <a href=\"https://%5/\">%5</a> <br>"
-        "Source: <a href=\"https://%2/\">%2</a> <br> <br>"
-        "%3 Core %4 <br> <br>"
-        "This software is licensed under the GNU Lesser General Public License v3.0.<br>"
-        "Copyright (C) %1 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft)"
-    ).arg(
-        /*1: year*/ QStringLiteral("2023"),
-        /*2: source*/ QStringLiteral("github.com/ManiVaultStudio"),
-        /*3: name*/ _baseNameAction.getString(),
-        /*4: version*/ QString::fromStdString(Application::current()->getVersion().getVersionString()),
-        /*5: webpage*/ QStringLiteral("manivault.studio")
-    ));
+    auto setAboutString = [this]() {
+        _aboutAction.setString(QString("%3 is a flexible and extensible visual analytics framework for high-dimensional data.<br> <br>"
+            "For more information, please visit: <br>"
+            "Webpage: <a href=\"https://%5/\">%5</a> <br>"
+            "Source: <a href=\"https://%2/\">%2</a> <br> <br>"
+            "%3 Core %4 <br> <br>"
+            "This software is licensed under the GNU Lesser General Public License v3.0.<br>"
+            "Copyright (C) %1 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft)"
+        ).arg(
+            /*1: year*/ QStringLiteral("2023"),
+            /*2: source*/ QStringLiteral("github.com/ManiVaultStudio"),
+            /*3: name*/ _baseNameAction.getString(),
+            /*4: version*/ QString::fromStdString(Application::current()->getVersion().getVersionString()),
+            /*5: webpage*/ QStringLiteral("manivault.studio")
+        ));
+        };
+
+    connect(&_baseNameAction, &StringAction::stringChanged, this, setAboutString);
+
+    setAboutString();
 }
 
 void BrandingConfigurationAction::fromVariantMap(const QVariantMap& variantMap)


### PR DESCRIPTION
The application name is currently not updated in the About menu, yielding an empty name spot there.

Previous:
<img width="528" height="301" alt="image" src="https://github.com/user-attachments/assets/5acce71f-52e9-4bbd-a171-c301ad2edbb9" />

New:
<img width="535" height="296" alt="image" src="https://github.com/user-attachments/assets/9df6d143-4cd3-4478-86c8-002027d1f889" />
