### PR TITLE
Fix compilation errors in ProjectsModelVisibilityController

### DIFF
--- a/ManiVault/src/models/ProjectsModelVisibilityController.cpp
+++ b/ManiVault/src/models/ProjectsModelVisibilityController.cpp
@@ -6,14 +6,12 @@
 
 #include <QHash>
 #include <QDebug>
+#include <QUrl>
 #include <algorithm>
 
 #ifdef _DEBUG
     #define PROJECTS_MODEL_VISIBILITY_CONTROLLER _VERBOSE
 #endif
-
-using namespace mv::gui;
-using namespace mv::util;
 
 namespace mv {
 

--- a/ManiVault/src/models/ProjectsModelVisibilityController.h
+++ b/ManiVault/src/models/ProjectsModelVisibilityController.h
@@ -5,14 +5,13 @@
 #pragma once
 
 #include "ManiVaultGlobals.h"
+#include "models/AbstractProjectsModel.h"
 
 #include <QStandardItemModel>
 #include <QObject>
 #include <functional>
 
 namespace mv {
-
-class AbstractProjectsModel;
 
 /**
  * Projects model visibility controller class

--- a/ManiVault/src/util/Miscellaneous.cpp
+++ b/ManiVault/src/util/Miscellaneous.cpp
@@ -15,6 +15,7 @@
 #include <QLayoutItem>
 #include <QPainter>
 #include <QPixmap>
+#include <QJsonDocument>
 #include <QString>
 #include <QTimer>
 #include <QTcpSocket>


### PR DESCRIPTION
- Add missing AbstractProjectsModel.h include to resolve incomplete type errors
- Add missing QUrl and QJsonDocument includes
- Remove unused namespace directives (mv::gui, mv::util)

These changes fix 16 compilation errors related to incomplete types and missing includes.