### PR TITLE
Seasonal dependency update 03/26 [zlib, valijson, ads & sentry]

### DIFF
--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -239,9 +239,6 @@ if(${MV_USE_ERROR_LOGGING})
         set(SENTRY_TRANSPORT "curl")        # Use the curl HTTP transport
     endif()
 
-    # Add preprocessor directive to notify sources of error logging
-    add_compile_definitions(ERROR_LOGGING)
-
     CPMAddPackage(
         NAME                sentry-native
         GITHUB_REPOSITORY   getsentry/sentry-native

--- a/ManiVault/src/private/ErrorManager.cpp
+++ b/ManiVault/src/private/ErrorManager.cpp
@@ -12,7 +12,7 @@ using namespace mv::util;
     //#define ERROR_MANAGER_VERBOSE
 #endif
 
-#ifdef ERROR_LOGGING
+#ifdef MV_USE_ERROR_LOGGING
     #include "private/SentryErrorLogger.h"
 #endif
 
@@ -82,7 +82,7 @@ void ErrorManager::initialize()
         errorLoggingSettingsAction.addAction(&getLoggingDsnAction());
         errorLoggingSettingsAction.addAction(&getLoggingShowCrashReportDialogAction());
 
-#ifdef ERROR_LOGGING
+#ifdef MV_USE_ERROR_LOGGING
         setErrorLogger(new SentryErrorLogger(this));
 
         getErrorLogger()->initialize();

--- a/ManiVault/src/private/SettingsManagerDialog.cpp
+++ b/ManiVault/src/private/SettingsManagerDialog.cpp
@@ -33,7 +33,7 @@ SettingsManagerDialog::SettingsManagerDialog(QWidget* parent /*= nullptr*/) :
 
     layout->addWidget(_groupsAction.createWidget(this));
 
-#ifdef ERROR_LOGGING
+#ifdef MV_USE_ERROR_LOGGING
     _groupsAction.addGroupAction(&mv::settings().getErrorLoggingSettingsAction());
 #endif
 


### PR DESCRIPTION
- https://github.com/madler/zlib/releases/tag/v1.3.2
- https://github.com/tristanpenman/valijson/releases/tag/v1.1.0
- https://github.com/getsentry/sentry-native/releases
- https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/releases/tag/4.5.0
  - We also need to pick up additional [changes from master](https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/compare/4.5.0...e2c960238d64982a4ac93c2c006155e86f23bb5f) to fix the CMake setup that is broken for using ads as subprojects in this release
- Ensure that the language is explicitly set for all dependency targets
- Only use one define for error logging (use `MV_USE_ERROR_LOGGING` instead of also `ERROR_LOGGING`)