### PR TITLE
Improve theme switching robustness

### DIFF
--- a/ManiVault/src/actions/WidgetActionLabel.cpp
+++ b/ManiVault/src/actions/WidgetActionLabel.cpp
@@ -28,6 +28,7 @@ WidgetActionLabel::WidgetActionLabel(WidgetAction* action, QWidget* parent /*= n
 
     connect(getAction(), &WidgetAction::isConnectedChanged, this, &WidgetActionLabel::updateNameLabel);
     connect(getAction(), &WidgetAction::connectionPermissionsChanged, this, &WidgetActionLabel::updateNameLabel);
+    connect(&mv::theme(), &AbstractThemeManager::colorSchemeChanged, this, &WidgetActionLabel::updateCustomStyle);
 
     auto layout = new QHBoxLayout();
 
@@ -162,6 +163,14 @@ bool WidgetActionLabel::eventFilter(QObject* target, QEvent* event)
     return QWidget::eventFilter(target, event);
 }
 
+bool WidgetActionLabel::event(QEvent* event)
+{
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        updateCustomStyle();
+
+    return WidgetActionViewWidget::event(event);
+}
+
 void WidgetActionLabel::resizeEvent(QResizeEvent* resizeEvent)
 {
     QWidget::resizeEvent(resizeEvent);
@@ -237,7 +246,7 @@ void WidgetActionLabel::updateCustomStyle()
         else
             _nameLabel.setStyleSheet(QString("QLabel { color: %1; }").arg(qApp->palette().text().color().name()));
     } else {
-        _nameLabel.setStyleSheet("color: gray;");
+        _nameLabel.setStyleSheet(QString("QLabel { color: %1; }").arg(qApp->palette().color(QPalette::Disabled, QPalette::Text).name()));
     }
 }
 

--- a/ManiVault/src/actions/WidgetActionLabel.h
+++ b/ManiVault/src/actions/WidgetActionLabel.h
@@ -61,6 +61,13 @@ public:
     bool eventFilter(QObject* target, QEvent* event) override;
 
     /**
+     * Respond to widget events
+     * @param event The event that took place
+     * @return Boolean indicating whether the event was handled
+     */
+    bool event(QEvent* event) override;
+
+    /**
      * Invoked when the widget is resized
      * @param resizeEvent Pointer to the resize event
      */

--- a/ManiVault/src/models/ColorSchemesListModel.cpp
+++ b/ManiVault/src/models/ColorSchemesListModel.cpp
@@ -63,9 +63,9 @@ void ColorSchemesListModel::addBuiltInColorSchemes()
         addColorScheme(ColorScheme(ColorScheme::Mode::BuiltIn, name, description, palette));
     };
 
-    addBuiltInCustomColorScheme("Dark", "Dark color scheme", QColor(45, 45, 45), Qt::white, QColor(30, 30, 30), QColor(45, 45, 45), Qt::white, Qt::white, Qt::white, QColor(60, 60, 60), Qt::white, Qt::red);
+    addBuiltInCustomColorScheme("Dark", "Dark color scheme", QColor(45, 45, 45), Qt::white, QColor(30, 30, 30), QColor(45, 45, 45), QColor(45, 45, 45), Qt::white, Qt::white, QColor(60, 60, 60), Qt::white, Qt::red);
     addBuiltInCustomColorScheme("Light", "Light color scheme", Qt::white, Qt::black, Qt::white, QColor(240, 240, 240), Qt::white, Qt::black, Qt::black, QColor(220, 220, 220), Qt::black, Qt::red);
