### PR TITLE
Add findPluginAncestor to WidgetAction

### DIFF
--- a/ManiVault/src/actions/WidgetAction.cpp
+++ b/ManiVault/src/actions/WidgetAction.cpp
@@ -105,6 +105,12 @@ void WidgetAction::updateLocation(bool recursive /*= true*/)
             child->updateLocation(recursive);
 }
 
+plugin::Plugin* WidgetAction::findPluginAncestor() const
+{
+    const auto ancestors = getAncestors<plugin::Plugin>();
+    return ancestors.isEmpty() ? nullptr : ancestors.first();
+}
+
 bool WidgetAction::isRoot() const
 {
     if (!getParent())

--- a/ManiVault/src/actions/WidgetAction.h
+++ b/ManiVault/src/actions/WidgetAction.h
@@ -282,6 +282,8 @@ public: // Hierarchy queries
         return false;
     }
 
+
+
 public: // Location
 
     /**
@@ -319,6 +321,12 @@ public:
                 qDebug() << segments.join("/");
         }
     }
+
+    /**
+     * Find the nearest plugin ancestor of the action
+     * @return Pointer to plugin ancestor, otherwise nullptr
+     */
+    plugin::Plugin* findPluginAncestor() const;
 
 public:
 


### PR DESCRIPTION
This pull request introduces a new method to the `WidgetAction` class that allows actions to easily locate their nearest plugin ancestor. This addition improves the ability to traverse and interact with the plugin hierarchy, making it easier for actions to access plugin-related functionality.

Enhancements to plugin hierarchy traversal:

* Added the `findPluginAncestor` method to `WidgetAction`, which returns a pointer to the nearest plugin ancestor or `nullptr` if none exists. [[1]](diffhunk://#diff-a1d5dfb45ad03411c371d43b4e1c4390312affd149b2aa70b7cb1f4661a424dcR108-R113) [[2]](diffhunk://#diff-2904bad02ab44ea022df6f0ba77b117aa88c1afc22f7250ea8b718f181d4cb19R325-R330)
* Updated the header file `WidgetAction.h` to declare the new `findPluginAncestor` method and document its purpose.

Minor formatting:

* Added spacing in `WidgetAction.h` for improved readability.