### PR TITLE
Update Qt to 6.9.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Windows build
         if: startsWith(runner.os, 'Windows')
-        uses: ManiVaultStudio/github-actions/conan_windows_build@main
+        uses: ManiVaultStudio/github-actions/conan_windows_build@feature/UpdateQt693
         with:
           conan-visual-version: ${{matrix.build-cversion}}
           conan-visual-runtime: ${{matrix.build-runtime}}
@@ -90,7 +90,7 @@ jobs:
 
       - name: Linux build
         if: startsWith(matrix.os, 'ubuntu')
-        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@main
+        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@feature/UpdateQt693
         with:
           conan-compiler: ${{matrix.build-compiler}}
           conan-cc: ${{matrix.build-cc}}
@@ -106,7 +106,7 @@ jobs:
           
       - name: Mac build
         if: startsWith(matrix.os, 'macos')
-        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@main
+        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@feature/UpdateQt693
         with:
           conan-compiler: ${{matrix.build-compiler}}
           conan-cc: ${{matrix.build-cc}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - name: Get matrix from file
       id: matrix_setup
-      uses: ManiVaultStudio/github-actions/matrix_setup@feature/UpdateQt693
+      uses: ManiVaultStudio/github-actions/matrix_setup@main
 
   cross-platform-build:
     name: Cross platform build
@@ -73,7 +73,7 @@ jobs:
 
       - name: Windows build
         if: startsWith(runner.os, 'Windows')
-        uses: ManiVaultStudio/github-actions/conan_windows_build@feature/UpdateQt693
+        uses: ManiVaultStudio/github-actions/conan_windows_build@main
         with:
           conan-visual-version: ${{matrix.build-cversion}}
           conan-visual-runtime: ${{matrix.build-runtime}}
@@ -90,7 +90,7 @@ jobs:
 
       - name: Linux build
         if: startsWith(matrix.os, 'ubuntu')
-        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@feature/UpdateQt693
+        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@main
         with:
           conan-compiler: ${{matrix.build-compiler}}
           conan-cc: ${{matrix.build-cc}}
@@ -106,7 +106,7 @@ jobs:
           
       - name: Mac build
         if: startsWith(matrix.os, 'macos')
-        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@feature/UpdateQt693
+        uses: ManiVaultStudio/github-actions/conan_linuxmac_build@main
         with:
           conan-compiler: ${{matrix.build-compiler}}
           conan-cc: ${{matrix.build-cc}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,20 +11,16 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-
 # Get centrally defined build matrix
 jobs:
   prepare_matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.matrix_setup.outputs.matrix }}
     steps:
     - name: Get matrix from file
       id: matrix_setup
-      uses: ManiVaultStudio/github-actions/matrix_setup@main
+      uses: ManiVaultStudio/github-actions/matrix_setup@feature/UpdateQt693
 
   cross-platform-build:
     name: Cross platform build
@@ -41,14 +37,14 @@ jobs:
     steps:
       - name: Checkout the source
         if: ${{ github.event_name != 'pull_request'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Checkout the source (pull_request version)
         if: ${{ github.event_name == 'pull_request'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           submodules: recursive
@@ -60,12 +56,12 @@ jobs:
           sudo xcode-select -switch /Applications/Xcode_${{matrix.build-xcode-version}}.app
           
       - name: Setup python version
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Start ssh key agent
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.RULESSUPPORT_DEPLOY_KEY }}
 

--- a/ManiVault/src/actions/ColorMapAction.cpp
+++ b/ManiVault/src/actions/ColorMapAction.cpp
@@ -233,10 +233,15 @@ QImage ColorMapAction::getColorMapImage() const
     if (getCustomColorMapAction().isChecked())
         colorMapImage = getEditor1DAction().getColorMapImage();
 
-    const auto mirrorHorizontally   = getMirrorAction(Axis::X).isChecked();
-    const auto mirrorVertically     = getMirrorAction(Axis::Y).isChecked();
+    Qt::Orientations orientations;
 
-    colorMapImage = colorMapImage.mirrored(mirrorHorizontally, mirrorVertically);
+    if (getMirrorAction(Axis::X).isChecked())
+        orientations |= Qt::Horizontal;
+
+    if (getMirrorAction(Axis::Y).isChecked())
+        orientations |= Qt::Vertical;
+
+    colorMapImage = colorMapImage.flipped(orientations);
 
     if (getDiscretizeAction().isChecked()) {
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -51,7 +51,7 @@ class HdpsCoreConan(ConanFile):
     install_dir = None
     this_dir = os.path.dirname(os.path.realpath(__file__))
 
-    requires = ("qt/6.8.3@lkeb/stable")
+    requires = ("qt/6.9.3@lkeb/stable")
 
     scm = {"type": "git", "subfolder": "hdps/core", "url": "auto", "revision": "auto"}
 


### PR DESCRIPTION
- Build with [Qt 6.9.3](https://doc.qt.io/qt-6/whatsnew69.html), [release overview](https://wiki.qt.io/Qt_6.9_Release)
  - Requires CMake version 3.22 or later, which we've already updated to in our last Qt update
- [`QImage::mirrored`](https://doc.qt.io/qt-6/qimage.html#mirrored) is deprecated since as of Qt 6.9, use `flipped` instead

This PR depends on https://github.com/ManiVaultStudio/github-actions/pull/12. ~~After that one is merged we'll need to change the `feature/UpdateQt693` mentions in `.github/workflows/build.yml` back to `main`.~~ (Done)

Thanks to @bldrvnlw the mac build setup is now much faster! Closes https://github.com/ManiVaultStudio/core/issues/1223 since the Qt 6.9.3 artifactory package is now ARM only.
 