### PR TITLE
Revamp navigation action linking

### DIFF
--- a/ManiVault/src/actions/NavigationAction.cpp
+++ b/ManiVault/src/actions/NavigationAction.cpp
@@ -35,7 +35,18 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
     _zoomMarginAction(this, "Zoom margin"),
     _zoomGroupAction(this, "Zoom group")
 {
-    //setShowLabels(false);
+    setConnectionPermissionsToAll();
+
+	_zoomOutAction.setConnectionPermissionsToForceNone(true);
+    _zoomInAction.setConnectionPermissionsToForceNone(true);
+    _zoomExtentsAction.setConnectionPermissionsToForceNone(true);
+    _zoomSelectionAction.setConnectionPermissionsToForceNone(true);
+    _zoomRegionAction.setConnectionPermissionsToForceNone(true);
+    _freezeNavigation.setConnectionPermissionsToForceNone(true);
+    _zoomRectangleAction.setConnectionPermissionsToForceNone(true);
+    _zoomFactorAction.setConnectionPermissionsToForceNone(true);
+    _zoomMarginAction.setConnectionPermissionsToForceNone(true);
+    _zoomGroupAction.setConnectionPermissionsToForceNone(true);
 
     _zoomOutAction.setToolTip("Zoom out by 10% (-)");
     _zoomPercentageAction.setToolTip("Zoom in/out (+)");
@@ -49,7 +60,6 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
     _freezeNavigation.setDefaultWidgetFlags(ToggleAction::WidgetFlag::CheckBox);
 
     _zoomPercentageAction.setOverrideSizeHint(QSize(300, 0));
-    _zoomPercentageAction.setConnectionPermissionsToAll();
 
     _zoomOutAction.setIconByName("search-minus");
     _zoomInAction.setIconByName("search-plus");
@@ -71,7 +81,6 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
     _zoomCenterAction.setIconByName("ruler");
     _zoomCenterAction.setDefaultWidgetFlags(GroupAction::WidgetFlag::Vertical);
     _zoomCenterAction.setPopupSizeHint(QSize(250, 0));
-    _zoomCenterAction.setConnectionPermissionsToAll(true);
 
     _zoomCenterAction.getXAction().setDefaultWidgetFlags(DecimalAction::WidgetFlag::SpinBox);
     _zoomCenterAction.getYAction().setDefaultWidgetFlags(DecimalAction::WidgetFlag::SpinBox);
@@ -117,6 +126,36 @@ void NavigationAction::setShortcutsEnabled(bool shortcutsEnabled)
     _zoomExtentsAction.setShortcut(shortcutsEnabled ? QKeySequence("O") : QKeySequence());
     _zoomSelectionAction.setShortcut(shortcutsEnabled ? QKeySequence("H") : QKeySequence());
     _zoomRegionAction.setShortcut(shortcutsEnabled ? QKeySequence("F") : QKeySequence());
+}
+
+void NavigationAction::connectToPublicAction(WidgetAction* publicAction, bool recursive)
+{
+    auto publicNavigationSourceAction = dynamic_cast<NavigationAction*>(publicAction);
+
+    Q_ASSERT(publicNavigationSourceAction != nullptr);
+
+    if (publicNavigationSourceAction == nullptr)
+        return;
+
+    if (recursive) {
+        actions().connectPrivateActionToPublicAction(&_zoomCenterAction, &publicNavigationSourceAction->getZoomCenterAction(), recursive);
+        actions().connectPrivateActionToPublicAction(&_zoomPercentageAction, &publicNavigationSourceAction->getZoomPercentageAction(), recursive);
+    }
+
+    HorizontalToolbarAction::connectToPublicAction(publicAction, recursive);
+}
+
+void NavigationAction::disconnectFromPublicAction(bool recursive)
+{
+    if (!isConnected())
+        return;
+
+    if (recursive) {
+        actions().disconnectPrivateActionFromPublicAction(&_zoomCenterAction, recursive);
+        actions().disconnectPrivateActionFromPublicAction(&_zoomPercentageAction, recursive);
+    }
+
+    HorizontalToolbarAction::disconnectFromPublicAction(recursive);
 }
 
 void NavigationAction::fromVariantMap(const QVariantMap& variantMap)

--- a/ManiVault/src/actions/NavigationAction.h
+++ b/ManiVault/src/actions/NavigationAction.h
@@ -48,6 +48,21 @@ public:
      */
     void setShortcutsEnabled(bool shortcutsEnabled);
 
+protected: // Linking
+
+    /**
+     * Connect this action to a public action
+     * @param publicAction Pointer to public action to connect to
+     * @param recursive Whether to also connect descendant child actions
+     */
+    void connectToPublicAction(WidgetAction* publicAction, bool recursive) override;
+
+    /**
+     * Disconnect this action from its public action
+     * @param recursive Whether to also disconnect descendant child actions
+     */
+    void disconnectFromPublicAction(bool recursive) override;
+
 public: // Serialization
 
     /**


### PR DESCRIPTION
This pull request introduces enhancements to the `NavigationAction` class, focusing on connection permissions and action linking. The main changes involve tightening connection permissions for navigation-related actions and adding new methods for linking and unlinking actions, which improves modularity and control over action connectivity.

**Connection permissions improvements:**

* Set connection permissions to all actions in the `NavigationAction` constructor using `setConnectionPermissionsToAll()`, and restricted specific navigation actions to force none for connection permissions (e.g., `_zoomOutAction`, `_zoomInAction`, etc.), improving security and control over action connections.
* Removed calls to `setConnectionPermissionsToAll()` and `setConnectionPermissionsToAll(true)` for `_zoomPercentageAction` and `_zoomCenterAction`, respectively, further tightening connection permissions for these actions. [[1]](diffhunk://#diff-82d6a09909d67cb60a6ac0c259c229767f5c79ae1a7b730ed04a47f3772bf2ddL52) [[2]](diffhunk://#diff-82d6a09909d67cb60a6ac0c259c229767f5c79ae1a7b730ed04a47f3772bf2ddL74)

**Action linking enhancements:**

* Added `connectToPublicAction` and `disconnectFromPublicAction` methods to `NavigationAction`, allowing for recursive linking and unlinking of actions to public actions, and integrated these methods with descendant actions for improved modularity. [[1]](diffhunk://#diff-82d6a09909d67cb60a6ac0c259c229767f5c79ae1a7b730ed04a47f3772bf2ddR131-R160) [[2]](diffhunk://#diff-53190cd3a4611a6768fb7bb3011f5774020698ea98f15039d4364ff1690e252fR51-R65)