### PR TITLE
C++ version compile feature should be public for exported targets

### DIFF
--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -17,7 +17,9 @@ set(MV_PUBLIC_LIB Core)                      # A public shared library used by p
 # -----------------------------------------------------------------------------
 # CMake Settings
 # -----------------------------------------------------------------------------
-set(CMAKE_CXX_STANDARD 20)
+set(MV_CXX_STANDARD 20)
+
+set(CMAKE_CXX_STANDARD ${MV_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -332,7 +334,7 @@ target_include_directories(${MV_PUBLIC_LIB} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}
 target_include_directories(${MV_PUBLIC_LIB} PRIVATE "${nlohmann_json_SOURCE_DIR}/include")
 target_include_directories(${MV_PUBLIC_LIB} PRIVATE "${valijson_SOURCE_DIR}/include")
 
-target_compile_features(${MV_PUBLIC_LIB} PUBLIC cxx_std_20)
+target_compile_features(${MV_PUBLIC_LIB} PUBLIC cxx_std_${MV_CXX_STANDARD})
 
 target_compile_definitions(${MV_PUBLIC_LIB} 
     PRIVATE 
@@ -394,7 +396,7 @@ target_include_directories(${MV_EXE} PRIVATE
 target_include_directories(${MV_EXE} PRIVATE "${nlohmann_json_SOURCE_DIR}/include")
 target_include_directories(${MV_EXE} PRIVATE "${valijson_SOURCE_DIR}/include")
 
-target_compile_features(${MV_EXE} PRIVATE cxx_std_20)
+target_compile_features(${MV_EXE} PRIVATE cxx_std_${MV_CXX_STANDARD})
 
 target_compile_definitions(${MV_EXE} PRIVATE VALIJSON_USE_EXCEPTIONS=1)
 

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -332,7 +332,7 @@ target_include_directories(${MV_PUBLIC_LIB} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}
 target_include_directories(${MV_PUBLIC_LIB} PRIVATE "${nlohmann_json_SOURCE_DIR}/include")
 target_include_directories(${MV_PUBLIC_LIB} PRIVATE "${valijson_SOURCE_DIR}/include")
 
-target_compile_features(${MV_PUBLIC_LIB} PRIVATE cxx_std_20)
+target_compile_features(${MV_PUBLIC_LIB} PUBLIC cxx_std_20)
 
 target_compile_definitions(${MV_PUBLIC_LIB} 
     PRIVATE 

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -652,6 +652,7 @@ set(ManiVault_LIB_DIR "${MV_INSTALL_DIR}/$<CONFIGURATION>/lib/" CACHE INTERNAL "
 set(ManiVault_INSTALL_DIR "${MV_INSTALL_DIR}" CACHE INTERNAL "")
 set(ManiVault_CMAKE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake/" CACHE INTERNAL "") # this differs from config
 set(ManiVault_VERSION "${MV_VERSION}" CACHE INTERNAL "")
+set(ManiVault_CXX_STANDARD "${MV_CXX_STANDARD}" CACHE INTERNAL "")
 
 # Call the install functions of the all public targets
 # needed for plugins directly after the build

--- a/ManiVault/cmake/MvCoreConfig.cmake.in
+++ b/ManiVault/cmake/MvCoreConfig.cmake.in
@@ -6,6 +6,8 @@ set(ManiVault_INCLUDE_DIR "${ManiVault_INSTALL_DIR}/$<CONFIGURATION>/include")
 set(ManiVault_LIB_DIR "${ManiVault_INSTALL_DIR}/$<CONFIGURATION>/lib")
 set_and_check(ManiVault_CMAKE_DIR "${PACKAGE_PREFIX_DIR}/cmake/mv" CACHE INTERNAL "")
 
+set(ManiVault_CXX_STANDARD @MV_CXX_STANDARD@)
+
 list(APPEND ManiVault_LINK_LIBS ManiVault::Core ManiVault::PointData ManiVault::ClusterData ManiVault::ImageData ManiVault::ColorData ManiVault::TextData)
 
 include("${ManiVault_CMAKE_DIR}/ManiVaultTargets.cmake")

--- a/ManiVault/src/plugins/ClusterData/CMakeLists.txt
+++ b/ManiVault/src/plugins/ClusterData/CMakeLists.txt
@@ -79,7 +79,7 @@ add_library(ManiVault::${CLUSTERDATA} ALIAS ${CLUSTERDATA})
 
 target_include_directories(${CLUSTERDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${CLUSTERDATA} PUBLIC cxx_std_20)
+target_compile_features(${CLUSTERDATA} PUBLIC cxx_std_${MV_CXX_STANDARD})
 
 # Generate a header file that contains the EXPORT macro for this library.
 include(GenerateExportHeader)

--- a/ManiVault/src/plugins/ClusterData/CMakeLists.txt
+++ b/ManiVault/src/plugins/ClusterData/CMakeLists.txt
@@ -79,7 +79,7 @@ add_library(ManiVault::${CLUSTERDATA} ALIAS ${CLUSTERDATA})
 
 target_include_directories(${CLUSTERDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${CLUSTERDATA} PRIVATE cxx_std_20)
+target_compile_features(${CLUSTERDATA} PUBLIC cxx_std_20)
 
 # Generate a header file that contains the EXPORT macro for this library.
 include(GenerateExportHeader)

--- a/ManiVault/src/plugins/ColorData/CMakeLists.txt
+++ b/ManiVault/src/plugins/ColorData/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(ManiVault::${COLORDATA} ALIAS ${COLORDATA})
 
 target_include_directories(${COLORDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${COLORDATA} PRIVATE cxx_std_20)
+target_compile_features(${COLORDATA} PUBLIC cxx_std_20)
 
 # Generate a header file that contains the EXPORT macro for this library.
 include(GenerateExportHeader)

--- a/ManiVault/src/plugins/ColorData/CMakeLists.txt
+++ b/ManiVault/src/plugins/ColorData/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(ManiVault::${COLORDATA} ALIAS ${COLORDATA})
 
 target_include_directories(${COLORDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${COLORDATA} PUBLIC cxx_std_20)
+target_compile_features(${COLORDATA} PUBLIC cxx_std_${MV_CXX_STANDARD})
 
 # Generate a header file that contains the EXPORT macro for this library.
 include(GenerateExportHeader)

--- a/ManiVault/src/plugins/DataHierarchyPlugin/CMakeLists.txt
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/CMakeLists.txt
@@ -42,7 +42,7 @@ add_library(${DATAHIERARCHYPLUGIN} SHARED ${DATAHIERARCHY_SOURCES})
 
 target_include_directories(${DATAHIERARCHYPLUGIN} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${DATAHIERARCHYPLUGIN} PRIVATE cxx_std_20)
+target_compile_features(${DATAHIERARCHYPLUGIN} PRIVATE cxx_std_${MV_CXX_STANDARD})
 
 target_link_libraries(${DATAHIERARCHYPLUGIN} PRIVATE Qt6::Widgets)
 target_link_libraries(${DATAHIERARCHYPLUGIN} PRIVATE Qt6::WebEngineWidgets)

--- a/ManiVault/src/plugins/DataPropertiesPlugin/CMakeLists.txt
+++ b/ManiVault/src/plugins/DataPropertiesPlugin/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(${DATAPROPERTIESPLUGIN} SHARED ${DATAPROPERTIES_SOURCES})
 
 target_include_directories(${DATAPROPERTIESPLUGIN} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${DATAPROPERTIESPLUGIN} PRIVATE cxx_std_20)
+target_compile_features(${DATAPROPERTIESPLUGIN} PRIVATE cxx_std_${MV_CXX_STANDARD})
 
 target_link_libraries(${DATAPROPERTIESPLUGIN} PRIVATE Qt6::Core)
 target_link_libraries(${DATAPROPERTIESPLUGIN} PRIVATE Qt6::Widgets)

--- a/ManiVault/src/plugins/ImageData/CMakeLists.txt
+++ b/ManiVault/src/plugins/ImageData/CMakeLists.txt
@@ -37,7 +37,7 @@ add_library(ManiVault::${IMAGEDATA} ALIAS ${IMAGEDATA})
 
 target_include_directories(${IMAGEDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${IMAGEDATA} PUBLIC cxx_std_20)
+target_compile_features(${IMAGEDATA} PUBLIC cxx_std_${MV_CXX_STANDARD})
 
 # Generate a header file that contains the EXPORT macro for this library.
 include(GenerateExportHeader)

--- a/ManiVault/src/plugins/ImageData/CMakeLists.txt
+++ b/ManiVault/src/plugins/ImageData/CMakeLists.txt
@@ -37,7 +37,7 @@ add_library(ManiVault::${IMAGEDATA} ALIAS ${IMAGEDATA})
 
 target_include_directories(${IMAGEDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${IMAGEDATA} PRIVATE cxx_std_20)
+target_compile_features(${IMAGEDATA} PUBLIC cxx_std_20)
 
 # Generate a header file that contains the EXPORT macro for this library.
 include(GenerateExportHeader)

--- a/ManiVault/src/plugins/LoggingPlugin/CMakeLists.txt
+++ b/ManiVault/src/plugins/LoggingPlugin/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(${LOGGINGPLUGIN} SHARED ${LOGGING_SOURCES})
 
 target_include_directories(${LOGGINGPLUGIN} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${LOGGINGPLUGIN} PRIVATE cxx_std_20)
+target_compile_features(${LOGGINGPLUGIN} PRIVATE cxx_std_${MV_CXX_STANDARD})
 
 target_link_libraries(${LOGGINGPLUGIN} PRIVATE Qt6::Widgets)
 target_link_libraries(${LOGGINGPLUGIN} PRIVATE Qt6::WebEngineWidgets)

--- a/ManiVault/src/plugins/PointData/CMakeLists.txt
+++ b/ManiVault/src/plugins/PointData/CMakeLists.txt
@@ -88,7 +88,7 @@ add_library(ManiVault::${POINTDATA} ALIAS ${POINTDATA})
 target_include_directories(${POINTDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 target_include_directories(${POINTDATA} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../external/biovault/)
 
-target_compile_features(${POINTDATA} PRIVATE cxx_std_20)
+target_compile_features(${POINTDATA} PUBLIC cxx_std_20)
 
 # Generate a header file that contains the EXPORT macro for this library.
 include(GenerateExportHeader)

--- a/ManiVault/src/plugins/PointData/CMakeLists.txt
+++ b/ManiVault/src/plugins/PointData/CMakeLists.txt
@@ -88,7 +88,7 @@ add_library(ManiVault::${POINTDATA} ALIAS ${POINTDATA})
 target_include_directories(${POINTDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 target_include_directories(${POINTDATA} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../external/biovault/)
 
-target_compile_features(${POINTDATA} PUBLIC cxx_std_20)
+target_compile_features(${POINTDATA} PUBLIC cxx_std_${MV_CXX_STANDARD})
 
 # Generate a header file that contains the EXPORT macro for this library.
 include(GenerateExportHeader)

--- a/ManiVault/src/plugins/SampleScopePlugin/CMakeLists.txt
+++ b/ManiVault/src/plugins/SampleScopePlugin/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(${SAMPLE_CONTEXT_PLUGIN} SHARED ${SAMPLE_SCOPE_PLUGIN_SOURCES})
 
 target_include_directories(${SAMPLE_CONTEXT_PLUGIN} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${SAMPLE_CONTEXT_PLUGIN} PRIVATE cxx_std_20)
+target_compile_features(${SAMPLE_CONTEXT_PLUGIN} PRIVATE cxx_std_${MV_CXX_STANDARD})
 
 target_link_libraries(${SAMPLE_CONTEXT_PLUGIN} PRIVATE Qt6::Core)
 target_link_libraries(${SAMPLE_CONTEXT_PLUGIN} PRIVATE Qt6::Widgets)

--- a/ManiVault/src/plugins/SharedParametersPlugin/CMakeLists.txt
+++ b/ManiVault/src/plugins/SharedParametersPlugin/CMakeLists.txt
@@ -33,7 +33,7 @@ add_dependencies(${SHARED_PARAMETERS_PLUGIN} ${MV_PUBLIC_LIB})
 
 target_include_directories(${SHARED_PARAMETERS_PLUGIN} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include")
 
-target_compile_features(${SHARED_PARAMETERS_PLUGIN} PRIVATE cxx_std_20)
+target_compile_features(${SHARED_PARAMETERS_PLUGIN} PRIVATE cxx_std_${MV_CXX_STANDARD})
 
 target_link_libraries(${SHARED_PARAMETERS_PLUGIN} PRIVATE Qt6::Widgets)
 target_link_libraries(${SHARED_PARAMETERS_PLUGIN} PRIVATE Qt6::WebEngineWidgets)

--- a/ManiVault/src/plugins/TasksPlugin/CMakeLists.txt
+++ b/ManiVault/src/plugins/TasksPlugin/CMakeLists.txt
@@ -26,7 +26,7 @@ add_dependencies(${TASKS_PLUGIN} ${MV_PUBLIC_LIB})
 
 target_include_directories(${TASKS_PLUGIN} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include")
 
-target_compile_features(${TASKS_PLUGIN} PRIVATE cxx_std_20)
+target_compile_features(${TASKS_PLUGIN} PRIVATE cxx_std_${MV_CXX_STANDARD})
 
 target_link_libraries(${TASKS_PLUGIN} PRIVATE Qt6::Widgets)
 target_link_libraries(${TASKS_PLUGIN} PRIVATE Qt6::WebEngineWidgets)

--- a/ManiVault/src/plugins/TextData/CMakeLists.txt
+++ b/ManiVault/src/plugins/TextData/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(ManiVault::${TEXTDATA} ALIAS ${TEXTDATA})
 
 target_include_directories(${TEXTDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${TEXTDATA} PRIVATE cxx_std_20)
+target_compile_features(${TEXTDATA} PUBLIC cxx_std_20)
 
 # Generate a header file that contains the EXPORT macro for this library.
 include(GenerateExportHeader)

--- a/ManiVault/src/plugins/TextData/CMakeLists.txt
+++ b/ManiVault/src/plugins/TextData/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(ManiVault::${TEXTDATA} ALIAS ${TEXTDATA})
 
 target_include_directories(${TEXTDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${TEXTDATA} PUBLIC cxx_std_20)
+target_compile_features(${TEXTDATA} PUBLIC cxx_std_${MV_CXX_STANDARD})
 
 # Generate a header file that contains the EXPORT macro for this library.
 include(GenerateExportHeader)

--- a/ManiVault/src/plugins/TutorialPlugin/CMakeLists.txt
+++ b/ManiVault/src/plugins/TutorialPlugin/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(${TUTORIAL_PLUGIN} SHARED ${TUTORIAL_PLUGIN_SOURCES})
 
 target_include_directories(${TUTORIAL_PLUGIN} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
-target_compile_features(${TUTORIAL_PLUGIN} PRIVATE cxx_std_20)
+target_compile_features(${TUTORIAL_PLUGIN} PRIVATE cxx_std_${MV_CXX_STANDARD})
 
 target_link_libraries(${TUTORIAL_PLUGIN} PRIVATE Qt6::Core)
 target_link_libraries(${TUTORIAL_PLUGIN} PRIVATE Qt6::Widgets)


### PR DESCRIPTION
Currently, we manually set the c++ version in plugins to align with the c++ version used in the core like this:
```cmake
target_compile_features(${MY_PLUGIN_TARGET} PRIVATE cxx_std_20)
```
If we want to bump the language version of the core, we'll need to updated each plugin.

A better way is to expose the language version as a public target property of the core. 
Then, when linking a plugin to `ManiVault::Core`, the plugin can see that `ManiVault::Core` requires a specific language version and will automatically set its minimum language version to that one. We won't need the above `target_compile_features` for the plugin anymore (expect if we want to set a newer language version of the plugin). I.e. we can simply delete that line when updating plugins.

This PR also adds `MV_CXX_STANDARD` to the core CMake config, so that we can change the language version of all ManiVault targets in one place.

I've also exported this variable as `ManiVault_CXX_STANDARD` for plugins to access. I don't think that we should encourage using this, since we can always query the language version of the core. But maybe someone will find this shortcut useful:
```cmake
find_package(ManiVault COMPONENTS Core CONFIG QUIET)

get_target_property(FEATURES_Core ManiVault::Core INTERFACE_COMPILE_FEATURES)
message(STATUS "Features for ManiVault::Core: ${FEATURES_Core}")
>> Features for ManiVault::Core: cxx_std_20

message(STATUS "ManiVault_CXX_STANDARD: ${ManiVault_CXX_STANDARD}")
>> ManiVault_CXX_STANDARD: 20
```

---

Relevant CMake doc: [INTERFACE_COMPILE_FEATURES](https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_COMPILE_FEATURES.html)
> When target dependencies are specified using [target_link_libraries()](https://cmake.org/cmake/help/latest/command/target_link_libraries.html#command:target_link_libraries), CMake will read this property from all target dependencies to determine the build properties of the consumer.