### PR TITLE
Fixes issues for building the core standalone on macOS brought up in issue 1228

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,6 @@ cmake_minimum_required(VERSION 3.22)
 set(MV_MAIN "mv-main")
 PROJECT(${MV_MAIN})
 
-if(APPLE)
-  enable_language(OBJC)
-  enable_language(OBJCXX)
-endif()
-
 # -----------------------------------------------------------------------------
 # User options
 # -----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ cmake_minimum_required(VERSION 3.22)
 set(MV_MAIN "mv-main")
 PROJECT(${MV_MAIN})
 
+if(APPLE)
+  enable_language(OBJC)
+  enable_language(OBJCXX)
+endif()
+
 # -----------------------------------------------------------------------------
 # User options
 # -----------------------------------------------------------------------------

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -386,15 +386,23 @@ if(MV_PRECOMPILE_HEADERS)
 endif()
 
 if(APPLE)
+    # Find libraries relative to the executable in the macOS .app tree
+    set_target_properties(${MV_EXE} PROPERTIES BUILD_WITH_INSTALL_RPATH True)
+    set_target_properties(${MV_EXE} PROPERTIES INSTALL_RPATH "@loader_path;@executable_path/../Frameworks")
 
-    set_target_properties(${MV_EXE} PROPERTIES
-        # Find libraries relative to the executable in the macOS .app tree
-        BUILD_WITH_INSTALL_RPATH True
-        # Debug ManiVault Studio from the install directory
-        XCODE_SCHEME_WORKING_DIRECTORY "$<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/Debug,$<IF:$<CONFIG:RELWITHDEBINFO>,${MV_INSTALL_DIR}/RelWithDebInfo,${MV_INSTALL_DIR}/Release>>"
-        XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING NO
-        XCODE_SCHEME_EXECUTABLE "${MV_INSTALL_DIR}/Debug/ManiVault Studio.app"
-    )
+
+    # Make required non-Qt dylibs available in the build-tree app bundle for debugger runs
+    add_custom_command(TARGET ${MV_EXE} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:qtadvanceddocking-qt6>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${MV_PUBLIC_LIB}>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
+        COMMENT "Copying bundle framework dependencies for build-tree debugging"
+	)
+
+    # Debug ManiVault Studio from the install directory
+    set_target_properties(${MV_EXE} PROPERTIES XCODE_SCHEME_WORKING_DIRECTORY "$<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/Debug,$<IF:$<CONFIG:RELWITHDEBINFO>,${MV_INSTALL_DIR}/RelWithDebInfo,${MV_INSTALL_DIR}/Release>>")   
+    set_target_properties(${MV_EXE} PROPERTIES XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING NO)
+    set_target_properties(${MV_EXE} PROPERTIES XCODE_SCHEME_EXECUTABLE "${MV_INSTALL_DIR}/Debug/ManiVault Studio.app")
 
 endif()
 
@@ -475,11 +483,6 @@ if(APPLE)
     )
     # -always-overwrite
     find_program(MACDEPLOYQT_EXECUTABLE macdeployqt HINTS "${_qt_bin_dir}")
