### PR TITLE
Add reference getter to DatasetsMimeData

### DIFF
--- a/ManiVault/src/DatasetsMimeData.cpp
+++ b/ManiVault/src/DatasetsMimeData.cpp
@@ -22,6 +22,11 @@ Datasets DatasetsMimeData::getDatasets() const
     return _datasets;
 }
 
+const Datasets& DatasetsMimeData::getDatasetsRef() const
+{
+    return _datasets;
+}
+
 QString DatasetsMimeData::format()
 {
     return "application/datasets";

--- a/ManiVault/src/DatasetsMimeData.h
+++ b/ManiVault/src/DatasetsMimeData.h
@@ -27,7 +27,7 @@ public:
      * Construct with \p datasets
      * @param datasets Mime data datasets for dropping
      */
-    DatasetsMimeData(Datasets datasets);
+    explicit DatasetsMimeData(Datasets datasets);
 
     /**
      * Get supported mime types

--- a/ManiVault/src/DatasetsMimeData.h
+++ b/ManiVault/src/DatasetsMimeData.h
@@ -47,6 +47,14 @@ public:
      */
     const Datasets& getDatasetsRef() const;
 
+    /**
+     * Get count of stored datasets
+     * @return Datasets count
+     */
+    size_t getDatasetsCount() const {
+        return _datasets.size();
+    }
+
     /** Supported mime type */
     static QString format();
 

--- a/ManiVault/src/DatasetsMimeData.h
+++ b/ManiVault/src/DatasetsMimeData.h
@@ -33,25 +33,25 @@ public:
      * Get supported mime types
      * @return List of string of supported mime types
      */
-    QStringList formats() const override;
+    [[nodiscard]] QStringList formats() const override;
 
     /**
      * Get stored datasets
      * @return Stored datasets
      */
-    Datasets getDatasets() const;
+    [[nodiscard]] Datasets getDatasets() const;
 
     /**
      * Get stored datasets as a const reference
      * @return Stored datasets reference
      */
-    const Datasets& getDatasetsRef() const;
+    [[nodiscard]] const Datasets& getDatasetsRef() const;
 
     /**
      * Get count of stored datasets
      * @return Datasets count
      */
-    size_t getDatasetsCount() const {
+    [[nodiscard]] size_t getDatasetsCount() const {
         return _datasets.size();
     }
 

--- a/ManiVault/src/DatasetsMimeData.h
+++ b/ManiVault/src/DatasetsMimeData.h
@@ -41,6 +41,12 @@ public:
      */
     Datasets getDatasets() const;
 
+    /**
+     * Get stored datasets as a const reference
+     * @return Stored datasets reference
+     */
+    const Datasets& getDatasetsRef() const;
+
     /** Supported mime type */
     static QString format();
 


### PR DESCRIPTION
All plugins that use the DropWidget have some boilderplate code like this (e.g. [the scatterplot](https://github.com/ManiVaultStudio/Scatterplot/blob/e1bac5fc4861b4e4120b268887a42a1930ae90f1/src/ScatterplotPlugin.cpp#L141)):
```cpp
        if (datasetsMimeData->getDatasets().count() > 1)
            return dropRegions;

        const auto dataset          = datasetsMimeData->getDatasets().first();
```

The `DatasetsMimeData::getDatasets` function returns a copy of its `QVector<Dataset<DatasetImpl>> _datasets` member, and the couple lines above will therefore trigger some constructor calls.
We can eliminate these calls by providing two helper access functions:
- `const Datasets& getDatasetsRef()`
- `size_t getDatasetsCount()`

The above code snippet can then be updated to:
```cpp
        if (datasetsMimeData->getDatasetsCount() > 1)
            return dropRegions;

        const auto& dataset          = datasetsMimeData->getDatasetsRef().first();
```

Drive-by:
- Add some `[[nodiscard]]` and `explicit`