### PR TITLE
CI: Use cache_variables for CMake options in `conanfile.py`

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -171,9 +171,9 @@ class HdpsCoreConan(ConanFile):
         if self.settings.os == "Macos":
             MV_USE_ERROR_LOGGING = "OFF"
 
-        tc.variables["MV_PRECOMPILE_HEADERS"] = MV_PRECOMPILE_HEADERS
-        tc.variables["MV_UNITY_BUILD"] = MV_UNITY_BUILD
-        tc.variables["MV_USE_ERROR_LOGGING"] = MV_USE_ERROR_LOGGING
+        tc.cache_variables["MV_PRECOMPILE_HEADERS"] = MV_PRECOMPILE_HEADERS
+        tc.cache_variables["MV_UNITY_BUILD"] = MV_UNITY_BUILD
+        tc.cache_variables["MV_USE_ERROR_LOGGING"] = MV_USE_ERROR_LOGGING
         
         try:
             tc.generate()


### PR DESCRIPTION
`tc.variables[...]` sets a normal CMake variable and `tc.cache_variable[...]` should be used for CMake options, see the [conan docs](https://docs.conan.io/2/reference/tools/cmake/cmaketoolchain.html).

In some cases this can lead to options not being set as expected, as I've recently stumbled over in https://github.com/biovault/HDILib/pull/68.