-
-    set(MACOSX_BUNDLE_ADDITIONAL_LIBS
-        \"$<TARGET_FILE:qtadvanceddocking-qt6>\"
-        \"$<TARGET_FILE:${MV_PUBLIC_LIB}>\"
-    )
 
     if(${MV_USE_ERROR_LOGGING})
         list(APPEND MACOSX_BUNDLE_ADDITIONAL_LIBS \"$<TARGET_FILE:sentry>\" \"$<TARGET_FILE:crashpad_wer>\" \"$<TARGET_FILE:crashpad_handler}>\")

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -395,6 +395,9 @@ if(APPLE)
     add_custom_command(TARGET ${MV_EXE} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:qtadvanceddocking-qt6>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
+        # Keep one real dylib and add a SONAME alias so dyld can resolve @rpath/libqtadvanceddocking*.4.dylib. Make sure to remove any existing SONAME (symlink) first.
+        COMMAND ${CMAKE_COMMAND} -E rm -f "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/$<TARGET_SONAME_FILE_NAME:qtadvanceddocking-qt6>"
+        COMMAND ${CMAKE_COMMAND} -E create_symlink "$<TARGET_FILE_NAME:qtadvanceddocking-qt6>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/$<TARGET_SONAME_FILE_NAME:qtadvanceddocking-qt6>"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${MV_PUBLIC_LIB}>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
         COMMENT "Copying bundle framework dependencies for build-tree debugging"
 	)

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -9,6 +9,11 @@ project(${MV_CORE}
     DESCRIPTION "Core application and library of ManiVault Studio, a flexible and extensible visual analytics framework for high-dimensional data"
     LANGUAGES CXX C)
 
+if(APPLE)
+  enable_language(OBJC)
+  enable_language(OBJCXX)
+endif()
+
 # These three targets defined in this CMakeLists.txt
 set(MV_APPLICATION_NAME "ManiVault Studio")  # Name of the executable
 set(MV_EXE MV_Application)                   # The ManiVault executable target

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -391,18 +391,6 @@ if(MV_PRECOMPILE_HEADERS)
 endif()
 
 if(APPLE)
-
-    # Make required non-Qt dylibs available in the build-tree app bundle for debugger runs
-    add_custom_command(TARGET ${MV_EXE} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:qtadvanceddocking-qt6>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
-        # Keep one real dylib and add a SONAME alias so dyld can resolve @rpath/libqtadvanceddocking*.4.dylib. Make sure to remove any existing SONAME (symlink) first.
-        COMMAND ${CMAKE_COMMAND} -E rm -f "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/$<TARGET_SONAME_FILE_NAME:qtadvanceddocking-qt6>"
-        COMMAND ${CMAKE_COMMAND} -E create_symlink "$<TARGET_FILE_NAME:qtadvanceddocking-qt6>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/$<TARGET_SONAME_FILE_NAME:qtadvanceddocking-qt6>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${MV_PUBLIC_LIB}>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
-        COMMENT "Copying bundle framework dependencies for build-tree debugging"
-	)
-
     set_target_properties(${MV_EXE} PROPERTIES
         # Find libraries relative to the executable in the macOS .app tree
         BUILD_WITH_INSTALL_RPATH True
@@ -412,7 +400,6 @@ if(APPLE)
         XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING NO
         XCODE_SCHEME_EXECUTABLE "${MV_INSTALL_DIR}/Debug/ManiVault Studio.app"
     )
-
 endif()
 
 # -----------------------------------------------------------------------------
@@ -667,6 +654,18 @@ if(APPLE)
             --prefix ${MV_INSTALL_DIR}/$<CONFIGURATION>
             --verbose
     )
+
+    # Make required non-Qt dylibs available in the build-tree app bundle for debugger runs
+    add_custom_command(TARGET ${MV_EXE} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:qtadvanceddocking-qt6>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
+        # Keep one real dylib and add a SONAME alias so dyld can resolve @rpath/libqtadvanceddocking*.4.dylib. Make sure to remove any existing SONAME (symlink) first.
+        COMMAND ${CMAKE_COMMAND} -E rm -f "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/$<TARGET_SONAME_FILE_NAME:qtadvanceddocking-qt6>"
+        COMMAND ${CMAKE_COMMAND} -E create_symlink "$<TARGET_FILE_NAME:qtadvanceddocking-qt6>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/$<TARGET_SONAME_FILE_NAME:qtadvanceddocking-qt6>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${MV_PUBLIC_LIB}>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
+        COMMENT "Copying bundle framework dependencies for build-tree debugging"
+	)
+
 endif()
 
 if(NOT APPLE)

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -480,10 +480,6 @@ if(APPLE)
     # -always-overwrite
     find_program(MACDEPLOYQT_EXECUTABLE macdeployqt HINTS "${_qt_bin_dir}")
 
