### PR TITLE
Discard fragments with zero opacity

### DIFF
--- a/ManiVault/res/shaders/PointPlot.frag
+++ b/ManiVault/res/shaders/PointPlot.frag
@@ -59,6 +59,9 @@ float normalize(float minPixelValue, float maxPixelValue, float pixelValue)
 
 void main()
 {
+	if (vOpacity == .0f)
+		discard;
+		
 	bool isSelectionHighlighted	= vHighlight == 1;
 	bool isFocusHighlighted 	= vFocusHighlight == 1;
 	bool isHighlighted			= isSelectionHighlighted || isFocusHighlighted;


### PR DESCRIPTION
This pull request introduces a small but important change to the `PointPlot.frag` shader. The main update is an early exit in the `main` function to discard fragments with zero opacity, which can improve rendering performance and visual correctness.

Rendering logic improvement:
* [`ManiVault/res/shaders/PointPlot.frag`](diffhunk://#diff-52eeb3e9f856a7b6756c6ffdc2a719757d53b6420da566306719dca0bec6b307R62-R64): Added a check to discard fragments when `vOpacity` is zero at the start of the `main` function, preventing unnecessary processing of fully transparent points.