### PR TITLE
Fix missing CoreInterface includes

### DIFF
--- a/ManiVault/src/actions/NavigationAction.cpp
+++ b/ManiVault/src/actions/NavigationAction.cpp
@@ -5,6 +5,7 @@
 #include "NavigationAction.h"
 
 #include "GroupSectionTreeItem.h"
+#include "CoreInterface.h"
 
 #include "util/StyledIcon.h"
 #include "util/Icon.h"

--- a/ManiVault/src/actions/WidgetActionLabel.cpp
+++ b/ManiVault/src/actions/WidgetActionLabel.cpp
@@ -6,6 +6,7 @@
 #include "WidgetAction.h"
 #include "WidgetActionContextMenu.h"
 #include "Application.h"
+#include "CoreInterface.h"
 
 #include <QDebug>
 #include <QHBoxLayout>


### PR DESCRIPTION
This patch adds the missing `CoreInterface.h` include to two action source files so the `mv::projects()` and `actions()` helpers are declared in those translation units.

It resolves the compile errors seen in `WidgetActionLabel.cpp` and `NavigationAction.cpp` during the core build.