### PR TITLE
Do not use `using namespace mv` in headers

### DIFF
--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.cpp
@@ -21,6 +21,7 @@
 
 Q_PLUGIN_METADATA(IID "studio.manivault.ClusterData")
 
+using namespace mv;
 using namespace mv::util;
 
 ClusterData::ClusterData(const mv::plugin::PluginFactory* factory) :

--- a/ManiVault/src/plugins/ClusterData/src/ClusterData.h
+++ b/ManiVault/src/plugins/ClusterData/src/ClusterData.h
@@ -19,8 +19,6 @@
 
 #include <vector>
 
-using namespace mv;
-
 const mv::DataType ClusterType = mv::DataType(QString("Clusters"));
 
 class InfoAction;
@@ -38,7 +36,7 @@ public:
      * @param guid Globally unique dataset identifier (use only for deserialization)
      * @return Smart pointer to dataset
      */
-    Dataset<DatasetImpl> createDataSet(const QString& guid = "") const override;
+    mv::Dataset<mv::DatasetImpl> createDataSet(const QString& guid = "") const override;
 
     /**
      * Get clusters
@@ -117,11 +115,11 @@ private:
 // Cluster Set
 // =============================================================================
 
-class CLUSTERDATA_EXPORT Clusters : public DatasetImpl
+class CLUSTERDATA_EXPORT Clusters : public mv::DatasetImpl
 {
 public:
     Clusters(QString dataName, bool mayUnderive = false, const QString& guid = "") :
-        DatasetImpl(dataName, mayUnderive, guid)
+        mv::DatasetImpl(dataName, mayUnderive, guid)
     {
     }
 
@@ -184,14 +182,14 @@ public:
      * Get a copy of the dataset
      * @return Smart pointer to copy of the dataset
      */
-    Dataset<DatasetImpl> copy() const override
+    mv::Dataset<DatasetImpl> copy() const override
     {
         auto clusters = new Clusters(getRawDataName());
 
         clusters->setText(text());
         clusters->indices = indices;
         
-        return Dataset<DatasetImpl>(clusters);
+        return mv::Dataset<DatasetImpl>(clusters);
     }
 
     /**
@@ -201,7 +199,7 @@ public:
      * @param visible Whether the subset will be visible in the UI
      * @return Smart pointer to the created subset
      */
-    Dataset<DatasetImpl> createSubsetFromSelection(const QString& guiName, const Dataset<DatasetImpl>& parentDataSet = Dataset<DatasetImpl>(), const bool& visible = true) const  override
+    mv::Dataset<DatasetImpl> createSubsetFromSelection(const QString& guiName, const mv::Dataset<DatasetImpl>& parentDataSet = mv::Dataset<DatasetImpl>(), const bool& visible = true) const  override
     {
         return mv::data().createSubsetFromSelection(getSelection(), toSmartPointer(), guiName, parentDataSet, visible);
     }
@@ -273,7 +271,7 @@ public: // Serialization
 
     std::vector<unsigned int>       indices;
     QSharedPointer<InfoAction>      _infoAction;        /** Shared pointer to info action */
-    EventListener                   _eventListener;     /** Listen to HDPS events */
+    mv::EventListener               _eventListener;     /** Listen to ManiVault events */
 };
 
 // =============================================================================

--- a/ManiVault/src/plugins/ClusterData/src/ClustersAction.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersAction.cpp
@@ -11,6 +11,8 @@
 #include <QHeaderView>
 #include <QVBoxLayout>
 
+using namespace mv;
+
 ClustersAction::ClustersAction(QObject* parent, Dataset<Clusters> clustersDataset /*= Dataset<Clusters>()*/) :
     WidgetAction(parent, "Clusters"),
     _clustersDataset(),

--- a/ManiVault/src/plugins/ClusterData/src/ClustersAction.h
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersAction.h
@@ -17,9 +17,6 @@
 
 #include <QItemSelectionModel>
 
-using namespace mv::gui;
-using namespace mv::util;
-
 /**
  * Clusters action class
  *
@@ -27,7 +24,7 @@ using namespace mv::util;
  *
  * @author Thomas Kroes
  */