-    addBuiltInCustomColorScheme("Fusion (dark)", "Fusion dark color scheme", QColor(45, 45, 45), Qt::white, QColor(30, 30, 30), QColor(45, 45, 45), Qt::white, Qt::white, Qt::white, QColor(60, 60, 60), Qt::white, Qt::red);
+    addBuiltInCustomColorScheme("Fusion (dark)", "Fusion dark color scheme", QColor(45, 45, 45), Qt::white, QColor(30, 30, 30), QColor(45, 45, 45), QColor(45, 45, 45), Qt::white, Qt::white, QColor(60, 60, 60), Qt::white, Qt::red);
     addBuiltInCustomColorScheme("Fusion (light)", "Fusion light color scheme", Qt::white, Qt::black, Qt::white, QColor(240, 240, 240), Qt::white, Qt::black, Qt::black, QColor(220, 220, 220), Qt::black, Qt::red);
     addBuiltInCustomColorScheme("Google Material Design (dark)", "Google material design dark color scheme", QColor(33, 33, 33), QColor(220, 220, 220), QColor(50, 50, 50), QColor(40, 40, 40), QColor(50, 50, 50), QColor(220, 220, 220), QColor(220, 220, 220), QColor(50, 50, 50), QColor(220, 220, 220), QColor(220, 220, 220));
     addBuiltInCustomColorScheme("Google Material Design (light)", "Google material design light color scheme", QColor(245, 245, 245), QColor(0, 0, 0), QColor(255, 255, 255), QColor(240, 240, 240), QColor(255, 255, 255), QColor(0, 0, 0), QColor(0, 0, 0), QColor(230, 230, 230), QColor(0, 0, 0), QColor(0, 0, 0));

--- a/ManiVault/src/private/PageActionDelegateEditorWidget.cpp
+++ b/ManiVault/src/private/PageActionDelegateEditorWidget.cpp
@@ -83,7 +83,7 @@ PageActionDelegateEditorWidget::PageActionDelegateEditorWidget(QWidget* parent /
 
     updateOverlayWidgetVisibility();
 
-    connect(&mv::theme(), &AbstractThemeManager::colorSchemeChanged, this, &PageActionDelegateEditorWidget::updateCustomStyle);
+    connect(&mv::theme(), &AbstractThemeManager::colorSchemeChanged, this, &PageActionDelegateEditorWidget::updateIcon);
 }
 
 void PageActionDelegateEditorWidget::setEditorData(const QModelIndex& index)
@@ -140,6 +140,9 @@ void PageActionDelegateEditorWidget::leaveEvent(QEvent* event)
 
 void PageActionDelegateEditorWidget::updateIcon()
 {
+    if (!_pageAction)
+        return;
+
     _iconLabel.setPixmap(_pageAction->getIcon().pixmap(PageAction::isCompactView() ? QSize(14, 14) : QSize(24, 24)));
 
     updateCustomStyle();

--- a/ManiVault/src/private/SettingsManagerDialog.cpp
+++ b/ManiVault/src/private/SettingsManagerDialog.cpp
@@ -7,6 +7,7 @@
 #include <CoreInterface.h>
 #include <QOperatingSystemVersion>
 #include <QVBoxLayout>
+#include <QStyle>
 
 using namespace mv;
 using namespace mv::util;
@@ -47,11 +48,30 @@ SettingsManagerDialog::SettingsManagerDialog(QWidget* parent /*= nullptr*/) :
         if (auto pluginGlobalSettingsGroupAction = pluginFactory->getGlobalSettingsGroupAction())
             _groupsAction.addGroupAction(pluginGlobalSettingsGroupAction);
     }
+
+    connect(&mv::theme(), &AbstractThemeManager::colorSchemeChanged, this, &SettingsManagerDialog::updateCustomStyle);
 }
 
 QSize SettingsManagerDialog::sizeHint() const
 {
     return { 400, 500 };
+}
+
+void SettingsManagerDialog::updateCustomStyle()
+{
+    const auto widgets = findChildren<QWidget*>();
+
+    setWindowIcon(StyledIcon("gears"));
+
+    style()->unpolish(this);
+    style()->polish(this);
+    update();
+
+    for (auto widget : widgets) {
+        widget->style()->unpolish(widget);
+        widget->style()->polish(widget);
+        widget->update();
+    }
 }
 
 }

--- a/ManiVault/src/private/SettingsManagerDialog.h
+++ b/ManiVault/src/private/SettingsManagerDialog.h
@@ -37,6 +37,11 @@ public:
     }
 
 private:
+
+    /** Update styling after a theme change */
+    void updateCustomStyle();
+
+private:
     GroupsAction    _groupsAction;      /** Groups action for all global settings sections */
 };
 

