### PR TITLE
Add `StandardPaths::getPluginDependenciesDirectory`

### DIFF
--- a/ManiVault/src/private/PluginManager.cpp
+++ b/ManiVault/src/private/PluginManager.cpp
@@ -101,22 +101,16 @@ void PluginManager::loadPluginFactories()
     qDebug() << "Loading plugin factories";
 #endif
 
-    QDir pluginsDir(StandardPaths::getPluginsDirectory());
+    const QDir pluginsDir(StandardPaths::getPluginsDirectory());
+    const QDir pluginsDependenciesDir(StandardPaths::getPluginDependenciesDirectory());
     
     _pluginFactories.clear();
 
     auto getPluginDependencyDir = [](const QDir& dir, const QString& name) -> std::pair<QDir, bool> {
         QDir dependenciesDir = dir;
 
-        dependenciesDir.cdUp();
-
-    	if (!dependenciesDir.cd("PluginDependencies"))  // name by convention
-            return { dependenciesDir, false };
-
     	if (!dependenciesDir.cd(name))
             return { dependenciesDir, false };
-
-    	dependenciesDir.cd(name);
 
     	return { dependenciesDir, true };
     };
@@ -140,10 +134,10 @@ void PluginManager::loadPluginFactories()
         return baseName;
         };
 