-class CLUSTERDATA_EXPORT ClustersAction : public WidgetAction
+class CLUSTERDATA_EXPORT ClustersAction : public mv::gui::WidgetAction
 {
     Q_OBJECT
 
@@ -65,7 +62,7 @@ public:
      * @param parent Pointer to parent object
      * @param clustersDataset Smart pointer to clusters
      */
-    ClustersAction(QObject* parent, Dataset<Clusters> clustersDataset = Dataset<Clusters>());
+    ClustersAction(QObject* parent, mv::Dataset<Clusters> clustersDataset = mv::Dataset<Clusters>());
 
     /**
      * Get clusters
@@ -77,13 +74,13 @@ public:
      * Get clusters dataset
      * @return Smart pointer to clusters dataset
      */
-    Dataset<Clusters>& getClustersDataset();
+    mv::Dataset<Clusters>& getClustersDataset();
 
     /**
      * Set clusters dataset
      * @param clustersDataset Smart pointer to clusters dataset
      */
-    void setClustersDataset(Dataset<Clusters> clustersDataset);
+    void setClustersDataset(mv::Dataset<Clusters> clustersDataset);
 
     /**
      * Create subset from selected clusters
@@ -125,7 +122,7 @@ signals:
     void refreshClusters();
 
 protected:
-    Dataset<Clusters>           _clustersDataset;           /** Smart pointer to the clusters dataset */
+    mv::Dataset<Clusters>       _clustersDataset;           /** Smart pointer to the clusters dataset */
     ClustersModel               _clustersModel;             /** Clusters model */
     ColorizeClustersAction      _colorizeClustersAction;    /** Colorize clusters action */
     PrefixClustersAction        _prefixClustersAction;      /** Prefix clusters action */

--- a/ManiVault/src/plugins/ClusterData/src/ClustersActionWidget.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersActionWidget.cpp
@@ -11,6 +11,8 @@
 #include <QHeaderView>
 #include <QVBoxLayout>
 
+using namespace mv;
+
 ClustersActionWidget::ClustersActionWidget(QWidget* parent, ClustersAction* clustersAction, const std::int32_t& widgetFlags) :
     WidgetActionWidget(parent, clustersAction),
     _filterModel(),
@@ -104,11 +106,11 @@ ClustersActionWidget::ClustersActionWidget(QWidget* parent, ClustersAction* clus
 
         // Add remove cluster(s) widget
         if (widgetFlags & ClustersAction::Remove)
-            toolbarLayout->addWidget(_removeClustersAction.createWidget(this, TriggerAction::Icon));
+            toolbarLayout->addWidget(_removeClustersAction.createWidget(this, gui::TriggerAction::Icon));
 
         // Add merge clusters widget
         if (widgetFlags & ClustersAction::Merge)
-            toolbarLayout->addWidget(_mergeClustersAction.createWidget(this, TriggerAction::Icon));
+            toolbarLayout->addWidget(_mergeClustersAction.createWidget(this, gui::TriggerAction::Icon));
 
         // Add colorize widget if required
         if (widgetFlags & ClustersAction::Colorize)
@@ -124,7 +126,7 @@ ClustersActionWidget::ClustersActionWidget(QWidget* parent, ClustersAction* clus
 
         // Add refresh widget if required
         if (widgetFlags & ClustersAction::Refresh)
-            toolbarLayout->addWidget(_refreshClustersAction.createWidget(this, TriggerAction::Icon));
+            toolbarLayout->addWidget(_refreshClustersAction.createWidget(this, gui::TriggerAction::Icon));
 
         toolbarLayout->addStretch(1);
 

--- a/ManiVault/src/plugins/ClusterData/src/ClustersActionWidget.h
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersActionWidget.h
@@ -20,9 +20,6 @@
 #include <QItemSelectionModel>
 #include <QTreeView>
 
-using namespace mv::gui;
-using namespace mv::util;
-
 class ClustersAction;
 
 /**
@@ -32,7 +29,7 @@ class ClustersAction;
  *
  * @author Thomas Kroes
  */
-class ClustersActionWidget : public WidgetActionWidget {
+class ClustersActionWidget : public mv::gui::WidgetActionWidget {
 public:
 
     /**

--- a/ManiVault/src/plugins/ClusterData/src/ColorizeClustersAction.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ColorizeClustersAction.cpp
@@ -8,6 +8,8 @@
 #include "ClusterData.h"
 #include "ClustersActionWidget.h"
 
+using namespace mv::gui;
+
 ColorizeClustersAction::ColorizeClustersAction(ClustersAction& clustersAction) :
     TriggerAction(&clustersAction, "Colorize"),
     _clustersAction(clustersAction),

--- a/ManiVault/src/plugins/ClusterData/src/ColorizeClustersAction.h
+++ b/ManiVault/src/plugins/ClusterData/src/ColorizeClustersAction.h
@@ -10,9 +10,6 @@
 #include <actions/IntegralAction.h>
 #include <actions/TriggerAction.h>
 
-using namespace mv;
-using namespace mv::gui;
-
 class ClustersAction;
 
 /**
@@ -22,12 +19,12 @@ class ClustersAction;
  *
  * @author Thomas Kroes
  */
-class ColorizeClustersAction : public TriggerAction
+class ColorizeClustersAction : public mv::gui::TriggerAction
 {
 protected:
 
     /** Widget class for colorize clusters action */
-    class Widget : public WidgetActionWidget {
+    class Widget : public mv::gui::WidgetActionWidget {
     public:
 
         /**
@@ -58,19 +55,19 @@ public:
 
 public: // Action getters
 
-    OptionAction& getColorByAction() { return _colorByAction; }
-    ColorMapAction& getColorMapAction() { return _colorMapAction; }
-    IntegralAction& getRandomSeedAction() { return _randomSeedAction; }
-    TriggerAction& getColorizeAction() { return _colorizeAction; }
+    mv::gui::OptionAction& getColorByAction() { return _colorByAction; }
+    mv::gui::ColorMapAction& getColorMapAction() { return _colorMapAction; }
+    mv::gui::IntegralAction& getRandomSeedAction() { return _randomSeedAction; }
+    mv::gui::TriggerAction& getColorizeAction() { return _colorizeAction; }
 
 public slots:
     /** When the color model or cluster number changes, update the cluster colors */
     void updateColorsInModel();
 
 protected:
-    ClustersAction&     _clustersAction;        /** Reference to clusters action */
-    OptionAction        _colorByAction;         /** Color by action */
-    ColorMap1DAction    _colorMapAction;        /** Color map action */
-    IntegralAction      _randomSeedAction;      /** Random seed action for random color generation */
-    TriggerAction       _colorizeAction;        /** Colorize action */
+    ClustersAction&             _clustersAction;        /** Reference to clusters action */
+    mv::gui::OptionAction       _colorByAction;         /** Color by action */
+    mv::gui::ColorMap1DAction   _colorMapAction;        /** Color map action */
+    mv::gui::IntegralAction     _randomSeedAction;      /** Random seed action for random color generation */
+    mv::gui::TriggerAction      _colorizeAction;        /** Colorize action */
 };

--- a/ManiVault/src/plugins/ClusterData/src/FilterClustersAction.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/FilterClustersAction.cpp
@@ -29,7 +29,7 @@ FilterClustersAction::FilterClustersAction(ClustersActionWidget* clustersActionW
     };
 
     // Update the filter model filter when the name filter action string changes
-    connect(&_nameFilterAction, &StringAction::stringChanged, this, updateNameFilter);
+    connect(&_nameFilterAction, &mv::gui::StringAction::stringChanged, this, updateNameFilter);
 
     // Do an initial update of the model name filter
     updateNameFilter();

--- a/ManiVault/src/plugins/ClusterData/src/FilterClustersAction.h
+++ b/ManiVault/src/plugins/ClusterData/src/FilterClustersAction.h
@@ -7,9 +7,6 @@
 #include <actions/WidgetAction.h>
 #include <actions/StringAction.h>
 
-using namespace mv;
-using namespace mv::gui;
-
 class ClustersActionWidget;
 
 /**
@@ -19,12 +16,12 @@ class ClustersActionWidget;
  *
  * @author Thomas Kroes
  */
-class FilterClustersAction : public WidgetAction
+class FilterClustersAction : public mv::gui::WidgetAction
 {
 protected:
 
     /** Widget class for filter clusters action */
-    class Widget : public WidgetActionWidget {
+    class Widget : public mv::gui::WidgetActionWidget {
     public:
 
         /**
@@ -55,9 +52,9 @@ public:
 
 public: // Action getters
 
-    StringAction& getNameFilterAction() { return _nameFilterAction; }
+    mv::gui::StringAction& getNameFilterAction() { return _nameFilterAction; }
 
 protected:
     ClustersActionWidget*   _clustersActionWidget;      /** Pointer to clusters action widget */
-    StringAction            _nameFilterAction;          /** Name filter action */
+    mv::gui::StringAction            _nameFilterAction;          /** Name filter action */
 };

--- a/ManiVault/src/plugins/ClusterData/src/InfoAction.h
+++ b/ManiVault/src/plugins/ClusterData/src/InfoAction.h
@@ -11,14 +11,6 @@
 #include "actions/StringAction.h"
 #include "event/EventListener.h"
 
-namespace mv {
-    class CoreInterface;
-}
-
-using namespace mv;
-using namespace mv::gui;
-using namespace mv::util;
-
 /**
  * Info action class
  *
@@ -26,7 +18,7 @@ using namespace mv::util;
  *
  * @author Thomas Kroes
  */
-class InfoAction : public GroupAction
+class InfoAction : public mv::gui::GroupAction
 {
 public:
 
@@ -39,11 +31,11 @@ public:
 
 public: // Action getters
 
-    StringAction& getNumberOfClustersAction() { return _numberOfClustersAction; }
+    mv::gui::StringAction& getNumberOfClustersAction() { return _numberOfClustersAction; }
 
 protected:
-    Dataset<Clusters>       _clusters;                  /** Clusters dataset smart pointer */
-    StringAction            _numberOfClustersAction;    /** Number of points action */
+    mv::Dataset<Clusters>   _clusters;                  /** Clusters dataset smart pointer */
+    mv::gui::StringAction   _numberOfClustersAction;    /** Number of points action */
     ClustersAction          _clustersAction;            /** Clusters action */
     mv::EventListener       _eventListener;             /** Listen to ManiniVault events */
 };

--- a/ManiVault/src/plugins/ClusterData/src/MergeClustersAction.h
+++ b/ManiVault/src/plugins/ClusterData/src/MergeClustersAction.h
@@ -6,9 +6,6 @@
 
 #include <actions/TriggerAction.h>
 
-using namespace mv;
-using namespace mv::gui;
-
 class ClustersActionWidget;
 
 /**
@@ -18,7 +15,7 @@ class ClustersActionWidget;
  *
  * @author Thomas Kroes
  */
-class MergeClustersAction : public TriggerAction
+class MergeClustersAction : public mv::gui::TriggerAction
 {
 public:
 

--- a/ManiVault/src/plugins/ClusterData/src/OverwriteClustersConfirmationDialog.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/OverwriteClustersConfirmationDialog.cpp
@@ -44,10 +44,10 @@ OverwriteClustersConfirmationDialog::OverwriteClustersConfirmationDialog(QWidget
     layout->addStretch(1);
     layout->addLayout(bottomLayout);
 
-    connect(&_alwaysAskPermissionAction, &ToggleAction::toggled, this, [this](bool toggled) {
+    connect(&_alwaysAskPermissionAction, &gui::ToggleAction::toggled, this, [this](bool toggled) {
         Application::current()->setSetting("OverwriteClustersAskConfirmation", toggled);
     });
 
-    connect(&_discardAction, &TriggerAction::triggered, this, &OverwriteClustersConfirmationDialog::accept);
-    connect(&_cancelAction, &TriggerAction::triggered, this, &OverwriteClustersConfirmationDialog::reject);
+    connect(&_discardAction, &gui::TriggerAction::triggered, this, &OverwriteClustersConfirmationDialog::accept);
+    connect(&_cancelAction, &gui::TriggerAction::triggered, this, &OverwriteClustersConfirmationDialog::reject);
 }

--- a/ManiVault/src/plugins/ClusterData/src/OverwriteClustersConfirmationDialog.h
+++ b/ManiVault/src/plugins/ClusterData/src/OverwriteClustersConfirmationDialog.h
@@ -9,8 +9,6 @@
 
 #include <QDialog>
 
-using namespace mv::gui;
-
 /**
  * Overwrite clusters confirmation dialog class
  *
@@ -41,7 +39,7 @@ public:
     }
 
 protected:
-    ToggleAction    _alwaysAskPermissionAction;     /** Whether to always ask permission prior to overwriting clusters */
-    TriggerAction   _discardAction;                 /** Discard cluster change(s) action */
-    TriggerAction   _cancelAction;                  /** Cancel action */
+    mv::gui::ToggleAction    _alwaysAskPermissionAction;     /** Whether to always ask permission prior to overwriting clusters */
+    mv::gui::TriggerAction   _discardAction;                 /** Discard cluster change(s) action */
+    mv::gui::TriggerAction   _cancelAction;                  /** Cancel action */
 };

--- a/ManiVault/src/plugins/ClusterData/src/PrefixClustersAction.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/PrefixClustersAction.cpp
@@ -10,6 +10,9 @@
 
 #include <Application.h>
 
+using namespace mv;
+using namespace mv::gui;
+
 PrefixClustersAction::PrefixClustersAction(ClustersAction& clustersAction) :
     TriggerAction(&clustersAction, "Prefix"),
     _clustersAction(clustersAction),

--- a/ManiVault/src/plugins/ClusterData/src/PrefixClustersAction.h
+++ b/ManiVault/src/plugins/ClusterData/src/PrefixClustersAction.h
@@ -7,9 +7,6 @@
 #include <actions/StringAction.h>
 #include <actions/TriggerAction.h>
 
-using namespace mv;
-using namespace mv::gui;
-
 class ClustersAction;
 
 /**
@@ -19,12 +16,12 @@ class ClustersAction;
  *
  * @author Thomas Kroes
  */
-class PrefixClustersAction : public TriggerAction
+class PrefixClustersAction : public mv::gui::TriggerAction
 {
 protected:
 
     /** Widget class for prefix clusters action */
-    class Widget : public WidgetActionWidget {
+    class Widget : public mv::gui::WidgetActionWidget {
     public:
 
         /**
@@ -54,11 +51,11 @@ public:
 
 public: // Action getters
 
-    StringAction& getPrefixAction() { return _prefixAction; }
-    TriggerAction& getApplyAction() { return _applyAction; }
+    mv::gui::StringAction& getPrefixAction() { return _prefixAction; }
+    mv::gui::TriggerAction& getApplyAction() { return _applyAction; }
 
 protected:
-    ClustersAction&     _clustersAction;        /** Reference to clusters action */
-    StringAction        _prefixAction;          /** Cluster name prefix action */
-    TriggerAction       _applyAction;           /** Apply cluster name prefixes action */
+    ClustersAction&             _clustersAction;        /** Reference to clusters action */
+    mv::gui::StringAction       _prefixAction;          /** Cluster name prefix action */
+    mv::gui::TriggerAction      _applyAction;           /** Apply cluster name prefixes action */
 };

--- a/ManiVault/src/plugins/ClusterData/src/RefreshClustersAction.h
+++ b/ManiVault/src/plugins/ClusterData/src/RefreshClustersAction.h
@@ -6,9 +6,6 @@
 
 #include <actions/TriggerAction.h>
 
-using namespace mv;
-using namespace mv::gui;
-
 class ClustersActionWidget;
 
 /**
@@ -18,7 +15,7 @@ class ClustersActionWidget;
  *
  * @author Thomas Kroes
  */
-class RefreshClustersAction : public TriggerAction
+class RefreshClustersAction : public mv::gui::TriggerAction
 {
 public:
 

--- a/ManiVault/src/plugins/ClusterData/src/RemoveClustersAction.h
+++ b/ManiVault/src/plugins/ClusterData/src/RemoveClustersAction.h
@@ -6,9 +6,6 @@
 
 #include <actions/TriggerAction.h>
 
-using namespace mv;
-using namespace mv::gui;
-
 class ClustersActionWidget;
 
 /**
@@ -18,7 +15,7 @@ class ClustersActionWidget;
  *
  * @author Thomas Kroes
  */
-class RemoveClustersAction : public TriggerAction
+class RemoveClustersAction : public mv::gui::TriggerAction
 {
 public:
 

--- a/ManiVault/src/plugins/ClusterData/src/SelectClustersAction.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/SelectClustersAction.cpp
@@ -10,6 +10,8 @@
 
 #include <QHBoxLayout>
 
+using namespace mv::gui;
+
 SelectClustersAction::SelectClustersAction(ClustersActionWidget* clustersActionWidget) :
     WidgetAction(clustersActionWidget, "Select Clusters"),
     _clustersActionWidget(clustersActionWidget),

--- a/ManiVault/src/plugins/ClusterData/src/SelectClustersAction.h
+++ b/ManiVault/src/plugins/ClusterData/src/SelectClustersAction.h
@@ -8,9 +8,6 @@
 #include <actions/WidgetAction.h>
 #include <actions/WidgetActionWidget.h>
 
-using namespace mv;
-using namespace mv::gui;
-
 class ClustersActionWidget;
 
 /**
@@ -20,12 +17,12 @@ class ClustersActionWidget;
  *
  * @author Thomas Kroes
  */
-class SelectClustersAction : public WidgetAction
+class SelectClustersAction : public mv::gui::WidgetAction
 {
 protected:
 
     /** Widget class for select clusters action */
-    class Widget : public WidgetActionWidget {
+    class Widget : public mv::gui::WidgetActionWidget {
     public:
 
         /**
@@ -56,13 +53,13 @@ public:
 
 public: // Action getters
 
-    TriggerAction& getSelectAllAction() { return _selectAllAction; }
-    TriggerAction& getSelectNoneAction() { return _selectNoneAction; }
-    TriggerAction& getSelectInvertAction() { return _selectInvertAction; }
+    mv::gui::TriggerAction& getSelectAllAction() { return _selectAllAction; }
+    mv::gui::TriggerAction& getSelectNoneAction() { return _selectNoneAction; }
+    mv::gui::TriggerAction& getSelectInvertAction() { return _selectInvertAction; }
 
 protected:
     ClustersActionWidget*   _clustersActionWidget;      /** Pointer to clusters action widget */
-    TriggerAction           _selectAllAction;           /** Select all clusters action */
-    TriggerAction           _selectNoneAction;          /** Clear cluster selection action */
-    TriggerAction           _selectInvertAction;        /** Invert the cluster selection action */
+    mv::gui::TriggerAction           _selectAllAction;           /** Select all clusters action */
+    mv::gui::TriggerAction           _selectNoneAction;          /** Clear cluster selection action */
+    mv::gui::TriggerAction           _selectInvertAction;        /** Invert the cluster selection action */
 };

--- a/ManiVault/src/plugins/ClusterData/src/SubsetAction.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/SubsetAction.cpp
@@ -33,7 +33,7 @@ SubsetAction::SubsetAction(ClustersActionWidget* clustersActionWidget) :
     };
 
     // Create the subset when the create subset action is triggered
-    connect(&_createSubsetAction, &TriggerAction::triggered, this, [this, getItemSelection]() {
+    connect(&_createSubsetAction, &mv::gui::TriggerAction::triggered, this, [this, getItemSelection]() {
         _clustersActionWidget->getClustersAction().createSubsetFromSelection(_subsetNameAction.getString());
         _subsetNameAction.setString("");
     });
@@ -55,7 +55,7 @@ SubsetAction::SubsetAction(ClustersActionWidget* clustersActionWidget) :
     connect(&_clustersActionWidget->getFilterModel(), &QAbstractItemModel::layoutChanged, this, updateReadOnly);
 
     // Update read only status when the subset name string changes
-    connect(&_subsetNameAction, &StringAction::stringChanged, this, updateReadOnly);
+    connect(&_subsetNameAction, &mv::gui::StringAction::stringChanged, this, updateReadOnly);
 
     // Do initial read only updates
     updateReadOnly();

--- a/ManiVault/src/plugins/ClusterData/src/SubsetAction.h
+++ b/ManiVault/src/plugins/ClusterData/src/SubsetAction.h
@@ -7,9 +7,6 @@
 #include "actions/StringAction.h"
 #include "actions/TriggerAction.h"
 
-using namespace mv;
-using namespace mv::gui;
-
 class ClustersActionWidget;
 
 /**
@@ -54,11 +51,11 @@ public:
 
 public: // Action getters
 
-    StringAction& getSubsetNameAction() { return _subsetNameAction; }
-    TriggerAction& getCreateSubsetAction() { return _createSubsetAction; }
+    mv::gui::StringAction& getSubsetNameAction() { return _subsetNameAction; }
+    mv::gui::TriggerAction& getCreateSubsetAction() { return _createSubsetAction; }
 
 protected:
     ClustersActionWidget*   _clustersActionWidget;      /** Pointer to clusters action widget */
-    StringAction            _subsetNameAction;          /** Subset name action */
-    TriggerAction           _createSubsetAction;        /** Create subset action */
+    mv::gui::StringAction            _subsetNameAction;          /** Subset name action */
+    mv::gui::TriggerAction           _createSubsetAction;        /** Create subset action */
 };

--- a/ManiVault/src/plugins/ColorData/src/ColorData.h
+++ b/ManiVault/src/plugins/ColorData/src/ColorData.h
@@ -12,8 +12,6 @@
 #include <QColor>
 #include <vector>
 
-using namespace mv;
-
 const mv::DataType ColorType = mv::DataType(QString("Colors"));
 
 // =============================================================================
@@ -35,7 +33,7 @@ public:
      * @param guid Globally unique dataset identifier (use only for deserialization)
      * @return Smart pointer to dataset
      */
-    Dataset<DatasetImpl> createDataSet(const QString& guid = "") const override;
+    mv::Dataset<mv::DatasetImpl> createDataSet(const QString& guid = "") const override;
 
 private:
     std::vector<QColor> _colors;
@@ -55,14 +53,14 @@ public:
      * Get a copy of the dataset
      * @return Smart pointer to copy of dataset
      */
-    Dataset<DatasetImpl> copy() const override
+    mv::Dataset<DatasetImpl> copy() const override
     {
         auto colors = new Colors(getRawDataName());
 
         colors->setText(text());
         colors->indices = indices;
 
-        return Dataset<DatasetImpl>(colors);
+        return mv::Dataset<DatasetImpl>(colors);
     }
 
     /**
@@ -72,7 +70,7 @@ public:
      * @param visible Whether the subset will be visible in the UI
      * @return Smart pointer to the created subset
      */
-    Dataset<DatasetImpl> createSubsetFromSelection(const QString& guiName, const Dataset<DatasetImpl>& parentDataSet = Dataset<DatasetImpl>(), const bool& visible = true) const override {
+    mv::Dataset<DatasetImpl> createSubsetFromSelection(const QString& guiName, const mv::Dataset<DatasetImpl>& parentDataSet = mv::Dataset<DatasetImpl>(), const bool& visible = true) const override {
         return mv::data().createSubsetFromSelection(getSelection(), toSmartPointer(), guiName, parentDataSet, visible);
     }
 

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyPlugin.cpp
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyPlugin.cpp
@@ -10,6 +10,7 @@ Q_PLUGIN_METADATA(IID "studio.manivault.DataHierarchyPlugin")
 
 using namespace mv;
 using namespace mv::gui;
+using namespace mv::plugin;
 using namespace mv::util;
 
 DataHierarchyPlugin::DataHierarchyPlugin(const PluginFactory* factory) :

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyPlugin.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyPlugin.h
@@ -8,16 +8,14 @@
 
 #include <ViewPlugin.h>
 
-using namespace mv::plugin;
-
 /**
  * Data hierarchy view plugin
  *
- * This plugin visualizes the data hierarchy and allows users the interact with it.
+ * This plugin visualizes the data hierarchy and allows users to interact with it.
  *
  * @author Thomas Kroes
  */
-class DataHierarchyPlugin : public ViewPlugin
+class DataHierarchyPlugin : public mv::plugin::ViewPlugin
 {
     Q_OBJECT
     
@@ -27,7 +25,7 @@ public:
      * Construct with pointer to plugin \p factory
      * @param factory Pointer to plugin factory
      */
-    DataHierarchyPlugin(const PluginFactory* factory);
+    DataHierarchyPlugin(const mv::plugin::PluginFactory* factory);
 
     /** Perform plugin initialization */
     void init() override;
@@ -36,7 +34,7 @@ private:
     DataHierarchyWidget     _dataHierarchyWidget;       /** Data hierarchy widget */
 };
 
-class DataHierarchyPluginFactory : public ViewPluginFactory
+class DataHierarchyPluginFactory : public mv::plugin::ViewPluginFactory
 {
     Q_INTERFACES(mv::plugin::ViewPluginFactory mv::plugin::PluginFactory)
     Q_OBJECT
@@ -67,5 +65,5 @@ public:
      * Produces the plugin
      * @return Pointer to the produced plugin
      */
-    ViewPlugin* produce() override;
+    mv::plugin::ViewPlugin* produce() override;
 };

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidget.h
@@ -10,12 +10,10 @@
 #include <models/DataHierarchyTreeModel.h>
 #include <models/DataHierarchyFilterModel.h>
 
-#include <actions/ToggleAction.h>
 #include <actions/TriggerAction.h>
 
 #include <widgets/HierarchyWidget.h>
 
-#include <DataHierarchyItem.h>
 #include <Dataset.h>
 
 #include <QWidget>
@@ -82,7 +80,6 @@ protected:
 
     /**
      * Initializes the model selection from the data hierarchy
-     * @param parentFilterModelIndex The parent filter model index for which to update the child model items
      */
     void initializeSelection();
 

--- a/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/src/DataHierarchyWidgetContextMenu.h
@@ -16,9 +16,6 @@
 
 class QAction;
 
-using namespace mv;
-using namespace mv::plugin;
-
 /**
  * Data hierarchy widget context menu
  * 
@@ -35,7 +32,7 @@ public:
      * @param parent Parent widget
      * @param selectedDatasets Selected datasets in the data hierarchy widget
      */
-    DataHierarchyWidgetContextMenu(QWidget* parent, Datasets selectedDatasets);
+    DataHierarchyWidgetContextMenu(QWidget* parent, mv::Datasets selectedDatasets);
 
 private:
 
@@ -44,7 +41,7 @@ private:
      * Goes over all loaded plugins of \p pluginType and builds a hierarchical menu structure (based on plugin title)
      * @param type PluginType
      */
-    void addMenusForPluginType(plugin::Type pluginType);
+    void addMenusForPluginType(mv::plugin::Type pluginType);
 
     /** Add menus for scripts  */
     void addMenusForScripts();
@@ -92,8 +89,8 @@ private:
     QMenu* getUnhideMenu();
 
 private:
-    Datasets    _allDatasets;           /** All datasets in the data hierarchy */
-    Datasets    _selectedDatasets;      /** Selected datasets in the data hierarchy widget */
+    mv::Datasets    _allDatasets;           /** All datasets in the data hierarchy */
+    mv::Datasets    _selectedDatasets;      /** Selected datasets in the data hierarchy widget */
 };
 
 /**
@@ -130,8 +127,8 @@ signals:
     void closeDialog(bool onlyIndices);
 
 private:
-    gui::IntegralAction      _selectionIndexAction;      /** For setting the selection group index */
-    gui::TriggerAction       _confirmAction;             /** Triggers the grouping */
+    mv::gui::IntegralAction      _selectionIndexAction;      /** For setting the selection group index */
+    mv::gui::TriggerAction       _confirmAction;             /** Triggers the grouping */
 };
 
 /**
@@ -184,9 +181,9 @@ signals:
     void closeDialog(bool onlyIndices);
 
 private:
-    gui::IntegralAction     _selectionIndexAction;      /** For setting the selection group index */
-    gui::StringAction       _selectionPatternAction;    /** For setting the selection group pattern */
-    gui::OptionAction       _selectionOptionAction;     /** Action for choosing whether to use prefix or suffix */
-    gui::StringAction       _infoTextAction;            /** For displaying some information */
-    gui::TriggerAction      _confirmAction;             /** Triggers the grouping */
+    mv::gui::IntegralAction     _selectionIndexAction;      /** For setting the selection group index */
+    mv::gui::StringAction       _selectionPatternAction;    /** For setting the selection group pattern */
+    mv::gui::OptionAction       _selectionOptionAction;     /** Action for choosing whether to use prefix or suffix */
+    mv::gui::StringAction       _infoTextAction;            /** For displaying some information */
+    mv::gui::TriggerAction      _confirmAction;             /** Triggers the grouping */
 };

--- a/ManiVault/src/plugins/DataPropertiesPlugin/src/DataPropertiesPlugin.cpp
+++ b/ManiVault/src/plugins/DataPropertiesPlugin/src/DataPropertiesPlugin.cpp
@@ -15,6 +15,9 @@
 Q_PLUGIN_METADATA(IID "studio.manivault.DataPropertiesPlugin")
 
 using namespace mv;
+using namespace mv::gui;
+using namespace mv::plugin;
+using namespace mv::util;
 
 DataPropertiesPlugin::DataPropertiesPlugin(const PluginFactory* factory) :
     ViewPlugin(factory),

--- a/ManiVault/src/plugins/DataPropertiesPlugin/src/DataPropertiesPlugin.h
+++ b/ManiVault/src/plugins/DataPropertiesPlugin/src/DataPropertiesPlugin.h
@@ -10,8 +10,6 @@
 
 #include <actions/TriggerAction.h>
 
-using namespace mv::plugin;
-
 /**
  * Data properties plugin
  *
@@ -19,7 +17,7 @@ using namespace mv::plugin;
  *
  * @author Thomas Kroes
  */
-class DataPropertiesPlugin : public ViewPlugin
+class DataPropertiesPlugin : public mv::plugin::ViewPlugin
 {
     Q_OBJECT
     
@@ -29,7 +27,7 @@ public:
      * Construct with pointer to plugin \p factory
      * @param factory Pointer to plugin factory
      */
-    DataPropertiesPlugin(const PluginFactory* factory);
+    DataPropertiesPlugin(const mv::plugin::PluginFactory* factory);
 
     /** Perform plugin initialization */
     void init() override;
@@ -40,14 +38,14 @@ protected:
      * Updates the window title based on the \p selectedDataHierarchyItems in the data hierarchy
      * @param selectedDataHierarchyItems Items selected in the data hierarchy
      */
-    void updateWindowTitle(DataHierarchyItems selectedDataHierarchyItems);
+    void updateWindowTitle(mv::DataHierarchyItems selectedDataHierarchyItems);
 
 private:
-    gui::TriggerAction      _additionalEditorAction;    /** Trigger action to start the data set editor */
+    mv::gui::TriggerAction  _additionalEditorAction;    /** Trigger action to start the data set editor */
     DataPropertiesWidget    _dataPropertiesWidget;      /** Data properties widget */
 };
 
-class DataPropertiesPluginFactory : public ViewPluginFactory
+class DataPropertiesPluginFactory : public mv::plugin::ViewPluginFactory
 {
     Q_INTERFACES(mv::plugin::ViewPluginFactory mv::plugin::PluginFactory)
     Q_OBJECT
@@ -75,5 +73,5 @@ public:
      * Produces the plugin
      * @return Pointer to the produced plugin
      */
-    ViewPlugin* produce() override;
+    mv::plugin::ViewPlugin* produce() override;
 };

--- a/ManiVault/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.cpp
+++ b/ManiVault/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.cpp
@@ -147,10 +147,10 @@ void DataPropertiesWidget::populate()
         }
         catch (std::exception& e)
         {
-            exceptionMessageBox("Cannot update data properties", e);
+            mv::util::exceptionMessageBox("Cannot update data properties", e);
         }
         catch (...) {
-            exceptionMessageBox("Cannot update data properties");
+            mv::util::exceptionMessageBox("Cannot update data properties");
         }
     }
     endPopulate();

--- a/ManiVault/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.h
+++ b/ManiVault/src/plugins/DataPropertiesPlugin/src/DataPropertiesWidget.h
@@ -10,10 +10,6 @@
 
 #include <QWidget>
 
-using namespace mv;
-using namespace mv::util;
-using namespace mv::gui;
-
 class DataPropertiesPlugin;
 
 /**
@@ -46,13 +42,13 @@ private:
     void endPopulate();
 
 protected:
-    DataPropertiesPlugin*   _dataPropertiesPlugin;      /** Pointer to owning data properties plugin */
-    QVBoxLayout             _layout;                    /** Main layout */
-    QTimer                  _populateTimer;             /** Timer for selectively populating the UI */
-    DataHierarchyItems      _scheduledItems;            /** Items scheduled to be shown */
-    DataHierarchyItems      _currentItems;              /** Items currently shown */
-    bool                    _abortPopulate;             /** Boolean determining whether the UI build process should be terminated */
-    bool                    _isPopulating;              /** Boolean determining whether the UI build process should be terminated */
-    GroupsAction            _groupsAction;              /** Groups action */
-    GroupsAction::Widget*   _groupsActionWidget;        /** Pointer to groups action widget (used to change label sizing) */
+    DataPropertiesPlugin*           _dataPropertiesPlugin;      /** Pointer to owning data properties plugin */
+    QVBoxLayout                     _layout;                    /** Main layout */
+    QTimer                          _populateTimer;             /** Timer for selectively populating the UI */
+    mv::DataHierarchyItems          _scheduledItems;            /** Items scheduled to be shown */
+    mv::DataHierarchyItems          _currentItems;              /** Items currently shown */
+    bool                            _abortPopulate;             /** Boolean determining whether the UI build process should be terminated */
+    bool                            _isPopulating;              /** Boolean determining whether the UI build process should be terminated */
+    mv::gui::GroupsAction           _groupsAction;              /** Groups action */
+    mv::gui::GroupsAction::Widget*  _groupsActionWidget;        /** Pointer to groups action widget (used to change label sizing) */
 };

--- a/ManiVault/src/plugins/ImageData/src/Images.cpp
+++ b/ManiVault/src/plugins/ImageData/src/Images.cpp
@@ -8,7 +8,7 @@
 #include "InfoAction.h"
 
 #include <util/Exception.h>
-#include <util/Timer.h>
+//#include <util/Timer.h>
 
 #include <DataHierarchyItem.h>
 #include <Dataset.h>
@@ -25,6 +25,7 @@
 
 #include <QDebug>
 
+using namespace mv;
 using namespace mv::util;
 
 Images::Images(QString dataName, bool mayUnderive /*= false*/, const QString& guid /*= ""*/) :

--- a/ManiVault/src/plugins/ImageData/src/Images.h
+++ b/ManiVault/src/plugins/ImageData/src/Images.h
@@ -18,8 +18,6 @@
 #include <tuple>
 #include <vector>
 
-using namespace mv::plugin;
-
 class InfoAction;
 
 /**

--- a/ManiVault/src/plugins/ImageData/src/InfoAction.cpp
+++ b/ManiVault/src/plugins/ImageData/src/InfoAction.cpp
@@ -3,7 +3,7 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "InfoAction.h"
-#include "Application.h"
+
 #include "event/Event.h"
 
 using namespace mv;

--- a/ManiVault/src/plugins/ImageData/src/InfoAction.h
+++ b/ManiVault/src/plugins/ImageData/src/InfoAction.h
@@ -9,10 +9,6 @@
 
 #include "Images.h"
 
-using namespace mv;
-using namespace mv::gui;
-using namespace mv::util;
-
 /**
  * Info action class
  *
@@ -20,7 +16,7 @@ using namespace mv::util;
  *
  * @author Thomas Kroes
  */
-class InfoAction : public GroupAction
+class InfoAction : public mv::gui::GroupAction
 {
     Q_OBJECT
 
@@ -34,11 +30,11 @@ public:
     InfoAction(QObject* parent, Images& images);
 
 protected:
-    Dataset<Images>         _images;                            /** Points dataset reference */
-    StringAction            _typeAction;                        /** Image collection type action */
-    StringAction            _numberOfImagesAction;              /** Number of images action */
-    StringAction            _imageResolutionAction;             /** Image resolution action */
-    StringAction            _numberOfPixelsAction;              /** Number of pixels per image action */
-    StringAction            _numberComponentsPerPixelAction;    /** Number of components action */
-    mv::EventListener       _eventListener;                     /** Listen to ManiniVault events */
+    mv::Dataset<Images>              _images;                            /** Points dataset reference */
+    mv::gui::StringAction            _typeAction;                        /** Image collection type action */
+    mv::gui::StringAction            _numberOfImagesAction;              /** Number of images action */
+    mv::gui::StringAction            _imageResolutionAction;             /** Image resolution action */
+    mv::gui::StringAction            _numberOfPixelsAction;              /** Number of pixels per image action */
+    mv::gui::StringAction            _numberComponentsPerPixelAction;    /** Number of components action */
+    mv::EventListener                _eventListener;                     /** Listen to ManiniVault events */
 };

--- a/ManiVault/src/plugins/LoggingPlugin/src/LoggingPlugin.cpp
+++ b/ManiVault/src/plugins/LoggingPlugin/src/LoggingPlugin.cpp
@@ -13,6 +13,7 @@ Q_PLUGIN_METADATA(IID "studio.manivault.LoggingPlugin")
 
 using namespace mv;
 using namespace mv::gui;
+using namespace mv::plugin;
 
 LoggingPlugin::LoggingPlugin(const PluginFactory* factory) :
     ViewPlugin(factory),

--- a/ManiVault/src/plugins/LoggingPlugin/src/LoggingPlugin.h
+++ b/ManiVault/src/plugins/LoggingPlugin/src/LoggingPlugin.h
@@ -8,8 +8,6 @@
 
 #include <ViewPlugin.h>
 
-using namespace mv::plugin;
-
 /**
  * Logging view plugin
  *
@@ -17,7 +15,7 @@ using namespace mv::plugin;
  *
  * @author Thomas Kroes
  */
-class LoggingPlugin : public ViewPlugin
+class LoggingPlugin : public mv::plugin::ViewPlugin
 {
     Q_OBJECT
     
@@ -27,7 +25,7 @@ public:
      * Construct with pointer to plugin \p factory
      * @param factory Pointer to plugin factory
      */
-    LoggingPlugin(const PluginFactory* factory);
+    LoggingPlugin(const mv::plugin::PluginFactory* factory);
 
     /** Perform plugin initialization */
     void init() override;
@@ -41,7 +39,7 @@ private:
  *
  * @author Thomas Kroes
  */
-class LoggingPluginFactory : public ViewPluginFactory
+class LoggingPluginFactory : public mv::plugin::ViewPluginFactory
 {
     Q_INTERFACES(mv::plugin::ViewPluginFactory mv::plugin::PluginFactory)
     Q_OBJECT
@@ -63,5 +61,5 @@ public:
      * Produces the plugin
      * @return Pointer to the produced plugin
      */
-    ViewPlugin* produce() override;
+    mv::plugin::ViewPlugin* produce() override;
 };

--- a/ManiVault/src/plugins/PointData/src/CreateSetFromSelectionAction.cpp
+++ b/ManiVault/src/plugins/PointData/src/CreateSetFromSelectionAction.cpp
@@ -24,7 +24,7 @@ CreateSetFromSelectionAction::CreateSetFromSelectionAction(QObject* parent, cons
 
     _nameAction.setPlaceHolderString("Enter set name here...");
 
-    connect(&_createAction, &TriggerAction::triggered, this, [this]() -> void {
+    connect(&_createAction, &mv::gui::TriggerAction::triggered, this, [this]() -> void {
         auto points = _points->isDerivedData() ? _points->getSourceDataset<Points>() : _points;
 
         if (points->isProxy()) {
@@ -47,7 +47,7 @@ CreateSetFromSelectionAction::CreateSetFromSelectionAction(QObject* parent, cons
         _createAction.setEnabled(!_nameAction.getString().isEmpty());
     };
 
-    connect(&_nameAction, &StringAction::stringChanged, this, updateCreateAction);
+    connect(&_nameAction, &gui::StringAction::stringChanged, this, updateCreateAction);
 
     updateCreateAction();
 }

--- a/ManiVault/src/plugins/PointData/src/CreateSetFromSelectionAction.h
+++ b/ManiVault/src/plugins/PointData/src/CreateSetFromSelectionAction.h
@@ -9,10 +9,6 @@
 #include <actions/TriggerAction.h>
 #include <actions/StringAction.h>
 
-using namespace mv;
-using namespace mv::util;
-using namespace mv::gui;
-
 /**
  * Create set from selection action class
  *
@@ -20,7 +16,7 @@ using namespace mv::gui;
  *
  * @author Thomas Kroes
  */
-class CreateSetFromSelectionAction : public WidgetAction
+class CreateSetFromSelectionAction : public mv::gui::WidgetAction
 {
     Q_OBJECT
 
@@ -54,12 +50,12 @@ public:
      * @param parent Pointer to parent object
      * @param points Smart pointer to points dataset
      */
-    CreateSetFromSelectionAction(QObject* parent, const Dataset<Points>& points);
+    CreateSetFromSelectionAction(QObject* parent, const mv::Dataset<Points>& points);
 
 public: // Action getters
 
-    StringAction& getNameAction() { return _nameAction; }
-    TriggerAction& getCreateAction() { return _createAction; }
+    mv::gui::StringAction& getNameAction() { return _nameAction; }
+    mv::gui::TriggerAction& getCreateAction() { return _createAction; }
 
 signals:
 
@@ -69,7 +65,7 @@ signals:
     void dimensionNamesChanged(const QStringList& dimensionNames);
 
 protected:
-    Dataset<Points>     _points;            /** Points dataset reference */
-    StringAction        _nameAction;        /** Set name action */
-    TriggerAction       _createAction;      /** Create set action */
+    mv::Dataset<Points>         _points;            /** Points dataset reference */
+    mv::gui::StringAction       _nameAction;        /** Set name action */
+    mv::gui::TriggerAction      _createAction;      /** Create set action */
 };

--- a/ManiVault/src/plugins/PointData/src/DimensionPickerAction.cpp
+++ b/ManiVault/src/plugins/PointData/src/DimensionPickerAction.cpp
@@ -8,6 +8,7 @@
 #include <QHBoxLayout>
 
 using namespace mv;
+using namespace mv::gui;
 
 DimensionPickerAction::DimensionPickerAction(QObject* parent, const QString& title) :
     WidgetAction(parent, title),
@@ -189,7 +190,7 @@ DimensionPickerAction::Widget::Widget(QWidget* parent, DimensionPickerAction* di
     auto lineEditWidget = dimensionPickerAction->getCurrentDimensionAction().createWidget(this, OptionAction::LineEdit);
 
     // Gets search icon to decorate the line edit
-    const auto searchIcon = StyledIcon("magnifying-glass");
+    const auto searchIcon = mv::util::StyledIcon("magnifying-glass");
 
     // Add the icon to the line edit
     lineEditWidget->findChild<QLineEdit*>("LineEdit")->addAction(searchIcon, QLineEdit::TrailingPosition);

--- a/ManiVault/src/plugins/PointData/src/DimensionPickerAction.h
+++ b/ManiVault/src/plugins/PointData/src/DimensionPickerAction.h
@@ -11,10 +11,6 @@
 
 #include "pointdata_export.h"
 
-using namespace mv;
-using namespace mv::gui;
-using namespace mv::util;
-
 /**
  * Dimension picker action class
  *
@@ -23,14 +19,14 @@ using namespace mv::util;
  *
  * @author Thomas Kroes
  */
-class POINTDATA_EXPORT DimensionPickerAction : public WidgetAction
+class POINTDATA_EXPORT DimensionPickerAction : public mv::gui::WidgetAction
 {
 Q_OBJECT
 
 public:
 
     /** Widget class for points dimension picker action */
-    class Widget : public WidgetActionWidget
+    class Widget : public mv::gui::WidgetActionWidget
     {
     protected:
 
@@ -69,7 +65,7 @@ public:
      * Set the points dataset from which the dimension will be picked
      * @param points Dataset reference to points dataset
      */
-    void setPointsDataset(const Dataset<Points>& points);
+    void setPointsDataset(const mv::Dataset<Points>& points);
 
     /** Get the names of the dimensions */
     QStringList getDimensionNames() const;
@@ -152,12 +148,12 @@ signals:
 
 public: /** Action getters */
 
-    OptionAction& getCurrentDimensionAction() { return _currentDimensionAction; }
+    mv::gui::OptionAction& getCurrentDimensionAction() { return _currentDimensionAction; }
 
 protected:
-    Dataset<Points>     _points;                    /** Smart pointer to points dataset from which the dimension will be picked */
-    OptionAction        _currentDimensionAction;    /** Current dimension action */
-    std::uint32_t       _searchThreshold;           /** Select from a drop-down below the threshold and above use a search bar */
+    mv::Dataset<Points>     _points;                    /** Smart pointer to points dataset from which the dimension will be picked */
+    mv::gui::OptionAction   _currentDimensionAction;    /** Current dimension action */
+    std::uint32_t           _searchThreshold;           /** Select from a drop-down below the threshold and above use a search bar */
 
 protected:
     static constexpr std::uint32_t DEFAULT_SEARCH_THRESHOLD = 1000;     /** Default search threshold */

--- a/ManiVault/src/plugins/PointData/src/DimensionsPickerAction.h
+++ b/ManiVault/src/plugins/PointData/src/DimensionsPickerAction.h
@@ -290,7 +290,7 @@ protected:
     QMetaObject::Connection                                 _summaryUpdateAwakeConnection;      /** Update summary view when idle */
 
     friend class Widget;
-    friend class AbstractActionsManager;
+    friend class mv::AbstractActionsManager;
 };
 
 Q_DECLARE_METATYPE(DimensionsPickerAction)

--- a/ManiVault/src/plugins/PointData/src/DimensionsPickerAction.h
+++ b/ManiVault/src/plugins/PointData/src/DimensionsPickerAction.h
@@ -22,9 +22,6 @@
 
 #include <QTableView>
 
-using namespace mv;
-using namespace mv::gui;
-
 class QMenu;
 
 /**
@@ -34,7 +31,7 @@ class QMenu;
  *
  * @author Thomas Kroes
  */
-class POINTDATA_EXPORT DimensionsPickerAction : public WidgetAction
+class POINTDATA_EXPORT DimensionsPickerAction : public mv::gui::WidgetAction
 {
 
     Q_OBJECT
@@ -42,7 +39,7 @@ class POINTDATA_EXPORT DimensionsPickerAction : public WidgetAction
 protected:
 
     /** Widget class for dimension selection action */
-    class Widget : public WidgetActionWidget {
+    class Widget : public mv::gui::WidgetActionWidget {
     public:
 
         /**
@@ -123,33 +120,32 @@ public:
 
     /**
      * Get the input points dataset
-     * @param Input points dataset
      */
-    Dataset<Points> getPointsDataset() const;
+    mv::Dataset<Points> getPointsDataset() const;
 
     /**
      * Set the input points dataset
      * @param points Smart pointer to points dataset
      */
-    void setPointsDataset(const Dataset<Points>& points);
+    void setPointsDataset(const mv::Dataset<Points>& points);
 
     /**
      * Get selection picker holder
      * @return Reference to dimensions picker holder
      */
-    DimensionsPickerHolder& getHolder();
+    mv::DimensionsPickerHolder& getHolder();
 
     /**
      * Get item model
      * @return Reference to item model
      */
-    DimensionsPickerItemModel& getItemModel();
+    mv::DimensionsPickerItemModel& getItemModel();
 
     /**
      * Get selection proxy model
      * @return Reference to selection proxy model
      */
-    DimensionsPickerProxyModel& getProxyModel();
+    mv::DimensionsPickerProxyModel& getProxyModel();
 
 public:
 
@@ -231,7 +227,7 @@ public:
             for (std::uint32_t i{}; i < n; ++i)
                 _holder.setDimensionEnabled(i, _proxyModel->filterAcceptsRow(i, QModelIndex()) == selectVisible);
 
-            const ModelResetter modelResetter(_proxyModel.get());
+            const mv::ModelResetter modelResetter(_proxyModel.get());
         }
     }
 
@@ -267,7 +263,7 @@ signals:
      * Signals that the proxy model changed
      * @param dimensionsPickerProxyModel Pointer to dimensions picker proxy model
      */
-    void proxyModelChanged(DimensionsPickerProxyModel* dimensionsPickerProxyModel);
+    void proxyModelChanged(mv::DimensionsPickerProxyModel* dimensionsPickerProxyModel);
 
     /**
      * Signals that the selected dimensions changed
@@ -277,21 +273,21 @@ signals:
 
 protected: // Action getters
 
-    DimensionsPickerFilterAction& getFilterAction() { return _filterAction; }
-    DimensionsPickerSelectAction& getSelectAction() { return _selectAction; }
-    StringAction& getSummaryAction() { return _summaryAction; }
-    DimensionsPickerMiscellaneousAction& getMiscellaneousAction() { return _miscellaneousAction; }
+    mv::gui::DimensionsPickerFilterAction& getFilterAction() { return _filterAction; }
+    mv::gui::DimensionsPickerSelectAction& getSelectAction() { return _selectAction; }
+    mv::gui::StringAction& getSummaryAction() { return _summaryAction; }
+    mv::gui::DimensionsPickerMiscellaneousAction& getMiscellaneousAction() { return _miscellaneousAction; }
 
 protected:
-    Dataset<Points>                                 _points;                            /** Smart pointer to points set */
-    DimensionsPickerHolder                          _holder;                            /** Selection holder */
-    std::unique_ptr<DimensionsPickerItemModel>      _itemModel;                         /** Selection item model */
-    std::unique_ptr<DimensionsPickerProxyModel>     _proxyModel;                        /** Selection proxy model for filtering etc. */
-    StringAction                                    _summaryAction;                     /** Summary action */
-    DimensionsPickerFilterAction                    _filterAction;                      /** Filter action */
-    DimensionsPickerSelectAction                    _selectAction;                      /** Select action */
-    DimensionsPickerMiscellaneousAction             _miscellaneousAction;               /** Miscellaneous settings action */
-    QMetaObject::Connection                         _summaryUpdateAwakeConnection;      /** Update summary view when idle */
+    mv::Dataset<Points>                                     _points;                            /** Smart pointer to points set */
+    mv::DimensionsPickerHolder                              _holder;                            /** Selection holder */
+    std::unique_ptr<mv::DimensionsPickerItemModel>          _itemModel;                         /** Selection item model */
+    std::unique_ptr<mv::DimensionsPickerProxyModel>         _proxyModel;                        /** Selection proxy model for filtering etc. */
+    mv::gui::StringAction                                   _summaryAction;                     /** Summary action */
+    mv::gui::DimensionsPickerFilterAction                   _filterAction;                      /** Filter action */
+    mv::gui::DimensionsPickerSelectAction                   _selectAction;                      /** Select action */
+    mv::gui::DimensionsPickerMiscellaneousAction            _miscellaneousAction;               /** Miscellaneous settings action */
+    QMetaObject::Connection                                 _summaryUpdateAwakeConnection;      /** Update summary view when idle */
 
     friend class Widget;
     friend class AbstractActionsManager;

--- a/ManiVault/src/plugins/PointData/src/EditProxyDatasetsAction.cpp
+++ b/ManiVault/src/plugins/PointData/src/EditProxyDatasetsAction.cpp
@@ -11,6 +11,8 @@
 #include <QListView>
 #include <QStringListModel>
 
+using namespace mv;
+
 EditProxyDatasetsAction::EditProxyDatasetsAction(QObject* parent, const Dataset<Points>& points) :
     WidgetAction(parent, "Edit Proxy Datasets"),
     _points(points)

--- a/ManiVault/src/plugins/PointData/src/EditProxyDatasetsAction.h
+++ b/ManiVault/src/plugins/PointData/src/EditProxyDatasetsAction.h
@@ -6,10 +6,6 @@
 
 #include "PointData.h"
 
-using namespace mv;
-using namespace mv::util;
-using namespace mv::gui;
-
 /**
  * Edit proxy datasets action class
  *
@@ -17,14 +13,14 @@ using namespace mv::gui;
  *
  * @author Thomas Kroes
  */
-class EditProxyDatasetsAction : public WidgetAction
+class EditProxyDatasetsAction : public mv::gui::WidgetAction
 {
     Q_OBJECT
 
 protected:
 
     /** Widget class for edit proxy datasets action */
-    class Widget : public WidgetActionWidget {
+    class Widget : public mv::gui::WidgetActionWidget {
     public:
 
         /**
@@ -51,16 +47,16 @@ public:
      * @param parent Pointer to parent object
      * @param points Smart pointer to points dataset
      */
-    EditProxyDatasetsAction(QObject* parent, const Dataset<Points>& points);
+    EditProxyDatasetsAction(QObject* parent, const mv::Dataset<Points>& points);
 
     /**
      * Get points
      * @return Smart pointer to points dataset
      */
-    Dataset<Points>& getPoints();
+    mv::Dataset<Points>& getPoints();
 
 public: // Action getters
 
 protected:
-    Dataset<Points>     _points;        /** Points dataset reference */
+    mv::Dataset<Points>     _points;        /** Points dataset reference */
 };

--- a/ManiVault/src/plugins/PointData/src/InfoAction.h
+++ b/ManiVault/src/plugins/PointData/src/InfoAction.h
@@ -13,10 +13,6 @@
 
 #include <actions/StringAction.h>
 
-using namespace mv;
-using namespace mv::gui;
-using namespace mv::util;
-
 /**
  * Info action class
  *
@@ -24,7 +20,7 @@ using namespace mv::util;
  *
  * @author Thomas Kroes
  */
-class InfoAction : public GroupAction
+class InfoAction : public mv::gui::GroupAction
 {
 public:
 
@@ -33,26 +29,26 @@ public:
      * @param parent Pointer to parent object
      * @param points Smart pointer to points dataset
      */
-    InfoAction(QObject* parent, const Dataset<Points>& points);
+    InfoAction(QObject* parent, const mv::Dataset<Points>& points);
 
 public: // Action getters
 
-    StringAction& getDataStorageAction() { return _dataStorageAction; }
+    mv::gui::StringAction& getDataStorageAction() { return _dataStorageAction; }
     ProxyDatasetsAction& getProxyDatasetsAction() { return _proxyDatasetsAction; }
-    StringAction& getNumberOfPointsAction() { return _numberOfPointsAction; }
-    StringAction& getNumberOfDimensionsAction() { return _numberOfDimensionsAction; }
-    StringAction& getRawDataSizeAction() { return _rawDataSizeAction; }
+    mv::gui::StringAction& getNumberOfPointsAction() { return _numberOfPointsAction; }
+    mv::gui::StringAction& getNumberOfDimensionsAction() { return _numberOfDimensionsAction; }
+    mv::gui::StringAction& getRawDataSizeAction() { return _rawDataSizeAction; }
     NumberOfSelectedPointsAction& getNumberOfSelectedPointsAction() { return _numberOfSelectedPointsAction; }
     SelectedIndicesAction& getSelectedIndicesAction() { return _selectedIndicesAction; }
     CreateSetFromSelectionAction& getCreateSetFromSelection() { return _createSetFromSelection; }
 
 protected:
-    Dataset<Points>                 _points;                            /** Points dataset reference */
-    StringAction                    _dataStorageAction;                 /** Type of data storage action */
+    mv::Dataset<Points>             _points;                            /** Points dataset reference */
+    mv::gui::StringAction           _dataStorageAction;                 /** Type of data storage action */
     ProxyDatasetsAction             _proxyDatasetsAction;               /** Proxy datasets action */
-    StringAction                    _numberOfPointsAction;              /** Number of points action */
-    StringAction                    _numberOfDimensionsAction;          /** Number of dimensions action */
-    StringAction                    _rawDataSizeAction;                 /** Amount of memory for raw data */    
+    mv::gui::StringAction           _numberOfPointsAction;              /** Number of points action */
+    mv::gui::StringAction           _numberOfDimensionsAction;          /** Number of dimensions action */
+    mv::gui::StringAction           _rawDataSizeAction;                 /** Amount of memory for raw data */
     NumberOfSelectedPointsAction    _numberOfSelectedPointsAction;      /** Number of selected points action */
     SelectedIndicesAction           _selectedIndicesAction;             /** Selected indices action */
     CreateSetFromSelectionAction    _createSetFromSelection;            /** Create set from selection action */

--- a/ManiVault/src/plugins/PointData/src/NumberOfSelectedPointsAction.cpp
+++ b/ManiVault/src/plugins/PointData/src/NumberOfSelectedPointsAction.cpp
@@ -8,6 +8,8 @@
 #include <QListView>
 #include <QStringListModel>
 
+using namespace mv;
+
 NumberOfSelectedPointsAction::NumberOfSelectedPointsAction(QObject* parent, const Dataset<Points>& points) :
     WidgetAction(parent, "Number Of Selected Points"),
     _points(points),

--- a/ManiVault/src/plugins/PointData/src/NumberOfSelectedPointsAction.h
+++ b/ManiVault/src/plugins/PointData/src/NumberOfSelectedPointsAction.h
@@ -10,10 +10,6 @@
 
 #include <QTimer>
 
-using namespace mv;
-using namespace mv::util;
-using namespace mv::gui;
-
 /**
  * Number of selected points action class
  *
@@ -21,12 +17,12 @@ using namespace mv::gui;
  *
  * @author Thomas Kroes
  */
-class NumberOfSelectedPointsAction : public WidgetAction
+class NumberOfSelectedPointsAction : public mv::gui::WidgetAction
 {
 protected:
 
     /** Widget class for number of selected points action */
-    class Widget : public WidgetActionWidget {
+    class Widget : public mv::gui::WidgetActionWidget {
     public:
 
         /**
@@ -58,19 +54,19 @@ public:
      * @param parent Pointer to parent object
      * @param points Smart pointer to points dataset
      */
-    NumberOfSelectedPointsAction(QObject* parent, const Dataset<Points>& points);
+    NumberOfSelectedPointsAction(QObject* parent, const mv::Dataset<Points>& points);
 
     /**
      * Get points
      * @return Smart pointer to points dataset
      */
-    Dataset<Points>& getPoints();
+    mv::Dataset<Points>& getPoints();
 
 public: // Action getters
 
-    StringAction& getNumberOfSelectedPointsAction() { return _numberOfSelectedPointsAction; }
+    mv::gui::StringAction& getNumberOfSelectedPointsAction() { return _numberOfSelectedPointsAction; }
 
 protected:
-    Dataset<Points>     _points;                            /** Points dataset reference */
-    StringAction        _numberOfSelectedPointsAction;      /** Number of selected points action */
+    mv::Dataset<Points>     _points;                            /** Points dataset reference */
+    mv::gui::StringAction   _numberOfSelectedPointsAction;      /** Number of selected points action */
 };

--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -27,6 +27,8 @@ Q_PLUGIN_METADATA(IID "studio.manivault.PointData")
 // PointData
 // =============================================================================
 
+using namespace mv;
+using namespace mv::plugin;
 using namespace mv::util;
 
 namespace
@@ -335,7 +337,7 @@ void Points::init()
     };
 
     //if (isFull()) {
-        _dimensionsPickerGroupAction = new GroupAction(this, "Dimensions Group");
+        _dimensionsPickerGroupAction = new gui::GroupAction(this, "Dimensions Group");
 
         _dimensionsPickerGroupAction->setText("Dimensions");
         _dimensionsPickerGroupAction->setShowLabels(false);

--- a/ManiVault/src/plugins/PointData/src/PointData.h
+++ b/ManiVault/src/plugins/PointData/src/PointData.h
@@ -28,8 +28,6 @@
 #include <variant>
 #include <vector>
 
-using namespace mv::plugin;
-
 namespace mv
 {
     // From "graphics/Vector2f.h"
@@ -205,7 +203,7 @@ public:
     template <std::size_t N>
     using ElementTypeAt = typename std::variant_alternative_t<N, VariantOfVectors>::value_type;
 
-    PointData(PluginFactory* factory) : RawData(factory, PointType) { }
+    PointData(mv::plugin::PluginFactory* factory) : RawData(factory, PointType) { }
     ~PointData() override = default;
 
     void init() override;
@@ -1019,7 +1017,7 @@ public:
 // Factory
 // =============================================================================
 
-class PointDataFactory : public RawDataFactory
+class PointDataFactory : public mv::plugin::RawDataFactory
 {
     Q_INTERFACES(mv::plugin::RawDataFactory mv::plugin::PluginFactory)
         Q_OBJECT

--- a/ManiVault/src/plugins/PointData/src/ProxyDatasetsAction.h
+++ b/ManiVault/src/plugins/PointData/src/ProxyDatasetsAction.h
@@ -9,10 +9,6 @@
 
 #include <actions/StringAction.h>
 
-using namespace mv;
-using namespace mv::util;
-using namespace mv::gui;
-
 /**
  * Proxy datasets action class
  *
@@ -20,7 +16,7 @@ using namespace mv::gui;
  *
  * @author Thomas Kroes
  */
-class ProxyDatasetsAction : public WidgetAction
+class ProxyDatasetsAction : public mv::gui::WidgetAction
 {
     Q_OBJECT
 
@@ -54,11 +50,11 @@ public:
      * @param parent Pointer to parent object
      * @param points Smart pointer to points dataset
      */
-    ProxyDatasetsAction(QObject* parent, const Dataset<Points>& points);
+    ProxyDatasetsAction(QObject* parent, const mv::Dataset<Points>& points);
 
 public: // Action getters
 
-    StringAction& getCountAction() { return _countAction; }
+    mv::gui::StringAction& getCountAction() { return _countAction; }
     EditProxyDatasetsAction& getEditProxyDatasetsAction() { return _editProxyDatasetsAction; }
 
 signals:
@@ -69,7 +65,7 @@ signals:
     void dimensionNamesChanged(const QStringList& dimensionNames);
 
 protected:
-    Dataset<Points>             _points;                        /** Points dataset reference */
-    StringAction                _countAction;                   /** Number of proxy datasets action */
+    mv::Dataset<Points>         _points;                        /** Points dataset reference */
+    mv::gui::StringAction       _countAction;                   /** Number of proxy datasets action */
     EditProxyDatasetsAction     _editProxyDatasetsAction;       /** Manual update action */
 };

--- a/ManiVault/src/plugins/PointData/src/SelectedIndicesAction.h
+++ b/ManiVault/src/plugins/PointData/src/SelectedIndicesAction.h
@@ -12,10 +12,6 @@
 #include <QTimer>
 #include <QListView>
 
-using namespace mv;
-using namespace mv::gui;
-using namespace mv::util;
-
 /**
  * Selected indices action class
  *
@@ -23,12 +19,12 @@ using namespace mv::util;
  *
  * @author Thomas Kroes
  */
-class SelectedIndicesAction : public WidgetAction
+class SelectedIndicesAction : public mv::gui::WidgetAction
 {
 protected:
 
     /** Widget class for points info action */
-    class Widget : public WidgetActionWidget {
+    class Widget : public mv::gui::WidgetActionWidget {
     public:
 
         /**
@@ -73,13 +69,13 @@ public:
      * @param parent Pointer to parent object
      * @param points Smart pointer to points dataset
      */
-    SelectedIndicesAction(QObject* parent, const Dataset<Points>& points);
+    SelectedIndicesAction(QObject* parent, const mv::Dataset<Points>& points);
 
     /**
      * Get points
      * @return Smart pointer to points dataset
      */
-    Dataset<Points>& getPoints();
+    mv::Dataset<Points>& getPoints();
 
     /**
      * Get selected indices
@@ -89,13 +85,13 @@ public:
 
 public: // Action getters
 
-    TriggerAction& getUpdateAction() { return _updateAction; }
-    ToggleAction& getManualUpdateAction() { return _manualUpdateAction; }
+    mv::gui::TriggerAction& getUpdateAction() { return _updateAction; }
+    mv::gui::ToggleAction& getManualUpdateAction() { return _manualUpdateAction; }
 
 protected:
-    Dataset<Points>     _points;                    /** Points dataset reference */
-    TriggerAction       _updateAction;              /** Update action */
-    ToggleAction        _manualUpdateAction;        /** Manual update action */
+    mv::Dataset<Points>     _points;                    /** Points dataset reference */
+    mv::gui::TriggerAction  _updateAction;              /** Update action */
+    mv::gui::ToggleAction   _manualUpdateAction;        /** Manual update action */
 
     /** Above this threshold, selected indices need to be updated manually */
     static const std::int32_t MANUAL_UPDATE_THRESHOLD = 1000;

--- a/ManiVault/src/plugins/SharedParametersPlugin/src/SharedParametersPlugin.cpp
+++ b/ManiVault/src/plugins/SharedParametersPlugin/src/SharedParametersPlugin.cpp
@@ -9,6 +9,8 @@
 Q_PLUGIN_METADATA(IID "studio.manivault.SharedParametersPlugin")
 
 using namespace mv;
+using namespace mv::gui;
+using namespace mv::plugin;
 
 SharedParametersPlugin::SharedParametersPlugin(const PluginFactory* factory) :
     ViewPlugin(factory),

--- a/ManiVault/src/plugins/SharedParametersPlugin/src/SharedParametersPlugin.h
+++ b/ManiVault/src/plugins/SharedParametersPlugin/src/SharedParametersPlugin.h
@@ -10,10 +10,6 @@
 
 #include <ViewPlugin.h>
 
-using namespace mv;
-using namespace mv::plugin;
-using namespace mv::gui;
-
 /**
  * Shared parameters plugin
  *
@@ -21,7 +17,7 @@ using namespace mv::gui;
  *
  * @author Thomas Kroes
  */
-class SharedParametersPlugin : public ViewPlugin
+class SharedParametersPlugin : public mv::plugin::ViewPlugin
 {
     Q_OBJECT
     
@@ -31,17 +27,17 @@ public:
      * Construct with pointer to plugin \p factory
      * @param factory Pointer to plugin factory
      */
-    SharedParametersPlugin(const PluginFactory* factory);
+    SharedParametersPlugin(const mv::plugin::PluginFactory* factory);
 
     /** Perform plugin initialization */
     void init() override;
 
 private:
-    PublicActionsModel  _publicActionsModel;    /** Public actions model of the top-level public actions and their descendants */
-    ActionsWidget       _actionsWidget;         /** Widget for interaction with shared parameters */
+    mv::PublicActionsModel      _publicActionsModel;    /** Public actions model of the top-level public actions and their descendants */
+    mv::gui::ActionsWidget      _actionsWidget;         /** Widget for interaction with shared parameters */
 };
 
-class SharedParametersPluginFactory : public ViewPluginFactory
+class SharedParametersPluginFactory : public mv::plugin::ViewPluginFactory
 {
     Q_INTERFACES(mv::plugin::ViewPluginFactory mv::plugin::PluginFactory)
     Q_OBJECT
@@ -69,5 +65,5 @@ public:
      * Produces the plugin
      * @return Pointer to the produced plugin
      */
-    ViewPlugin* produce() override;
+    mv::plugin::ViewPlugin* produce() override;
 };

--- a/ManiVault/src/plugins/TasksPlugin/src/TasksPlugin.cpp
+++ b/ManiVault/src/plugins/TasksPlugin/src/TasksPlugin.cpp
@@ -16,7 +16,7 @@ Q_PLUGIN_METADATA(IID "studio.manivault.TasksPlugin")
 using namespace mv;
 using namespace mv::util;
 
-TasksPlugin::TasksPlugin(const PluginFactory* factory) :
+TasksPlugin::TasksPlugin(const plugin::PluginFactory* factory) :
     ViewPlugin(factory),
     _tasksAction(this, "Tasks")
 {
@@ -127,7 +127,7 @@ QUrl TasksPluginFactory::getRepositoryUrl() const
     return { "https://github.com/ManiVaultStudio/core" };
 }
 
-ViewPlugin* TasksPluginFactory::produce()
+plugin::ViewPlugin* TasksPluginFactory::produce()
 {
     return new TasksPlugin(this);
 }

--- a/ManiVault/src/plugins/TasksPlugin/src/TasksPlugin.cpp
+++ b/ManiVault/src/plugins/TasksPlugin/src/TasksPlugin.cpp
@@ -56,9 +56,9 @@ void TasksPlugin::init()
 
 void TasksPlugin::addTestSuite()
 {
-    auto testModalTaskGroupAction   = new GroupAction(this, "Test Modal Task");
-    auto modalTaskTestTypeAction    = new OptionAction(this, "Task Test Type", AbstractTaskTester::getTesterNames(), AbstractTaskTester::getTesterNames().first());
-    auto modalTaskStartTestAction   = new TriggerAction(this, "Start Test");
+    auto testModalTaskGroupAction   = new mv::gui::GroupAction(this, "Test Modal Task");
+    auto modalTaskTestTypeAction    = new mv::gui::OptionAction(this, "Task Test Type", AbstractTaskTester::getTesterNames(), AbstractTaskTester::getTesterNames().first());
+    auto modalTaskStartTestAction   = new mv::gui::TriggerAction(this, "Start Test");
 
     modalTaskTestTypeAction->setPlaceHolderString("<Pick Type>");
 
@@ -67,7 +67,7 @@ void TasksPlugin::addTestSuite()
 
     getWidget().layout()->addWidget(testModalTaskGroupAction->createWidget(&getWidget()));
 
-    connect(modalTaskStartTestAction, &TriggerAction::triggered, this, [this, modalTaskTestTypeAction]() -> void {
+    connect(modalTaskStartTestAction, &mv::gui::TriggerAction::triggered, this, [this, modalTaskTestTypeAction]() -> void {
         try {
             const auto metaTypeName = modalTaskTestTypeAction->getCurrentText();
             const auto metaType     = QMetaType::fromName(metaTypeName.toLatin1());

--- a/ManiVault/src/plugins/TasksPlugin/src/TasksPlugin.h
+++ b/ManiVault/src/plugins/TasksPlugin/src/TasksPlugin.h
@@ -17,10 +17,6 @@
 
 //#define TEST_SUITE
 
-using namespace mv;
-using namespace mv::plugin;
-using namespace mv::gui;
-
 /**
  * Tasks plugin
  *
@@ -28,7 +24,7 @@ using namespace mv::gui;
  *
  * @author Thomas Kroes
  */
-class TasksPlugin : public ViewPlugin
+class TasksPlugin : public mv::plugin::ViewPlugin
 {
     Q_OBJECT
     
@@ -38,7 +34,7 @@ public:
      * Construct with pointer to plugin \p factory
      * @param factory Pointer to plugin factory
      */
-    TasksPlugin(const PluginFactory* factory);
+    TasksPlugin(const mv::plugin::PluginFactory* factory);
 
     /** Perform plugin initialization */
     void init() override;
@@ -52,12 +48,12 @@ private:
 #endif
     
 private:
-    TasksTreeModel      _model;         /** Tasks tree model */
-    TasksFilterModel    _filterModel;   /** Filter model for the tasks model */
-    TasksTreeAction     _tasksAction;   /** Tasks action for displaying and interacting with the tasks in the system */
+    mv::TasksTreeModel           _model;         /** Tasks tree model */
+    mv::TasksFilterModel         _filterModel;   /** Filter model for the tasks model */
+    mv::gui::TasksTreeAction     _tasksAction;   /** Tasks action for displaying and interacting with the tasks in the system */
 };
 
-class TasksPluginFactory : public ViewPluginFactory
+class TasksPluginFactory : public mv::plugin::ViewPluginFactory
 {
     Q_INTERFACES(mv::plugin::ViewPluginFactory mv::plugin::PluginFactory)
     Q_OBJECT
@@ -85,5 +81,5 @@ public:
      * Produces the plugin
      * @return Pointer to the produced plugin
      */
-    ViewPlugin* produce() override;
+    mv::plugin::ViewPlugin* produce() override;
 };

--- a/ManiVault/src/plugins/TextData/src/InfoAction.h
+++ b/ManiVault/src/plugins/TextData/src/InfoAction.h
@@ -10,10 +10,6 @@
 
 #include <actions/StringAction.h>
 
-using namespace mv;
-using namespace mv::gui;
-using namespace mv::util;
-
 /**
  * Info action class
  *
@@ -21,7 +17,7 @@ using namespace mv::util;
  *
  * @author Julian Thijssen and Thomas Kroes
  */
-class InfoAction : public GroupAction
+class InfoAction : public mv::gui::GroupAction
 {
 public:
 
@@ -30,17 +26,17 @@ public:
      * @param parent Pointer to parent object
      * @param points Smart pointer to points dataset
      */
-    InfoAction(QObject* parent, const Dataset<Text>& dataset);
+    InfoAction(QObject* parent, const mv::Dataset<Text>& dataset);
 
 public: // Action getters
 
-    StringAction& getDataStorageAction() { return _dataStorageAction; }
-    StringAction& getNumberOfPointsAction() { return _numberOfPointsAction; }
-    StringAction& getRawDataSizeAction() { return _rawDataSizeAction; }
+    mv::gui::StringAction& getDataStorageAction() { return _dataStorageAction; }
+    mv::gui::StringAction& getNumberOfPointsAction() { return _numberOfPointsAction; }
+    mv::gui::StringAction& getRawDataSizeAction() { return _rawDataSizeAction; }
 
 protected:
-    Dataset<Text>                   _dataset;                           /** Text dataset reference */
-    StringAction                    _dataStorageAction;                 /** Type of data storage action */
-    StringAction                    _numberOfPointsAction;              /** Number of points action */
-    StringAction                    _rawDataSizeAction;                 /** Amount of memory for raw data */
+    mv::Dataset<Text>       _dataset;                           /** Text dataset reference */
+    mv::gui::StringAction   _dataStorageAction;                 /** Type of data storage action */
+    mv::gui::StringAction   _numberOfPointsAction;              /** Number of points action */
+    mv::gui::StringAction   _rawDataSizeAction;                 /** Amount of memory for raw data */
 };

--- a/ManiVault/src/plugins/TextData/src/TextData.cpp
+++ b/ManiVault/src/plugins/TextData/src/TextData.cpp
@@ -13,6 +13,9 @@
 
 Q_PLUGIN_METADATA(IID "studio.manivault.TextData")
 
+using namespace mv;
+using namespace mv::plugin;
+
 TextData::~TextData(void)
 {
 }
@@ -28,7 +31,7 @@ Dataset<DatasetImpl> TextData::createDataSet(const QString& guid /*= ""*/) const
 
 void TextData::fromVariantMap(const QVariantMap& variantMap)
 {
-    variantMapMustContain(variantMap, "OrderedMap");
+    mv::util::variantMapMustContain(variantMap, "OrderedMap");
 
     _data.fromVariantMap(variantMap["OrderedMap"].toMap());
 }
@@ -163,7 +166,7 @@ void Text::fromVariantMap(const QVariantMap& variantMap)
 {
     DatasetImpl::fromVariantMap(variantMap);
 
-    variantMapMustContain(variantMap, "Data");
+    util::variantMapMustContain(variantMap, "Data");
 
     getRawData<TextData>()->fromVariantMap(variantMap["Data"].toMap());
 

--- a/ManiVault/src/plugins/TextData/src/TextData.h
+++ b/ManiVault/src/plugins/TextData/src/TextData.h
@@ -14,9 +14,6 @@
 #include <QString>
 #include <vector>
 
-using namespace mv;
-using namespace mv::plugin;
-
 class InfoAction;
 
 // =============================================================================
@@ -32,7 +29,7 @@ const mv::DataType TextType = mv::DataType(QString("Text"));
 class TEXTDATA_EXPORT TextData : public mv::plugin::RawData
 {
 public:
-    TextData(PluginFactory* factory) :
+    TextData(mv::plugin::PluginFactory* factory) :
         mv::plugin::RawData(factory, TextType)
     {
     }
@@ -46,7 +43,7 @@ public:
      * @param guid Globally unique dataset identifier (use only for deserialization)
      * @return Smart pointer to dataset
      */
-    Dataset<DatasetImpl> createDataSet(const QString& guid = "") const override;
+    mv::Dataset<mv::DatasetImpl> createDataSet(const QString& guid = "") const override;
 
     /**
      * Determine if a column exists with the given header name
@@ -113,14 +110,14 @@ public: // Serialization
     QVariantMap toVariantMap() const override;
 
 private:
-    OrderedMap _data;
+    mv::OrderedMap _data;
 };
 
-class TEXTDATA_EXPORT Text : public DatasetImpl
+class TEXTDATA_EXPORT Text : public mv::DatasetImpl
 {
 public:
     Text(QString dataName, bool mayUnderive = true, const QString& guid = "") :
-        DatasetImpl(dataName, mayUnderive, guid),
+        mv::DatasetImpl(dataName, mayUnderive, guid),
         _infoAction(nullptr)
     {
     }
@@ -129,7 +126,7 @@ public:
 
     void init() override;
 
-    Dataset<DatasetImpl> copy() const override
+    mv::Dataset<DatasetImpl> copy() const override
     {
         auto text = new Text(getRawDataName());
 
@@ -173,7 +170,7 @@ public: // Subsetting
      * @param visible Whether the subset will be visible in the UI
      * @return Smart pointer to the created subset
      */
-    Dataset<DatasetImpl> createSubsetFromSelection(const QString& guiName, const Dataset<DatasetImpl>& parentDataSet = Dataset<DatasetImpl>(), const bool& visible = true) const override
+    mv::Dataset<DatasetImpl> createSubsetFromSelection(const QString& guiName, const mv::Dataset<DatasetImpl>& parentDataSet = mv::Dataset<DatasetImpl>(), const bool& visible = true) const override
     {
         return mv::data().createSubsetFromSelection(getSelection(), toSmartPointer(), guiName, parentDataSet, visible);
     }
@@ -239,7 +236,7 @@ public: // Selection
 // Factory
 // =============================================================================
 
-class TextDataFactory : public RawDataFactory
+class TextDataFactory : public mv::plugin::RawDataFactory
 {
     Q_INTERFACES(mv::plugin::RawDataFactory mv::plugin::PluginFactory)
     Q_OBJECT

--- a/ManiVault/src/private/DataHierarchyManager.h
+++ b/ManiVault/src/private/DataHierarchyManager.h
@@ -12,8 +12,6 @@
 #include <QMap>
 #include <QString>
 
-using namespace mv::gui;
-
 namespace mv
 {
 

--- a/ManiVault/src/private/DataManager.cpp
+++ b/ManiVault/src/private/DataManager.cpp
@@ -23,6 +23,7 @@
     //#define DATA_MANAGER_VERBOSE
 #endif
 
+using namespace mv::gui;
 using namespace mv::util;
 
 namespace mv

--- a/ManiVault/src/private/RemoveDatasetsDialog.cpp
+++ b/ManiVault/src/private/RemoveDatasetsDialog.cpp
@@ -13,7 +13,7 @@
 #include <QVBoxLayout>
 #include <QHeaderView>
 
-using namespace mv;
+using namespace mv::gui;
 using namespace mv::util;
 
 RemoveDatasetsDialog::RemoveDatasetsDialog(mv::Datasets selectedDatasets, QWidget* parent /*= nullptr*/) :
@@ -48,7 +48,7 @@ RemoveDatasetsDialog::RemoveDatasetsDialog(mv::Datasets selectedDatasets, QWidge
     _mainGroupAction.addStretch();
     _mainGroupAction.addAction(&_bottomHorizontalGroupAction);
 
-    DataHierarchyItems selectedDataHierarchyItems, topLevelSelectedDataHierarchyItems;
+    mv::DataHierarchyItems selectedDataHierarchyItems, topLevelSelectedDataHierarchyItems;
 
     for (auto& selectedDataset : selectedDatasets)
         selectedDataHierarchyItems << &selectedDataset->getDataHierarchyItem();
@@ -67,10 +67,10 @@ RemoveDatasetsDialog::RemoveDatasetsDialog(mv::Datasets selectedDatasets, QWidge
     _messageAction.setString(QString("The selected dataset%1 contain%2 %3 child%4, what would you like to do with them?").arg(_selectedDatasets.count() == 1 ? "" : "s", _selectedDatasets.count() == 1 ? "s" : "", QString::number(_descendantDatasets.count()), _descendantDatasets.count() >= 2 ? "ren" : ""));
 
     _descendantsModeAction.setDefaultWidgetFlags(OptionAction::WidgetFlag::HorizontalButtons);
-    _descendantsModeAction.setCurrentIndex(settings().getMiscellaneousSettings().getKeepDescendantsAfterRemovalAction().isChecked() ? 0 : 1);
+    _descendantsModeAction.setCurrentIndex(mv::settings().getMiscellaneousSettings().getKeepDescendantsAfterRemovalAction().isChecked() ? 0 : 1);
 
     connect(&_descendantsModeAction, &OptionAction::currentIndexChanged, this, [this](const std::int32_t& currentIndex) -> void {
-        settings().getMiscellaneousSettings().getKeepDescendantsAfterRemovalAction().setChecked(currentIndex == 0);
+        mv::settings().getMiscellaneousSettings().getKeepDescendantsAfterRemovalAction().setChecked(currentIndex == 0);
     });
 
     _selectDatasetsAction.initialize(&_model, &_filterModel, "dataset");
@@ -134,10 +134,10 @@ RemoveDatasetsDialog::RemoveDatasetsDialog(mv::Datasets selectedDatasets, QWidge
     _bottomHorizontalGroupAction.addAction(&_removeAction);
     _bottomHorizontalGroupAction.addAction(&_cancelAction);
 
-    _showAgainAction.setChecked(settings().getMiscellaneousSettings().getAskConfirmationBeforeRemovingDatasetsAction().isChecked());
+    _showAgainAction.setChecked(mv::settings().getMiscellaneousSettings().getAskConfirmationBeforeRemovingDatasetsAction().isChecked());
 
     connect(&_showAgainAction, &ToggleAction::toggled, this, [this](bool toggled) -> void {
-        settings().getMiscellaneousSettings().getAskConfirmationBeforeRemovingDatasetsAction().setChecked(toggled);
+        mv::settings().getMiscellaneousSettings().getAskConfirmationBeforeRemovingDatasetsAction().setChecked(toggled);
     });
 
     _removeAction.setToolTip("Remove the dataset(s)");

--- a/ManiVault/src/private/RemoveDatasetsDialog.h
+++ b/ManiVault/src/private/RemoveDatasetsDialog.h
@@ -13,14 +13,11 @@
 #include <actions/TriggerAction.h>
 #include <actions/HorizontalGroupAction.h>
 #include <actions/TreeAction.h>
-#include <actions/LabelProxyAction.h>
 
 #include <Dataset.h>
 
 #include <QDialog>
 #include <QTimer>
-
-using namespace mv::gui;
 
 /**
  * Remove datasets dialog class
@@ -69,15 +66,15 @@ protected:
     mv::Datasets                    _candidateDatasets;             /** All datasets eligible for removal */
     DatasetsToRemoveModel           _model;                         /** Model with all candidate datasets */
     DatasetsToRemoveFilterModel     _filterModel;                   /** Filter model for the model above */
-    VerticalGroupAction             _mainGroupAction;               /** Main group action layout */
-    StringAction                    _messageAction;                 /** Message action for informing the user about the existence of descendant datasets */
-    OptionAction                    _descendantsModeAction;         /** Option action for switching between keeping and removing descendant datasets */
-    VerticalGroupAction             _selectDatasetsGroupAction;     /** Vertical group action for configuring selected datasets */
-    TreeAction                      _selectDatasetsAction;          /** Tree action for dataset tree visualization and selection */
-    TriggerAction                   _selectAllDatasetsAction;       /** Trigger action to select all datasets */
-    HorizontalGroupAction           _bottomHorizontalGroupAction;   /** Group action for bottom actions */
-    ToggleAction                    _showAgainAction;               /** Toggle action to hide or show the dialog next time */
-    TriggerAction                   _removeAction;                  /** Trigger action to remove the dataset (s) */
-    TriggerAction                   _cancelAction;                  /** Trigger action to cancel the removal and the dialog */
+    mv::gui::VerticalGroupAction    _mainGroupAction;               /** Main group action layout */
+    mv::gui::StringAction           _messageAction;                 /** Message action for informing the user about the existence of descendant datasets */
+    mv::gui::OptionAction           _descendantsModeAction;         /** Option action for switching between keeping and removing descendant datasets */
+    mv::gui::VerticalGroupAction    _selectDatasetsGroupAction;     /** Vertical group action for configuring selected datasets */
+    mv::gui::TreeAction             _selectDatasetsAction;          /** Tree action for dataset tree visualization and selection */
+    mv::gui::TriggerAction          _selectAllDatasetsAction;       /** Trigger action to select all datasets */
+    mv::gui::HorizontalGroupAction  _bottomHorizontalGroupAction;   /** Group action for bottom actions */
+    mv::gui::ToggleAction           _showAgainAction;               /** Toggle action to hide or show the dialog next time */
+    mv::gui::TriggerAction          _removeAction;                  /** Trigger action to remove the dataset (s) */
+    mv::gui::TriggerAction          _cancelAction;                  /** Trigger action to cancel the removal and the dialog */
     QTimer                          _updateRemoveActionTimer;       /** Timer to prevent redundant updates of the remove action */
 };


### PR DESCRIPTION
We should not write `using namespace mv` header files that others might consume since then they would unknowingly also use that namespace constantly. 
This also follows the c++ core guideline [Don’t write using namespace at global scope in a header file](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rs-using-directive):
> **Reason**: Doing so takes away an `#includer`’s ability to effectively disambiguate and to use alternatives. It also makes `#include`d headers order-dependent as they might have different meaning when included in different orders

We have done this already across the core's public API, but the core and data plugins have not been as compliant.

This PR might break the build of some plugins, which will have to add `using namespace mv` back to their source.

<details>
<summary>I've tested:</summary>

- BinIO
- ClusterIO
- ClusteringPlugin, https://github.com/ManiVaultStudio/ClusteringPlugin/pull/3, 
- ClusterMeansPlugin, https://github.com/ManiVaultStudio/ClusterMeansPlugin/pull/5
- ClustersFromPointsPlugin, https://github.com/ManiVaultStudio/ClustersFromPointsPlugin/pull/20, https://github.com/ManiVaultStudio/ClustersFromPointsPlugin/pull/22
- CsvLoader
- CsvWriter
- DE-MultiSpecies
- DifferentialExpressionPlugin
- DimensionsViewerPlugin, https://github.com/ManiVaultStudio/DimensionsViewerPlugin/pull/27
- ENVILoader
- ExamplePlugins
- ExtCsvLoader
- HDF5Loader, https://github.com/ManiVaultStudio/HDF5Loader/pull/39
- HeatMap
- ImageLoaderPlugin, https://github.com/ManiVaultStudio/ImageLoaderPlugin/pull/129
- ImageTransformationPlugin, https://github.com/ManiVaultStudio/ImageTransformationPlugin/pull/7
- ImageViewerPlugin, https://github.com/ManiVaultStudio/ImageViewerPlugin/pull/153
- JupyterPlugin, https://github.com/ManiVaultStudio/JupyterPlugin/pull/63
- MeanShiftClustering
- ParallelCoordinatesPlugin
- PcaPlugin, https://github.com/ManiVaultStudio/PcaPlugin/pull/39
- PointDataConversionPlugin
- RefinePlugin, https://github.com/ManiVaultStudio/RefinePlugin/pull/13
- Scatterplot
- SparseH5DataAccessPlugin, https://github.com/ManiVaultStudio/SparseH5DataAccessPlugin/pull/19
- SpectralViewPlugin, https://github.com/ManiVaultStudio/SpectralViewPlugin/pull/18
- SunburstClusterPlugin, https://github.com/ManiVaultStudio/SunburstClusterPlugin/pull/20
- UMAP-Plugin, https://github.com/ManiVaultStudio/UMAP-Plugin/pull/31
- t-SNE-Analysis, https://github.com/ManiVaultStudio/t-SNE-Analysis/pull/166
- VolumeProjectorPlugin, https://github.com/ManiVaultStudio/VolumeProjectorPlugin/pull/10

All linked PRs in plugins do not depend on this PR (they are compatible with the current core), but are required after this PR is merged.

If there is no linked PR, the plugin does not need to be updated.

</details>