--- a/ManiVault/src/private/StartPageOpenProjectWidget.cpp
+++ b/ManiVault/src/private/StartPageOpenProjectWidget.cpp
@@ -80,6 +80,8 @@ StartPageOpenProjectWidget::StartPageOpenProjectWidget(StartPageContentWidget* s
 
     createCustomIcons();
 
+    connect(&mv::theme(), &AbstractThemeManager::colorSchemeChanged, this, &StartPageOpenProjectWidget::updateCustomStyle);
+
     auto& startPageConfigurationAction = Application::current()->getConfigurationAction().getStartPageConfigurationAction();
 
     const auto toggleViews = [this, &startPageConfigurationAction]() -> void {

--- a/ManiVault/src/private/ThemeManager.cpp
+++ b/ManiVault/src/private/ThemeManager.cpp
@@ -14,6 +14,7 @@
 
 #include <QStyleHints>
 #include <QGuiApplication>
+#include <QPixmapCache>
 
 using namespace mv::gui;
 using namespace mv::util;
@@ -30,10 +31,11 @@ ThemeManager::ThemeSettings::ThemeSettings(QObject* parent):
     _colorScheme(Qt::ColorScheme::Unknown)
 {
     _updateThemeTimer.setSingleShot(true);
-    _updateThemeTimer.setInterval(1000);
-    _updateThemeTimer.start();
+    _updateThemeTimer.setInterval(0);
 
     connect(&_updateThemeTimer, &QTimer::timeout, this, &ThemeSettings::updateTheme);
+
+    _updateThemeTimer.start();
 }
 
 void ThemeManager::ThemeSettings::setColorSchemeMode(const ColorSchemeMode& colorSchemeMode)
@@ -74,7 +76,7 @@ void ThemeManager::ThemeSettings::updateTheme()
         {
 #if defined(Q_OS_WIN) || defined(Q_OS_LINUX)
             qApp->styleHints()->setColorScheme(_colorScheme);
-            qApp->setPalette(QApplication::style()->standardPalette());
+            qApp->setPalette(ThemeManager::getSystemColorSchemePalette(_colorScheme));
 #endif
 
 #ifdef Q_OS_MACOS
@@ -87,7 +89,7 @@ void ThemeManager::ThemeSettings::updateTheme()
         {
 #if defined(Q_OS_WIN) || defined(Q_OS_LINUX)
             qApp->styleHints()->setColorScheme(_colorScheme);
-            qApp->setPalette(QApplication::style()->standardPalette());
+            qApp->setPalette(ThemeManager::getSystemColorSchemePalette(_colorScheme));
 #endif
 
 #ifdef Q_OS_MACOS
@@ -112,12 +114,15 @@ void ThemeManager::ThemeSettings::updateTheme()
         case ColorSchemeMode::Custom:
         {
 #if defined(Q_OS_WIN) || defined(Q_OS_LINUX)
+            qApp->styleHints()->setColorScheme(ThemeManager::getPaletteColorScheme(_palette));
             qApp->setPalette(_palette);
             mv::help().addNotification("Theme update", QString("Custom <b>%1</b> theme has been activated.").arg(_paletteName), util::StyledIcon("palette"));
 #endif
             break;
         }
     }
+
+    QPixmapCache::clear();
 
     AbstractThemeManager::restyleAllWidgets();
     deleteLater();
@@ -404,10 +409,11 @@ void ThemeManager::addCustomColorScheme(const CustomColorSchemeMode& mode, const
 
 ThemeManager::ThemeSettings* ThemeManager::getRequestThemeSettings()
 {
-    if (_requestThemeSettings.isNull())
-        _requestThemeSettings = new ThemeSettings();
+    if (_requestThemeSettings.isNull()) {
+        _requestThemeSettings = new ThemeSettings(this);
 
-    connect(_requestThemeSettings, &QObject::destroyed, this, &AbstractThemeManager::colorSchemeChanged);
+        connect(_requestThemeSettings, &QObject::destroyed, this, &AbstractThemeManager::colorSchemeChanged);
+    }
 
     return _requestThemeSettings;
 }
@@ -451,14 +457,63 @@ Qt::ColorScheme ThemeManager::getCurrentSystemColorScheme()
 #endif
 }
 
+Qt::ColorScheme ThemeManager::getPaletteColorScheme(const QPalette& palette)
+{
+    return palette.color(QPalette::Window).lightness() < palette.color(QPalette::WindowText).lightness() ? Qt::ColorScheme::Dark : Qt::ColorScheme::Light;
+}
+
+QPalette ThemeManager::getSystemColorSchemePalette(const Qt::ColorScheme& colorScheme)
+{
+    if (colorScheme != Qt::ColorScheme::Dark)
+        return QApplication::style()->standardPalette();
+
+    auto palette = QApplication::style()->standardPalette();
+
+    palette.setColor(QPalette::Window, QColor(45, 45, 45));
+    palette.setColor(QPalette::WindowText, Qt::white);
+    palette.setColor(QPalette::Base, QColor(30, 30, 30));
+    palette.setColor(QPalette::AlternateBase, QColor(45, 45, 45));
+    palette.setColor(QPalette::ToolTipBase, QColor(45, 45, 45));
+    palette.setColor(QPalette::ToolTipText, Qt::white);
+    palette.setColor(QPalette::Text, Qt::white);
+    palette.setColor(QPalette::Button, QColor(60, 60, 60));
+    palette.setColor(QPalette::ButtonText, Qt::white);
+    palette.setColor(QPalette::BrightText, Qt::red);
+    palette.setColor(QPalette::Light, QColor(75, 75, 75));
+    palette.setColor(QPalette::Midlight, QColor(60, 60, 60));
+    palette.setColor(QPalette::Dark, QColor(35, 35, 35));
+    palette.setColor(QPalette::Mid, QColor(45, 45, 45));
+    palette.setColor(QPalette::Shadow, QColor(20, 20, 20));
+    palette.setColor(QPalette::Highlight, QColor(42, 130, 218));
+    palette.setColor(QPalette::HighlightedText, Qt::white);
+    palette.setColor(QPalette::Link, QColor(42, 130, 218));
+    palette.setColor(QPalette::LinkVisited, QColor(170, 130, 218));
+    palette.setColor(QPalette::PlaceholderText, QColor(160, 160, 160));
+
+    palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(130, 130, 130));
+    palette.setColor(QPalette::Disabled, QPalette::Text, QColor(130, 130, 130));
+    palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(130, 130, 130));
+    palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(130, 130, 130));
+    palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
+    palette.setColor(QPalette::Disabled, QPalette::Base, QColor(35, 35, 35));
+    palette.setColor(QPalette::Disabled, QPalette::Button, QColor(45, 45, 45));
+
+    return palette;
+}
+
 void ThemeManager::privateActivateSystemColorScheme()
 {
 #ifdef THEME_MANAGER_VERBOSE
     qDebug() << __FUNCTION__;
 #endif
 
+    const auto currentSystemColorScheme = getCurrentSystemColorScheme();
+
+    _systemColorScheme      = currentSystemColorScheme;
+    _applicationColorScheme = currentSystemColorScheme;
+
     getRequestThemeSettings()->setColorSchemeMode(ColorSchemeMode::System);
-    getRequestThemeSettings()->setColorScheme(getCurrentSystemColorScheme());
+    getRequestThemeSettings()->setColorScheme(currentSystemColorScheme);
 }
 
 void ThemeManager::privateActivateSystemColorSchemeLightDark()