-    auto loadPluginDependencies = [&getLibraryName, &getPluginDependencyDir](const QDir& pluginDir, const QString& fileName) -> void {
+    auto loadPluginDependencies = [&getLibraryName, &getPluginDependencyDir](const QDir& pluginsDependenciesDir, const QString& fileName) -> void {
 
         const auto pluginName = getLibraryName(fileName);
-        const auto [pluginDependenciesDir, pluginDependenciesExists] = getPluginDependencyDir(pluginDir, pluginName);
+        const auto [pluginDependenciesDir, pluginDependenciesExists] = getPluginDependencyDir(pluginsDependenciesDir, pluginName);
 
         if (!pluginDependenciesExists)
             return;
@@ -189,7 +183,7 @@ void PluginManager::loadPluginFactories()
     for (const auto& fileName: resolvedPlugins)
     {
         // Load plugin dependencies, if there are any
-        loadPluginDependencies(pluginsDir, fileName);
+        loadPluginDependencies(pluginsDependenciesDir, fileName);
 
         // Dynamic loader of plugin shared library
         QPluginLoader pluginLoader(pluginsDir.absoluteFilePath(fileName));

--- a/ManiVault/src/private/PluginManager.cpp
+++ b/ManiVault/src/private/PluginManager.cpp
@@ -282,7 +282,7 @@ QStringList PluginManager::resolveDependencies(QDir pluginDir) const
      * immediately add it to the list of resolved plugins. Dependencies are given by a list of plugin kinds
      * under the 'dependencies' key in the accompanying .json metadata file.
      */
-    for (QString fileName: pluginDir.entryList(QDir::Files))
+    for (const QString& fileName: pluginDir.entryList(QDir::Files))
     {
         QPluginLoader pluginLoader(pluginDir.absoluteFilePath(fileName));
 

--- a/ManiVault/src/util/StandardPaths.cpp
+++ b/ManiVault/src/util/StandardPaths.cpp
@@ -12,6 +12,14 @@
 
 namespace mv::util {
 
+namespace
+{
+    constexpr bool isMacOS()
+    {
+        return QOperatingSystemVersion::currentType() == QOperatingSystemVersion::MacOS;
+    }
+}
+
 QString StandardPaths::get(StandardLocation location)
 {
 	switch (location) {
@@ -105,11 +113,6 @@ QString StandardPaths::getLogsDirectory()
         return QDir::homePath();
 
     return documentLocationsDir.filePath(dirSuffix);
-}
-
-bool StandardPaths::isMacOS()
-{
-    return QOperatingSystemVersion::currentType() == QOperatingSystemVersion::MacOS;
 }
 
 }

--- a/ManiVault/src/util/StandardPaths.cpp
+++ b/ManiVault/src/util/StandardPaths.cpp
@@ -115,4 +115,17 @@ QString StandardPaths::getLogsDirectory()
     return documentLocationsDir.filePath(dirSuffix);
 }
 
+QString StandardPaths::getPluginDependenciesDirectory()
+{
+    const auto applicationDir = QDir(QCoreApplication::applicationDirPath());
+    const auto dirName = QString("PluginDependencies");
+
+    auto pathSuffix = QString("/%1/").arg(dirName);
+
+    if constexpr (isMacOS())
+        pathSuffix = applicationDir.dirName() == "MacOS" ? QString("../../../../%1").arg(dirName) : QString("/../%1").arg(dirName);
+
+    return QDir::cleanPath(applicationDir.path() + pathSuffix);
+}
+
 }

--- a/ManiVault/src/util/StandardPaths.cpp
+++ b/ManiVault/src/util/StandardPaths.cpp
@@ -40,7 +40,7 @@ QString StandardPaths::getPluginsDirectory()
 
     auto pathSuffix = QString("/%1/").arg(dirName);
 
-    if (isMacOS())
+    if constexpr (isMacOS())
         pathSuffix = applicationDir.dirName() == "MacOS" ? QString("../../../../%1").arg(dirName) : QString("/../%1").arg(dirName);
 
     return QDir::cleanPath(applicationDir.path() + pathSuffix);
@@ -52,7 +52,7 @@ QString StandardPaths::getDownloadsDirectory()
     const auto applicationDataDir   = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
     const auto dirName              = QString("Downloads");
 
-    if (isMacOS()) {
+    if constexpr (isMacOS()) {
         const auto pathSuffix = applicationDir.dirName() == "MacOS" ? QString("../../../../%1").arg(dirName) : QString("/../%1").arg(dirName);
         const auto finalPath = QDir::cleanPath(applicationDir.path() + pathSuffix);
 
@@ -73,7 +73,7 @@ QString StandardPaths::getCustomizationDirectory()
 
     QString pathSuffix = QString("/%1").arg(dirName);
 
-    if (isMacOS())
+    if constexpr (isMacOS())
         pathSuffix = applicationDir.dirName() == "MacOS" ? QString("../../../../%1").arg(dirName) : QString("/../%1").arg(dirName);
 
     const auto finalPath = QDir::cleanPath(applicationDir.path() + pathSuffix);

--- a/ManiVault/src/util/StandardPaths.h
+++ b/ManiVault/src/util/StandardPaths.h
@@ -27,7 +27,8 @@ public:
         Downloads,
         Customization,
         Projects,
-        Logs
+        Logs,
+        PluginDependencies
     };
 
     /**
@@ -45,6 +46,7 @@ public: // Specific getters for convenience
     static QString getCustomizationDirectory();
     static QString getProjectsDirectory();
     static QString getLogsDirectory();
+    static QString getPluginDependenciesDirectory();
 
 };
 

--- a/ManiVault/src/util/StandardPaths.h
+++ b/ManiVault/src/util/StandardPaths.h
@@ -46,13 +46,6 @@ public: // Specific getters for convenience
     static QString getProjectsDirectory();
     static QString getLogsDirectory();
 
-private:
-
-    /**
-     * Determine if the OS is macOS
-     * @return True if the OS is macOS
-     */
-    static bool isMacOS();
 };
 
 }


### PR DESCRIPTION
This PR adds `StandardPaths::getPluginDependenciesDirectory()` which returns the path to the PluginDependencies folder. Previously this path was hard-coded in all places that might have needed it.

We can use this to simplify path resolution when loading plugin dependencies and in plugins like the JupyterPlugin this will help with cross-platform path resolutions as well.

Drive-by:
- Add `constexpr if`s and make `isMacOS` constexpr 
- I moved `isMacOS` from a private member function to an anonymous namespace since it caused some compilation issues in the `if constexpr`s when tagging it as `static constexpr`