### PR TITLE
Remove duplicate GradientCompute.frag resource

### DIFF
--- a/ManiVault/res/ResourcesCore.qrc
+++ b/ManiVault/res/ResourcesCore.qrc
@@ -45,7 +45,6 @@
         <file>shaders/DensityCompute.frag</file>
         <file>shaders/GradientCompute.frag</file>
 		<file>shaders/GradientCompute.vert</file>
-        <file>shaders/GradientCompute.frag</file>
         <file>shaders/MeanshiftCompute.frag</file>
 		<file>shaders/MeanshiftCompute.vert</file>
         <file>shaders/DensityDraw.frag</file>


### PR DESCRIPTION
`GradientCompute.frag` is listed twice in `ResourcesCore.qrc`