### PR TITLE
Remove duplicate FILE_DIALOG_VERBOSE definition

### DIFF
--- a/ManiVault/src/widgets/FileDialog.cpp
+++ b/ManiVault/src/widgets/FileDialog.cpp
@@ -10,8 +10,6 @@
     #define FILE_DIALOG_VERBOSE
 #endif
 
-#define FILE_DIALOG_VERBOSE
-
 using namespace mv::util;
 
 namespace mv::gui {


### PR DESCRIPTION
The preceding
```cpp
#ifdef _DEBUG
    #define FILE_DIALOG_VERBOSE
#endif
```
should be enough.