### PR TITLE
Add datasetAboutToBePicked signal and emit it

### DIFF
--- a/ManiVault/src/actions/DatasetPickerAction.cpp
+++ b/ManiVault/src/actions/DatasetPickerAction.cpp
@@ -31,6 +31,8 @@ DatasetPickerAction::DatasetPickerAction(QObject* parent, const QString& title) 
     connect(this, &OptionAction::currentIndexChanged, this, [this](const std::int32_t& currentIndex) {
         const auto sourceModelRow = _datasetsFilterModel.mapToSource(_datasetsFilterModel.index(currentIndex, 0)).row();
 
+        emit datasetAboutToBePicked(getCurrentDataset());
+
         switch (_populationMode)
         {
             case AbstractDatasetsModel::PopulationMode::Manual:

--- a/ManiVault/src/actions/DatasetPickerAction.h
+++ b/ManiVault/src/actions/DatasetPickerAction.h
@@ -178,6 +178,12 @@ public: // Serialization
 signals:
 
     /**
+     * Signals that a dataset is about to be picked
+     * @param currentDataset Smart pointer to current dataset (if any, otherwise an invalid dataset)
+     */
+    void datasetAboutToBePicked(mv::Dataset<> currentDataset);
+
+    /**
      * Signals that a dataset has been picked
      * @param pickedDataset Smart pointer to picked dataset
      */


### PR DESCRIPTION
This pull request introduces a new signal to the `DatasetPickerAction` class to notify when a dataset is about to be picked, improving the action's event handling and making it easier to respond to user selections before they are finalized.

**Event handling improvements:**

* Added a new signal `datasetAboutToBePicked(mv::Dataset<>)` to the `DatasetPickerAction` class, which is emitted just before a dataset is picked, allowing connected components to react to this event.
* Emitted the new `datasetAboutToBePicked` signal in the `currentIndexChanged` lambda within the `DatasetPickerAction` constructor, ensuring the signal is triggered at the appropriate time in the dataset selection process.