### PR TITLE
Fix plugin name regression

### DIFF
--- a/ManiVault/cmake/mv_plugin_meta_data.cmake
+++ b/ManiVault/cmake/mv_plugin_meta_data.cmake
@@ -22,6 +22,16 @@ function(mv_handle_plugin_config plugin_target)
     # Check if config file contains certain entries
     set(HAS_PLUGIN_TYPE 0)
 
+    # Get current ManiVault core version
+    if(DEFINED ManiVault_VERSION) # plugins (outside of core)
+        set(CORE_VERSION "${ManiVault_VERSION}")
+    elseif(DEFINED MV_VERSION) # core plugins
+        set(CORE_VERSION "${MV_VERSION}")
+    else()
+        message(WARNING "mv_handle_plugin_config: No ManiVault core version available - this is likely an error")
+        set(CORE_VERSION "0.0.0")
+    endif()
+
     # Get the number of top-level keys
     string(JSON TOP_LEVEL_COUNT LENGTH "${PLUGIN_INFO_JSON}")
 
@@ -40,7 +50,7 @@ function(mv_handle_plugin_config plugin_target)
     string(JSON PLUGIN_VERSION GET "${PLUGIN_INFO_JSON}" version plugin)
     message(STATUS "  version: ${PLUGIN_VERSION}")
     set_target_properties(${plugin_target} PROPERTIES
-        OUTPUT_NAME  "${plugin_target}_p${PLUGIN_VERSION}_c${ManiVault_VERSION}"
+        OUTPUT_NAME  "${plugin_target}_p${PLUGIN_VERSION}_c${CORE_VERSION}"
     )
 
     # Extract plugin type

