### PR TITLE
Restore action load order before plugin state restoration

### DIFF
--- a/ManiVault/src/Project.cpp
+++ b/ManiVault/src/Project.cpp
@@ -154,10 +154,10 @@ UniqueWorkflowPlan Project::fromVariantMapWorkflow(QVariantMap variantMap)
     };
 
     addManagerLoadStage(mv::dataHierarchy(), 100.0);
-    addManagerLoadStage(mv::plugins(), 1.0);
-	addManagerLoadStage(mv::events(), 1.0);
     addManagerLoadStage(mv::actions(), 1.0);
-
+	addManagerLoadStage(mv::plugins(), 1.0);
+	addManagerLoadStage(mv::events(), 1.0);
+    
     plan->addSequentialStage("Post-process", [this](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext&) {
         if (getReadOnlyAction().isChecked() && getAllowedPluginsOnlyAction().isChecked()) {
 			for (auto pluginFactory : mv::plugins().getPluginFactoriesByTypes())


### PR DESCRIPTION
## Summary

Restores the project loading order so public actions are loaded before plugin/view state is restored.

PR #1229 changed project loading to workflow-based stages and moved `actions()` after `plugins()`. That changed when `PublicActionID` references could be resolved during plugin/view action deserialization.

## Why

Dimension picker actions may connect to public actions during `WidgetAction::fromVariantMap()`. If this happens at a different point in project loading, their nested option actions can expose public options in sorted order rather than dataset dimension order.

## Fix

Load managers in the previous effective order:

1. data hierarchy
2. actions
3. plugins
4. events

## Notes

The existing `OptionAction` public option sorting behavior predates PR #1229, so this PR fixes the ordering regression instead of changing option sorting semantics globally.