### PR TITLE
Update Quazip to 1.7.0

### DIFF
--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -162,12 +162,13 @@ set_target_properties(zlibstatic PROPERTIES
 CPMAddPackage(
   NAME              quazip
   GITHUB_REPOSITORY stachenov/quazip
-  GIT_TAG           v1.5
+  GIT_TAG           v1.7.0
   OPTIONS 
     "QUAZIP_QT_MAJOR_VERSION 6" 
     "QUAZIP_BZIP2 OFF" 
     "QUAZIP_INSTALL OFF" 
     "BUILD_SHARED_LIBS OFF"
+    "QUAZIP_ENABLE_QTEXTCODEC OFF"
 )
 
 set_target_properties(QuaZip PROPERTIES 


### PR DESCRIPTION
- Updates Quazip to [`1.7.0`](https://github.com/stachenov/quazip/releases) from `1.5`

The new Quazip version allows us to get rid of `ManiVault.exe`'s transitive `Core5Compat` Qt dependency since it uses `QStringConverter` instead of `QTextCodec`. This, apparently, supports fewer encodings, but, as far as I can tell, that does not affect us.

(We have never explicitly checked for the Qt module ourselves in the CMake, but list it [in the wiki](https://github.com/ManiVaultStudio/core/wiki/Installation/65f3602c8b7b7ce7a2b14916bab814ddb8195200#dependencies))