-    if(${MV_USE_ERROR_LOGGING})
-        list(APPEND MACOSX_BUNDLE_ADDITIONAL_LIBS \"$<TARGET_FILE:sentry>\" \"$<TARGET_FILE:crashpad_wer>\" \"$<TARGET_FILE:crashpad_handler}>\")
-    endif()
-
     install(CODE "
         message(\"**** MacOS bundle install ****\")
 
@@ -496,13 +492,8 @@ if(APPLE)
             if(NOT retval EQUAL 0)
                 message(FATAL_ERROR \"macdeployqt failed\")
             endif()
-
-
-            message(\"**** Copy additional libs: \${MACOSX_BUNDLE_ADDITIONAL_LIBS}\")
-            file(COPY \${MACOSX_BUNDLE_ADDITIONAL_LIBS} DESTINATION \"${BUNDLE_DIR}/Contents/Frameworks/\")
         endif()
     " COMPONENT MACOS_BUNDLE)
-
       
     install(CODE "execute_process(
             COMMAND bash ${WEBENGINEINSTALL_CMD} ${Qt6_DIR} \"${BUNDLE_DIR}\"
@@ -665,6 +656,15 @@ if(APPLE)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${MV_PUBLIC_LIB}>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
         COMMENT "Copying bundle framework dependencies for build-tree debugging"
 	)
+
+    if(${MV_USE_ERROR_LOGGING})
+        add_custom_command(TARGET ${MV_EXE} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:sentry>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:crashpad_wer>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:crashpad_handler>" "$<TARGET_FILE_DIR:${MV_EXE}>/../Frameworks/"
+            COMMENT "Copying bundle framework dependencies for build-tree debugging (error logging)"
+        )
+    endif()
 
 endif()
 

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -391,10 +391,6 @@ if(MV_PRECOMPILE_HEADERS)
 endif()
 
 if(APPLE)
-    # Find libraries relative to the executable in the macOS .app tree
-    set_target_properties(${MV_EXE} PROPERTIES BUILD_WITH_INSTALL_RPATH True)
-    set_target_properties(${MV_EXE} PROPERTIES INSTALL_RPATH "@loader_path;@executable_path/../Frameworks")
-
 
     # Make required non-Qt dylibs available in the build-tree app bundle for debugger runs
     add_custom_command(TARGET ${MV_EXE} POST_BUILD
@@ -407,10 +403,15 @@ if(APPLE)
         COMMENT "Copying bundle framework dependencies for build-tree debugging"
 	)
 
-    # Debug ManiVault Studio from the install directory
-    set_target_properties(${MV_EXE} PROPERTIES XCODE_SCHEME_WORKING_DIRECTORY "$<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/Debug,$<IF:$<CONFIG:RELWITHDEBINFO>,${MV_INSTALL_DIR}/RelWithDebInfo,${MV_INSTALL_DIR}/Release>>")   
-    set_target_properties(${MV_EXE} PROPERTIES XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING NO)
-    set_target_properties(${MV_EXE} PROPERTIES XCODE_SCHEME_EXECUTABLE "${MV_INSTALL_DIR}/Debug/ManiVault Studio.app")
+    set_target_properties(${MV_EXE} PROPERTIES
+        # Find libraries relative to the executable in the macOS .app tree
+        BUILD_WITH_INSTALL_RPATH True
+        INSTALL_RPATH "@loader_path;@executable_path/../Frameworks"
+        # Debug ManiVault Studio from the install directory
+        XCODE_SCHEME_WORKING_DIRECTORY "$<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/Debug,$<IF:$<CONFIG:RELWITHDEBINFO>,${MV_INSTALL_DIR}/RelWithDebInfo,${MV_INSTALL_DIR}/Release>>"
+        XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING NO
+        XCODE_SCHEME_EXECUTABLE "${MV_INSTALL_DIR}/Debug/ManiVault Studio.app"
+    )
 
 endif()
 

--- a/ManiVault/cmake/mv_project_defaults.cmake
+++ b/ManiVault/cmake/mv_project_defaults.cmake
@@ -50,7 +50,7 @@ function(mv_project_defaults)
         set(CMAKE_XCODE_GENERATE_SCHEME ON CACHE BOOL "" FORCE)
 
         # macOS-specific RPATH
-        set(MV_INSTALL_RPATH "@loader_path")
+        set(MV_INSTALL_RPATH "@loader_path;@executable_path/../Frameworks")
     endif()
 
     # -----------------------------------------------------------------------------


### PR DESCRIPTION
The PCH problem is addressed here by enabling Objective C(++) compilation for macOS, rather than turning of precompiled headers.

Running the app from the debugger immediately crashed for me because the built libraries (MV_Public and qtadvanceddocking) were not embedded into the app bundle. I moved this step from install to post build to make sure it happens and by doing it as post build the libraries will already be there in build-tree, rather than only in install.

I have tested this with Xcode projects and makefiles (in VS Code) as target.

Fixes #1228