### PR TITLE
Add invalidateFilter() to mv::gui::DatasetPickerAction

### DIFF
--- a/ManiVault/src/actions/DatasetPickerAction.cpp
+++ b/ManiVault/src/actions/DatasetPickerAction.cpp
@@ -208,6 +208,11 @@ QString DatasetPickerAction::getCurrentDatasetId() const
     return getCurrentDataset().getDatasetId();
 }
 
+void DatasetPickerAction::invalidateFilter()
+{
+    _datasetsFilterModel.invalidate();
+}
+
 AbstractDatasetsModel::PopulationMode DatasetPickerAction::getPopulationMode() const
 {
     return _populationMode;

--- a/ManiVault/src/actions/DatasetPickerAction.h
+++ b/ManiVault/src/actions/DatasetPickerAction.h
@@ -44,7 +44,6 @@ public:
      * Constructor
      * @param parent Pointer to parent object
      * @param title Title of the action
-     * @param mode Picker mode
      */
     Q_INVOKABLE DatasetPickerAction(QObject* parent, const QString& title);
 
@@ -94,6 +93,9 @@ public:
      * @return The globally unique identifier of the currently selected dataset (if any)
      */
     QString getCurrentDatasetId() const;
+
+    /** Invalidate the current filter so that the internal datasets list is refreshed (only when population mode is AbstractDatasetsModel::PopulationMode::Automatic) */
+    void invalidateFilter();
 
 public: // Population
 
@@ -145,7 +147,7 @@ public: // Serialization
 
     /**
      * Load widget action from variant map
-     * @param Variant map representation of the widget action
+     * @param variantMap Variant map representation of the widget action
      */
     void fromVariantMap(const QVariantMap& variantMap) override;
 


### PR DESCRIPTION
This pull request introduces a method to allow external invalidation of the dataset filter in the `DatasetPickerAction` class, along with some minor documentation improvements. The main focus is to enable refreshing the internal datasets list, particularly when the population mode is set to automatic.

### Feature addition

* Added a new public method `invalidateFilter()` to `DatasetPickerAction`, which calls the internal filter model's `invalidate()` method to refresh the datasets list. This is especially relevant when using automatic population mode. [[1]](diffhunk://#diff-280db8f0749c97b3d0e042b0731a4d4192ef5348d79739eb18a85ff72d15b66fR211-R215) [[2]](diffhunk://#diff-f6b59469618c6440d285dc12856dd0b92f4874c085faed341a262d9f01a2aa76R97-R99)

### Documentation improvements

* Improved parameter documentation in the header file, clarifying the meaning of the `variantMap` parameter and removing an outdated parameter from the constructor documentation. [[1]](diffhunk://#diff-f6b59469618c6440d285dc12856dd0b92f4874c085faed341a262d9f01a2aa76L47) [[2]](diffhunk://#diff-f6b59469618c6440d285dc12856dd0b92f4874c085faed341a262d9f01a2aa76L148-R150)