### PR TITLE
 Use different symbol resolution backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(MV_USE_ERROR_LOGGING "Use error logging with Sentry" OFF)
 option(MV_PRECOMPILE_HEADERS "Precompile several headers for faster compilation" ON)
 option(MV_UNITY_BUILD "Combine target source files into batches for faster compilation" OFF)
 option(MV_WARNINGS_AS_ERRORS "Treat warnings as errors when using MSVC" ON)
+option(MV_ENABLE_CPPTRACE "Enable cpptrace stack traces" ON)
 
 # defines MV_VERSION
 include(ManiVault/cmake/Utils.cmake)

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -277,8 +277,6 @@ if(${MV_USE_ERROR_LOGGING})
 
 endif()
 
-option(MV_ENABLE_CPPTRACE "Enable cpptrace stack traces" ON)
-
 if(MV_ENABLE_CPPTRACE)
 
     set(CPPTRACE_OPTIONS

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -286,7 +286,7 @@ if(MV_ENABLE_CPPTRACE)
     )
 
     # do not use the default backend libdwarf
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(UNIX)
         list(APPEND CPPTRACE_OPTIONS "CPPTRACE_GET_SYMBOLS_WITH_LIBBACKTRACE ON")
     endif()
 

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -280,13 +280,23 @@ endif()
 option(MV_ENABLE_CPPTRACE "Enable cpptrace stack traces" ON)
 
 if(MV_ENABLE_CPPTRACE)
+
+    set(CPPTRACE_OPTIONS
+        "CPPTRACE_BUILD_BENCHMARKING OFF"
+        "CPPTRACE_BUILD_TOOLS OFF"
+        "CPPTRACE_PROVIDE_EXPORT_SET OFF"
+    )
+
+    # do not use the default backend libdwarf
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        list(APPEND CPPTRACE_OPTIONS "CPPTRACE_GET_SYMBOLS_WITH_LIBBACKTRACE ON")
+    endif()
+
     CPMAddPackage(
         NAME cpptrace
         GITHUB_REPOSITORY jeremy-rifkin/cpptrace
         GIT_TAG v1.0.4
-        OPTIONS
-            "CPPTRACE_BUILD_TESTING OFF"
-            "CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF OFF"
+        OPTIONS ${CPPTRACE_OPTIONS}
     )
 endif()
 

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -286,8 +286,10 @@ if(MV_ENABLE_CPPTRACE)
     )
 
     # do not use the default backend libdwarf
-    if(UNIX)
+    if(UNIX AND NOT APPLE)
         list(APPEND CPPTRACE_OPTIONS "CPPTRACE_GET_SYMBOLS_WITH_LIBBACKTRACE ON")
+    elseif(APPLE)
+        list(APPEND CPPTRACE_OPTIONS "CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE ON")
     endif()
 
     CPMAddPackage(


### PR DESCRIPTION
- Use [libbacktrace](https://github.com/gcc-mirror/gcc/blob/master/libbacktrace/README) on linux
- Use [atos](https://manp.gs/mac/1/atos) on mac

See https://github.com/jeremy-rifkin/cpptrace#library-back-ends for more info on backends for cpptrace