### PR TITLE
uses .icns file instead of lowres png to set icon on macOS (issue #1143)

### DIFF
--- a/ManiVault/res/ResourcesCore.qrc
+++ b/ManiVault/res/ResourcesCore.qrc
@@ -26,6 +26,7 @@
         <file alias="AppIcon256">icons/AppIcon256.png</file>
         <file alias="AppIcon512">icons/AppIcon512.png</file>
         <file alias="AppIcon1024">icons/AppIcon1024.png</file>
+        <file alias="AppIconIcns">icons/AppIcon.icns</file>
     </qresource>
     <qresource prefix="/Images">
         <file alias="AppBackground256">images/AppBackground256.png</file>

--- a/ManiVault/src/Application.cpp
+++ b/ManiVault/src/Application.cpp
@@ -25,6 +25,7 @@
 #include <QMainWindow>
 #include <QDir>
 #include <QShortcut>
+#include <QOperatingSystemVersion>
 
 using nlohmann::json;
 
@@ -80,7 +81,12 @@ Application::Application(int& argc, char** argv) :
 
         _configurationAction.getStartPageConfigurationAction().getToggleCustomizationAction().setChecked(true);
 
-        Application::setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
+        if(QOperatingSystemVersion::currentType() == QOperatingSystemVersion::MacOS)
+        {
+            Application::setWindowIcon(QIcon(":/Icons/AppIcon.icns"));
+        } else {
+            Application::setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
+        }
 	}
 }
 

--- a/ManiVault/src/Application.cpp
+++ b/ManiVault/src/Application.cpp
@@ -81,7 +81,7 @@ Application::Application(int& argc, char** argv) :
 
         _configurationAction.getStartPageConfigurationAction().getToggleCustomizationAction().setChecked(true);
 
-        if(QOperatingSystemVersion::currentType() == QOperatingSystemVersion::MacOS)
+        if constexpr (QOperatingSystemVersion::currentType() == QOperatingSystemVersion::MacOS)
         {
             Application::setWindowIcon(QIcon(":/Icons/AppIcon.icns"));
         } else {

--- a/ManiVault/src/actions/ApplicationIconAction.cpp
+++ b/ManiVault/src/actions/ApplicationIconAction.cpp
@@ -98,7 +98,7 @@ void ApplicationIconAction::overrideMainWindowIcon() const
 
 void ApplicationIconAction::resetApplicationIcon()
 {
-    if(QOperatingSystemVersion::currentType() == QOperatingSystemVersion::MacOS)
+    if constexpr (QOperatingSystemVersion::currentType() == QOperatingSystemVersion::MacOS)
     {
         Application::getMainWindow()->setWindowIcon(QIcon(":/Icons/AppIcon.icns"));
     } else {

--- a/ManiVault/src/actions/ApplicationIconAction.cpp
+++ b/ManiVault/src/actions/ApplicationIconAction.cpp
@@ -5,6 +5,7 @@
 #include "ApplicationIconAction.h"
 
 #include <QMainWindow>
+#include <QOperatingSystemVersion>
 
 #include "Application.h"
 #include "util/Icon.h"
@@ -97,7 +98,12 @@ void ApplicationIconAction::overrideMainWindowIcon() const
 
 void ApplicationIconAction::resetApplicationIcon()
 {
-    Application::getMainWindow()->setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
+    if(QOperatingSystemVersion::currentType() == QOperatingSystemVersion::MacOS)
+    {
+        Application::getMainWindow()->setWindowIcon(QIcon(":/Icons/AppIcon.icns"));
+    } else {
+        Application::getMainWindow()->setWindowIcon(createIcon(QPixmap(":/Icons/AppIcon256")));
+    }
 }
 
 void ApplicationIconAction::fromVariantMap(const QVariantMap& variantMap)


### PR DESCRIPTION
This addresses #1143 by changing two calls that set the default app icon to use the existing .icns file, instead of a single resolution png.

It does not address custom icons. It might be good to allow for other resources than images to create those later one. However, at least for macOS there is also a new icon format from macOS 26 on, so it would probably be best to combine addition of the new icon format with deeper integrations like custom icons in a later update.