### PR TITLE
Add missing Qt headers

### DIFF
--- a/ManiVault/src/actions/GroupAction.cpp
+++ b/ManiVault/src/actions/GroupAction.cpp
@@ -9,6 +9,7 @@
 
 #include <QDebug>
 #include <QHBoxLayout>
+#include <QUuid>
 
 #ifdef _DEBUG
     //#define GROUP_ACTION_VERBOSE

--- a/ManiVault/src/util/Version.cpp
+++ b/ManiVault/src/util/Version.cpp
@@ -4,6 +4,8 @@
 
 #include "Version.h"
 
+#include <QRegularExpression>
+
 namespace mv::util {
 
 const QString Version::semanticVersioningRegex = QString(R"((0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-([\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*))?(?:\+([\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*))?)");


### PR DESCRIPTION
Newer compilers like current AppleClang err without the inclusion when compiling with newer Qt versions like 6.11