--- a/ManiVault/src/plugins/ClusterData/CMakeLists.txt
+++ b/ManiVault/src/plugins/ClusterData/CMakeLists.txt
@@ -5,7 +5,7 @@ PROJECT(${CLUSTERDATA} LANGUAGES CXX)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-set(CLUSTERD_SOURCES
+set(CLUSTER_SOURCES
     src/ClusterData.h
     src/ClusterData.cpp
     src/Cluster.h
@@ -71,13 +71,13 @@ set(CLUSTER_AUX
     PluginInfo.json
 )
 
-source_group(Plugin FILES ${CLUSTERD_SOURCES})
+source_group(Plugin FILES ${CLUSTER_SOURCES})
 source_group(Actions FILES ${ACTIONS_SOURCES})
 source_group(Model FILES ${MODEL_SOURCES})
 source_group(Dialog FILES ${DIALOG_SOURCES})
-source_group(AUX FILES ${CLUSTER_AUX})
+source_group(Aux FILES ${CLUSTER_AUX})
 
-add_library(${CLUSTERDATA} SHARED ${CLUSTERD_SOURCES} ${ACTIONS_SOURCES} ${MODEL_SOURCES} ${DIALOG_SOURCES} ${CLUSTER_AUX})
+add_library(${CLUSTERDATA} SHARED ${CLUSTER_SOURCES} ${ACTIONS_SOURCES} ${MODEL_SOURCES} ${DIALOG_SOURCES} ${CLUSTER_AUX})
 
 add_library(ManiVault::${CLUSTERDATA} ALIAS ${CLUSTERDATA})
 

--- a/ManiVault/src/plugins/ClusterData/PluginInfo.json
+++ b/ManiVault/src/plugins/ClusterData/PluginInfo.json
@@ -1,5 +1,5 @@
 {
-    "name" : "Cluster Data",
+    "name" : "Cluster",
     "version" :  {
         "plugin" : "1.0.0"
     },

--- a/ManiVault/src/plugins/ClusterData/PluginInfo.json
+++ b/ManiVault/src/plugins/ClusterData/PluginInfo.json
@@ -4,5 +4,5 @@
         "plugin" : "1.0.0"
     },
     "type" : "Data",
-    "dependencies" : []
+    "dependencies" : ["Points"]
 }

--- a/ManiVault/src/plugins/ColorData/CMakeLists.txt
+++ b/ManiVault/src/plugins/ColorData/CMakeLists.txt
@@ -18,9 +18,10 @@ set(COLORDATA_AUX
     PluginInfo.json
 )
 
-source_group( Plugin FILES ${COLORDATA_SOURCES} ${COLORDATA_AUX})
+source_group(Plugin FILES ${COLORDATA_SOURCES})
+source_group(Aux FILES ${COLORDATA_AUX})
 
-add_library(${COLORDATA} SHARED ${COLORDATA_SOURCES})
+add_library(${COLORDATA} SHARED ${COLORDATA_SOURCES} ${COLORDATA_AUX})
 
 add_library(ManiVault::${COLORDATA} ALIAS ${COLORDATA})
 

--- a/ManiVault/src/plugins/ColorData/PluginInfo.json
+++ b/ManiVault/src/plugins/ColorData/PluginInfo.json
@@ -1,5 +1,5 @@
 {
-    "name" : "Color Data",
+    "name" : "ColorData",
     "version" :  {
         "plugin" : "1.0.0"
     },

--- a/ManiVault/src/plugins/DataHierarchyPlugin/PluginInfo.json
+++ b/ManiVault/src/plugins/DataHierarchyPlugin/PluginInfo.json
@@ -1,5 +1,5 @@
 {
-    "name" : "Data Hierarchy",
+    "name" : "Data hierarchy",
     "version" :  {
         "plugin" : "1.0.0"
     },

--- a/ManiVault/src/plugins/DataPropertiesPlugin/PluginInfo.json
+++ b/ManiVault/src/plugins/DataPropertiesPlugin/PluginInfo.json
@@ -1,5 +1,5 @@
 {
-    "name" : "Data Properties",
+    "name" : "Data properties",
     "version" :  {
         "plugin" : "1.0.0"
     },

--- a/ManiVault/src/plugins/ImageData/PluginInfo.json
+++ b/ManiVault/src/plugins/ImageData/PluginInfo.json
@@ -1,5 +1,5 @@
 {
-    "name" : "Image Data",
+    "name" : "Images",
     "version" :  {
         "plugin" : "1.0.0"
     },

--- a/ManiVault/src/plugins/PointData/CMakeLists.txt
+++ b/ManiVault/src/plugins/PointData/CMakeLists.txt
@@ -81,8 +81,10 @@ set(POINT_DATA_AUX
     PluginInfo.json
 )
 
-source_group(Plugin FILES ${POINTS_SOURCES} ${POINT_DATA_AUX})
+source_group(Plugin FILES ${POINTS_SOURCES})
 source_group(Actions FILES ${ACTIONS_SOURCES})
+source_group(BFloat FILES ${BFLOAT_HEADER})
+source_group(Aux FILES ${POINT_DATA_AUX})
 
 add_library(${POINTDATA} SHARED ${POINTS_SOURCES} ${ACTIONS_SOURCES} ${POINT_DATA_AUX})
 

--- a/ManiVault/src/plugins/PointData/PluginInfo.json
+++ b/ManiVault/src/plugins/PointData/PluginInfo.json
@@ -1,5 +1,5 @@
 {
-    "name" : "Point Data",
+    "name" : "Points",
     "version" :  {
         "plugin" : "1.0.0"
     },

--- a/ManiVault/src/plugins/SampleScopePlugin/PluginInfo.json
+++ b/ManiVault/src/plugins/SampleScopePlugin/PluginInfo.json
@@ -1,5 +1,5 @@
 {
-    "name" : "Sample Scope",
+    "name" : "Sample scope",
     "version" :  {
         "plugin" : "1.0.0"
     },

--- a/ManiVault/src/plugins/SharedParametersPlugin/PluginInfo.json
+++ b/ManiVault/src/plugins/SharedParametersPlugin/PluginInfo.json
@@ -1,5 +1,5 @@
 {
-    "name" : "Shared Parameters",
+    "name" : "Shared parameters",
     "version" :  {
         "plugin" : "1.0.0"
     },

--- a/ManiVault/src/plugins/TextData/CMakeLists.txt
+++ b/ManiVault/src/plugins/TextData/CMakeLists.txt
@@ -24,7 +24,8 @@ set(TEXTDATA_AUX
     PluginInfo.json
 )
 
-source_group( Plugin FILES ${TEXTDATA_SOURCES} ${TEXTDATA_AUX})
+source_group(Plugin FILES ${TEXTDATA_SOURCES})
+source_group(Aux FILES ${TEXTDATA_AUX})
 
 add_library(${TEXTDATA} SHARED ${TEXTDATA_SOURCES} ${TEXTDATA_AUX})
 

--- a/ManiVault/src/plugins/TextData/PluginInfo.json
+++ b/ManiVault/src/plugins/TextData/PluginInfo.json
@@ -1,5 +1,5 @@
 {
-    "name" : "Cluster Data",
+    "name" : "Text",
     "version" :  {
         "plugin" : "1.0.0"
     },


### PR DESCRIPTION
#1244 changed plugin names, e.g. `Cluster` to `Cluster Data`, which results in errors when loading projects saved with previous core versions.

- This PR reverts those renames
- It also handles the core version for core plugins in `mv_plugin_meta_data.cmake` (which affects the dynamic library file name)

Note:
- It's `Points` and `Images` but `Cluster`, `Text` and `ColorData`. In a future version, we might want to introduce a more consistent naming scheme