### PR TITLE
Change navigationbar icon order

### DIFF
--- a/ManiVault/src/actions/NavigationAction.cpp
+++ b/ManiVault/src/actions/NavigationAction.cpp
@@ -54,10 +54,9 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
     _zoomExtentsAction.setToolTip("Zoom to the boundaries of the scene (o)");
     _zoomSelectionAction.setToolTip("Zoom to the boundaries of the current selection (b)");
     _zoomRegionAction.setToolTip("Zoom to a picked region");
-    _freezeNavigation.setToolTip("Freeze the navigation");
+    _freezeNavigation.setToolTip("Toggle the navigation on/off");
 
-    _freezeNavigation.setIconByName("icicles");
-    _freezeNavigation.setDefaultWidgetFlags(ToggleAction::WidgetFlag::CheckBox);
+    _freezeNavigation.setIconByName("hand-pointer");
 
     _zoomPercentageAction.setOverrideSizeHint(QSize(300, 0));
 
@@ -104,6 +103,8 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
 
     const auto updateReadOnly = [this]() -> void {
         const bool navigationIsActive = isNavigationActive();
+
+        _freezeNavigation.setIconByName(navigationIsActive ? "hand-pointer":  "hand-back-fist");
 
         _zoomOutAction.setEnabled(navigationIsActive);
         _zoomPercentageAction.setEnabled(navigationIsActive);

--- a/ManiVault/src/actions/NavigationAction.cpp
+++ b/ManiVault/src/actions/NavigationAction.cpp
@@ -103,15 +103,15 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
     addAction(&_zoomMarginAction);
 
     const auto updateReadOnly = [this]() -> void {
-        const auto notFrozen = _freezeNavigation.isChecked();
+        const bool navigationIsActive = isNavigationActive();
 
-        _zoomOutAction.setEnabled(!notFrozen);
-        _zoomPercentageAction.setEnabled(!notFrozen);
-        _zoomInAction.setEnabled(!notFrozen);
-        _zoomExtentsAction.setEnabled(!notFrozen);
-        _zoomSelectionAction.setEnabled(!notFrozen);
-        _zoomRegionAction.setEnabled(!notFrozen);
-        _zoomCenterAction.setEnabled(!notFrozen);
+        _zoomOutAction.setEnabled(navigationIsActive);
+        _zoomPercentageAction.setEnabled(navigationIsActive);
+        _zoomInAction.setEnabled(navigationIsActive);
+        _zoomExtentsAction.setEnabled(navigationIsActive);
+        _zoomSelectionAction.setEnabled(navigationIsActive);
+        _zoomRegionAction.setEnabled(navigationIsActive);
+        _zoomCenterAction.setEnabled(navigationIsActive);
     };
 
     updateReadOnly();

--- a/ManiVault/src/actions/NavigationAction.cpp
+++ b/ManiVault/src/actions/NavigationAction.cpp
@@ -90,6 +90,7 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
     _zoomGroupAction.setShowLabels(false);
     _zoomGroupAction.setIconByName("magnifying-glass");
 
+    _zoomGroupAction.addAction(&_freezeNavigation, ToggleAction::PushButtonIcon);
     _zoomGroupAction.addAction(&_zoomOutAction, TriggerAction::Icon);
     _zoomGroupAction.addAction(&_zoomPercentageAction);
     _zoomGroupAction.addAction(&_zoomInAction, TriggerAction::Icon);
@@ -99,7 +100,6 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
     _zoomGroupAction.addAction(&_zoomRegionAction, TriggerAction::Icon);
     
     addAction(&_zoomGroupAction, 1);
-    addAction(&_freezeNavigation, 50);
     addAction(&_zoomMarginAction);
 
     const auto updateReadOnly = [this]() -> void {

--- a/ManiVault/src/actions/NavigationAction.cpp
+++ b/ManiVault/src/actions/NavigationAction.cpp
@@ -9,12 +9,6 @@
 #include "util/StyledIcon.h"
 #include "util/Icon.h"
 
-#ifdef _DEBUG
-    //#define NAVIGATION_ACTION_VERBOSE
-#endif
-
-//#define NAVIGATION_ACTION_VERBOSE
-
 using namespace mv::util;
 
 namespace mv::gui

--- a/ManiVault/src/actions/NavigationAction.cpp
+++ b/ManiVault/src/actions/NavigationAction.cpp
@@ -112,6 +112,7 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
         _zoomSelectionAction.setEnabled(navigationIsActive);
         _zoomRegionAction.setEnabled(navigationIsActive);
         _zoomCenterAction.setEnabled(navigationIsActive);
+        _zoomMarginAction.setEnabled(navigationIsActive);
     };
 
     updateReadOnly();

--- a/ManiVault/src/actions/NavigationAction.cpp
+++ b/ManiVault/src/actions/NavigationAction.cpp
@@ -98,9 +98,9 @@ NavigationAction::NavigationAction(QObject* parent, const QString& title) :
     _zoomGroupAction.addAction(&_zoomExtentsAction, TriggerAction::Icon);
     _zoomGroupAction.addAction(&_zoomSelectionAction, TriggerAction::Icon);
     _zoomGroupAction.addAction(&_zoomRegionAction, TriggerAction::Icon);
+    _zoomGroupAction.addAction(&_zoomMarginAction);
     
     addAction(&_zoomGroupAction, 1);
-    addAction(&_zoomMarginAction);
 
     const auto updateReadOnly = [this]() -> void {
         const bool navigationIsActive = isNavigationActive();

--- a/ManiVault/src/actions/NavigationAction.h
+++ b/ManiVault/src/actions/NavigationAction.h
@@ -11,7 +11,6 @@
 #include "actions/HorizontalGroupAction.h"
 #include "actions/DecimalRectangleAction.h"
 #include "actions/DecimalPointAction.h"
-#include "actions/VerticalGroupAction.h"
 #include "actions/ZoomMarginAction.h"
 
 #include <QObject>

--- a/ManiVault/src/actions/NavigationAction.h
+++ b/ManiVault/src/actions/NavigationAction.h
@@ -78,6 +78,10 @@ public: // Serialization
 
     QVariantMap toVariantMap() const override;
 
+public: // State getters
+    [[nodiscard]] bool isNavigationFrozen() const { return _freezeNavigation.isChecked(); }
+    [[nodiscard]] bool isNavigationActive() const { return !isNavigationFrozen(); }
+
 public: // Action getters
 
     TriggerAction& getZoomOutAction() { return _zoomOutAction; }

--- a/ManiVault/src/renderers/Navigator2D.cpp
+++ b/ManiVault/src/renderers/Navigator2D.cpp
@@ -202,7 +202,7 @@ bool Navigator2D::eventFilter(QObject* watched, QEvent* event)
     if (!_initialized || !_enabled)
         return false;
 
-    if (getNavigationAction().getFreezeNavigation().isChecked())
+    if (getNavigationAction().isNavigationFrozen())
         return QObject::eventFilter(watched, event);
 
     if (event->type() == QEvent::KeyPress) {
@@ -366,7 +366,7 @@ QRectF Navigator2D::getZoomRectangleWorld() const
 
 void Navigator2D::setZoomRectangleWorld(const QRectF& zoomRectangleWorld)
 {
-    if (getNavigationAction().getFreezeNavigation().isChecked())
+    if (getNavigationAction().isNavigationFrozen())
         return;
 
 #ifdef NAVIGATOR_2D_VERBOSE


### PR DESCRIPTION
This PR aims to streamline the layout of the navigation bars in plugins that use the `NavigationAction` from the core (as used in e.g. the [Scatterplot](https://github.com/ManiVaultStudio/Scatterplot)) and other plugins like the [ImageViewer](github.com/ManiVaultStudio/ImageViewerPlugin).

New (this PR):
<img width="409" height="38" alt="new-nav" src="https://github.com/user-attachments/assets/d2e1d8fd-3afd-4c14-a3a6-1ff91a50e370" /> (default: navigation `ON`)
<img width="401" height="39" alt="new-freeze" src="https://github.com/user-attachments/assets/5173611a-9f60-4876-924f-52fd74fad9f3" /> &nbsp; (frozen: navigation `OFF`)

Old (current):
<img width="492" height="32" alt="image" src="https://github.com/user-attachments/assets/250dafb8-5da4-4e89-ab1f-82d81ce0d9f6" />
<img width="498" height="34" alt="image" src="https://github.com/user-attachments/assets/bf8b2ead-863d-4140-9816-e093a8ade969" />

Image Viewer (does not use the `NavigationAction` but a custom setup):
<img width="380" height="36" alt="image" src="https://github.com/user-attachments/assets/49746e1c-fc1e-43b2-8491-846f21ed2ab2" />

Drive-by:
- Fix: the `_zoomMarginAction` was not disabled when navigation was frozen
- Adds the two status getter `isNavigationFrozen()` and `isNavigationActive()` to `NavigationAction`