@@ -466,6 +521,8 @@ void ThemeManager::privateActivateSystemColorSchemeLightDark()
 #ifdef THEME_MANAGER_VERBOSE
     qDebug() << __FUNCTION__;
 #endif
+
+    normalizeSystemLightDarkColorSchemeActions();
 
     if (_systemDarkColorSchemeAction.isChecked())
         privateActivateDarkSystemColorScheme();
@@ -481,6 +538,8 @@ void ThemeManager::privateActivateLightSystemColorScheme()
 #endif
 
     if (isSystemColorSchemeModeActive() || isSystemLightDarkColorSchemeModeActive()) {
+        _applicationColorScheme = Qt::ColorScheme::Light;
+
         getRequestThemeSettings()->setColorSchemeMode(ColorSchemeMode::SystemLightDark);
         getRequestThemeSettings()->setColorScheme(Qt::ColorScheme::Light);
     }
@@ -493,6 +552,8 @@ void ThemeManager::privateActivateDarkSystemColorScheme()
 #endif
 
     if (isSystemColorSchemeModeActive() || isSystemLightDarkColorSchemeModeActive()) {
+        _applicationColorScheme = Qt::ColorScheme::Dark;
+
         getRequestThemeSettings()->setColorSchemeMode(ColorSchemeMode::SystemLightDark);
         getRequestThemeSettings()->setColorScheme(Qt::ColorScheme::Dark);
     }
