### PR TITLE
Consistently use uint64_t in PointData

### DIFF
--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -300,7 +300,7 @@ void PointData::extractFullDataForDimensions(std::vector<mv::Vector2f>& result, 
 }
 
 
-void PointData::extractDataForDimensions(std::vector<mv::Vector2f>& result, const int dimensionIndex1, const int dimensionIndex2, const std::vector<unsigned int>& indices) const
+void PointData::extractDataForDimensions(std::vector<mv::Vector2f>& result, const int dimensionIndex1, const int dimensionIndex2, const std::vector<std::uint32_t>& indices) const
 {
     CheckDimensionIndex(dimensionIndex1);
     CheckDimensionIndex(dimensionIndex2);
@@ -702,7 +702,7 @@ void Points::selectedLocalIndices(const std::vector<std::uint32_t>& selectionInd
     }
 }
 
-void Points::getLocalSelectionIndices(std::vector<unsigned int>& localSelectionIndices) const
+void Points::getLocalSelectionIndices(std::vector<std::uint32_t>& localSelectionIndices) const
 {
     if (isProxy())
     {
@@ -939,7 +939,7 @@ bool Points::canSelectInvert() const
 
 void Points::selectAll()
 {
-    std::vector<unsigned int> selectionIndices;
+    std::vector<std::uint32_t> selectionIndices;
 
     selectionIndices.resize(getNumPoints());
 
@@ -963,7 +963,7 @@ void Points::selectNone()
 void Points::selectInvert()
 {
     // Get the locally selected indices (the points in the subset that are selected)
-    std::vector<unsigned int> localSelectionIndices;
+    std::vector<std::uint32_t> localSelectionIndices;
     getLocalSelectionIndices(localSelectionIndices);
 
     // Compute the inverse of this

--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -45,11 +45,6 @@ namespace
 
 }
 
-PointData::~PointData(void)
-{
-    
-}
-
 void PointData::init()
 {
 }
@@ -326,10 +321,6 @@ Points::Points(QString dataName, bool mayUnderive /*= true*/, const QString& gui
     _infoAction(nullptr),
     _dimensionsPickerGroupAction(nullptr),
     _dimensionsPickerAction(nullptr)
-{
-}
-
-Points::~Points()
 {
 }
 

--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -1108,10 +1108,10 @@ QVariantMap Points::toVariantMap() const
     if (dimensionNames.size() > 1000)
         dimensionsDataStream << dimensionNames;
 
-    QVariantMap indices;
+    QVariantMap indicesMap;
 
-    indices["Count"]    = QVariant::fromValue(this->indices.size());
-    indices["Raw"]      = rawDataToVariantMap((char*)this->indices.data(), this->indices.size() * sizeof(std::uint32_t), true);
+    indicesMap["Count"]    = QVariant::fromValue(this->indices.size());
+    indicesMap["Raw"]      = rawDataToVariantMap((char*)this->indices.data(), this->indices.size() * sizeof(typename decltype(this->indices)::value_type), true);
 
     QVariantMap selection;
 
@@ -1119,12 +1119,12 @@ QVariantMap Points::toVariantMap() const
         auto selectionSet = getSelection<Points>();
 
         selection["Count"]  = QVariant::fromValue(selectionSet->indices.size());
-        selection["Raw"]    = rawDataToVariantMap((char*)selectionSet->indices.data(), selectionSet->indices.size() * sizeof(std::uint32_t), true);
+        selection["Raw"]    = rawDataToVariantMap((char*)selectionSet->indices.data(), selectionSet->indices.size() * sizeof(typename decltype(this->indices)::value_type), true);
     }
 
     variantMap["Data"]                  = isFull() ? getRawData<PointData>()->toVariantMap() : QVariantMap();
     variantMap["NumberOfPoints"]        = QVariant::fromValue<std::uint64_t>(getNumPoints());
-    variantMap["Indices"]               = indices;
+    variantMap["Indices"]               = indicesMap;
     variantMap["Selection"]             = selection;
     variantMap["DimensionNames"]        = (dimensionNames.size() > 1000) ? rawDataToVariantMap((char*)dimensionsByteArray.data(), dimensionsByteArray.size(), true) : QVariant::fromValue(dimensionNames);
     variantMap["NumberOfDimensions"]    = QVariant::fromValue<std::uint64_t>(getNumDimensions());

--- a/ManiVault/src/plugins/PointData/src/PointData.h
+++ b/ManiVault/src/plugins/PointData/src/PointData.h
@@ -206,7 +206,7 @@ public:
     using ElementTypeAt = typename std::variant_alternative_t<N, VariantOfVectors>::value_type;
 
     PointData(PluginFactory* factory) : RawData(factory, PointType) { }
-    ~PointData(void) override;
+    ~PointData() override = default;
 
     void init() override;
 
@@ -600,7 +600,7 @@ private:
 
 public:
     Points(QString dataName, bool mayUnderive = true, const QString& guid = "");
-    ~Points() override;
+    ~Points() override = default;
 
     void init() override;
 

--- a/ManiVault/src/plugins/PointData/src/PointData.h
+++ b/ManiVault/src/plugins/PointData/src/PointData.h
@@ -301,7 +301,7 @@ public:
 
         std::visit([&resultContainer, this, &dimensionIndices, &indices](const auto& vec)
             {
-                const std::uint64_t numPoints{ static_cast<std::uint32_t>(indices.size()) };
+                const std::uint64_t numPoints{ static_cast<std::uint64_t>(indices.size()) };
                 std::uint64_t resultIndex{};
 
                 for (std::uint64_t pointIndex{}; pointIndex < numPoints; ++pointIndex)
@@ -352,7 +352,7 @@ public:
     void convertData(const T* const data, const std::size_t numPoints, const std::size_t numDimensions)
     {
         convertData(data, numPoints * numDimensions);
-        _numDimensions = static_cast<std::uint32_t>(numDimensions);
+        _numDimensions = static_cast<std::uint64_t>(numDimensions);
     }
 
     /// Converts the specified data to the internal data, using static_cast for each data element.
@@ -362,7 +362,7 @@ public:
     void convertData(const T& inputDataContainer, const std::size_t numDimensions)
     {
         convertData(inputDataContainer.data(), inputDataContainer.size());
-        _numDimensions = static_cast<std::uint32_t>(numDimensions);
+        _numDimensions = static_cast<std::uint64_t>(numDimensions);
     }
 
     /// Copies the specified data into the internal data, sets the number of
@@ -372,7 +372,7 @@ public:
     void setData(const T* const data, const std::size_t numPoints, const std::size_t numDimensions)
     {
          _variantOfVectors = VariantOfVectors( std::vector<T>(data, data + numPoints * numDimensions) );
-         _numDimensions = static_cast<std::uint32_t>(numDimensions);
+         _numDimensions = static_cast<std::uint64_t>(numDimensions);
     }
 
 
@@ -422,7 +422,7 @@ public: // Sparse data, test implementation
         static void setSparseData(PointData* points, size_t numRows, size_t numCols, const std::vector<size_t>& rowPointers, const std::vector<size_t>& colIndices, const std::vector<float>& values)
         {
             points->_sparseData.setData(numRows, numCols, rowPointers, colIndices, values);
-            points->_numRows = static_cast<uint32_t>(numRows);
+            points->_numRows = static_cast<uint64_t>(numRows);
             points->setData(std::vector<float> {}, numCols);
             points->_isDense = false;
         }
@@ -430,7 +430,7 @@ public: // Sparse data, test implementation
         static void setSparseData(PointData* points, size_t numRows, size_t numCols, std::vector<size_t>&& rowPointers, std::vector<size_t>&& colIndices, std::vector<float>&& values)
         {
             points->_sparseData.setData(numRows, numCols, std::move(rowPointers), std::move(colIndices), std::move(values));
-            points->_numRows = static_cast<uint32_t>(numRows);
+            points->_numRows = static_cast<uint64_t>(numRows);
             points->setData(std::vector<float> {}, numCols);
             points->_isDense = false;
         }
@@ -795,7 +795,7 @@ public:
     std::uint64_t getNumPoints() const
     {
         if (isProxy()) {
-            auto numberOfPoints = 0;
+            std::uint64_t numberOfPoints = 0;
 
             for (auto& proxyMember : getProxyMembers())
                 numberOfPoints += mv::Dataset<Points>(proxyMember)->getNumPoints();
@@ -803,8 +803,12 @@ public:
             return numberOfPoints;
         }
         else {
-            if (isFull()) return getRawData<PointData>()->getNumPoints();
-                else return static_cast<std::uint32_t>(indices.size());
+            if (isFull()) {
+                return getRawData<PointData>()->getNumPoints();
+            }
+            else {
+                return static_cast<std::uint64_t>(indices.size());
+            }
         }
     }
 


### PR DESCRIPTION
Follow up to #1231. There are some conversions to `uint32_t` which are then silently reverted to back to `uint64_t`.

Also, some small consistency adjustments, see commit messages. 