@@ -507,10 +568,33 @@ void ThemeManager::privateActivateCustomColorScheme()
     const auto currentCustomColorSchemeName = _colorSchemeAction.getCurrentColorSchemeAction().getCurrentText();
     const auto customColorSchemes           = getCustomColorSchemes();
 
-    if (isCustomColorSchemeModeActive() && customColorSchemes.keys().contains(currentCustomColorSchemeName)) {
+    if (isCustomColorSchemeModeActive() && customColorSchemes.contains(currentCustomColorSchemeName)) {
+        const auto palette = customColorSchemes.value(currentCustomColorSchemeName).getPalette();
+
+        _applicationColorScheme = getPaletteColorScheme(palette);
+
         getRequestThemeSettings()->setColorSchemeMode(ColorSchemeMode::Custom);
-        getRequestThemeSettings()->setPalette(customColorSchemes[currentCustomColorSchemeName].getPalette(), currentCustomColorSchemeName);
+        getRequestThemeSettings()->setPalette(palette, currentCustomColorSchemeName);
     }
+}
+
+void ThemeManager::normalizeSystemLightDarkColorSchemeActions()
+{
+    const auto lightChecked = _systemLightColorSchemeAction.isChecked();
+    const auto darkChecked  = _systemDarkColorSchemeAction.isChecked();
+
+    if (lightChecked != darkChecked)
+        return;
+
+    auto colorScheme = _applicationColorScheme;
+
+    if (colorScheme == Qt::ColorScheme::Unknown)
+        colorScheme = getCurrentSystemColorScheme();
+
+    const auto useLightColorScheme = colorScheme == Qt::ColorScheme::Light;
+
+    setSystemLightColorSchemeActionCheckedSilent(useLightColorScheme);
+    setSystemDarkColorSchemeActionCheckedSilent(!useLightColorScheme);
 }
 
 void ThemeManager::setSystemLightColorSchemeActionCheckedSilent(bool checked)

--- a/ManiVault/src/private/ThemeManager.h
+++ b/ManiVault/src/private/ThemeManager.h
@@ -187,6 +187,9 @@ private:
      */
     void privateActivateCustomColorScheme() ;
 
+    /** Ensure exactly one light/dark system color scheme action is checked */
+    void normalizeSystemLightDarkColorSchemeActions();
+
     /**
      * Set the system light color scheme action to \p checked without emitting signals
      * @param checked Checked state
@@ -211,6 +214,20 @@ private:
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     static Qt::ColorScheme getCurrentSystemColorScheme();
 #endif
+
+    /**
+     * Get the color scheme that best matches \p palette
+     * @param palette Palette to classify
+     * @return Matching light/dark color scheme
+     */
+    static Qt::ColorScheme getPaletteColorScheme(const QPalette& palette);
+
+    /**
+     * Get an application palette for \p colorScheme
+     * @param colorScheme Requested color scheme
+     * @return Palette matching the requested color scheme
+     */
+    static QPalette getSystemColorSchemePalette(const Qt::ColorScheme& colorScheme);
 
 protected: // Action getters
 


### PR DESCRIPTION
- Use proper palette-based dark mode colors instead of style()->standardPalette() for system dark scheme
- Add QPalette::Disabled colors for correct disabled widget appearance
- Fix WidgetActionLabel disabled text color to use palette instead of hardcoded 'gray'
- React to ApplicationPaletteChange events in WidgetActionLabel
- Clear QPixmapCache on theme change to force icon refresh
- Add normalizeSystemLightDarkColorSchemeActions() to prevent both light/dark being checked simultaneously
- Fix SettingsManagerDialog to restyle on theme change
- Connect StartPageOpenProjectWidget to colorSchemeChanged
- Fix ThemeSettings parent ownership and connection placement
- Set colorSchemeHint when applying custom palettes