### PR TITLE
Update Qt to 6.10.3

### DIFF
--- a/ManiVault/src/actions/OptionAction.cpp
+++ b/ManiVault/src/actions/OptionAction.cpp
@@ -643,7 +643,8 @@ void OptionAction::StringsFilterModel::setTextFilter(const QString& textFilter)
 
     _textFilter = textFilter;
 
-    invalidateFilter(); // Reapply the filter
+    beginFilterChange();
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
 }
 
 OptionAction::LazyIndicesModel::LazyIndicesModel(QObject* parent): QAbstractListModel(parent)

--- a/ManiVault/src/models/ColorSchemesFilterModel.cpp
+++ b/ManiVault/src/models/ColorSchemesFilterModel.cpp
@@ -21,7 +21,7 @@ ColorSchemesFilterModel::ColorSchemesFilterModel(QObject* parent /*= nullptr*/) 
 {
     setRecursiveFilteringEnabled(true);
 
-    connect(&_modeFilterAction, &gui::OptionsAction::selectedOptionsChanged, this, &ColorSchemesFilterModel::invalidateFilter);
+    connect(&_modeFilterAction, &gui::OptionsAction::selectedOptionsChanged, this, &ColorSchemesFilterModel::invalidateModeFilter);
 }
 
 bool ColorSchemesFilterModel::filterAcceptsRow(int row, const QModelIndex& parent) const
@@ -40,6 +40,11 @@ bool ColorSchemesFilterModel::filterAcceptsRow(int row, const QModelIndex& paren
     }
 
     return SortFilterProxyModel::filterAcceptsRow(row, parent);
+}
+
+void ColorSchemesFilterModel::invalidateModeFilter() {
+    beginFilterChange();
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
 }
 
 }

--- a/ManiVault/src/models/ColorSchemesFilterModel.h
+++ b/ManiVault/src/models/ColorSchemesFilterModel.h
@@ -41,6 +41,10 @@ public: // Action getters
     gui::OptionsAction& getModeFilterAction() { return _modeFilterAction; }
 
 private:
+    /** Invalidates the row filtering after the mode filter action changes */
+    void invalidateModeFilter();
+
+  private:
     gui::OptionsAction  _modeFilterAction;  /** Filter action for the color scheme mode */
 };
 

--- a/ManiVault/src/models/WorkflowMessagesFilterModel.cpp
+++ b/ManiVault/src/models/WorkflowMessagesFilterModel.cpp
@@ -26,7 +26,7 @@ namespace mv {
         getSeverityLevelName(SeverityLevel::Fatal)
     })
 {
-    connect(&_filterLevelAction, &gui::OptionsAction::selectedOptionsChanged, this, &WorkflowMessagesFilterModel::invalidateFilter);
+  connect(&_filterLevelAction, &gui::OptionsAction::selectedOptionsChanged, this, &WorkflowMessagesFilterModel::invalidateModeFilter);
 
     _filterLevelAction.setStretch(2);
 }
@@ -120,6 +120,11 @@ bool WorkflowMessagesFilterModel::lessThan(const QModelIndex& lhs, const QModelI
 	}
 
 	return SortFilterProxyModel::lessThan(lhs, rhs);
+}
+
+void WorkflowMessagesFilterModel::invalidateModeFilter() {
+  beginFilterChange();
+  endFilterChange(QSortFilterProxyModel::Direction::Rows);
 }
 
 }

--- a/ManiVault/src/models/WorkflowMessagesFilterModel.h
+++ b/ManiVault/src/models/WorkflowMessagesFilterModel.h
@@ -47,6 +47,10 @@ public: // Action getters
     gui::OptionsAction& getFilterLevelAction() { return _filterLevelAction; }
 
 private:
+  /** Invalidates the row filtering after the mode filter action changes */
+  void invalidateModeFilter();
+
+private:
     gui::OptionsAction  _filterLevelAction;    /** Options action for filtering based on message level */
 };
 

--- a/ManiVault/src/plugins/ClusterData/src/ClustersFilterModel.cpp
+++ b/ManiVault/src/plugins/ClusterData/src/ClustersFilterModel.cpp
@@ -62,5 +62,6 @@ void ClustersFilterModel::setNameFilter(const QString& nameFilter)
 
     _nameFilter = nameFilter;
 
-	invalidateFilter();
+    beginFilterChange();
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
 }

--- a/ManiVault/src/util/ColorMapFilterModel.cpp
+++ b/ManiVault/src/util/ColorMapFilterModel.cpp
@@ -33,7 +33,8 @@ void ColorMapFilterModel::setType(const ColorMap::Type& type)
 
     _type = type;
 
-    invalidateFilter();
+    beginFilterChange();
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
 }
 
 }

--- a/conanfile.py
+++ b/conanfile.py
@@ -51,7 +51,7 @@ class HdpsCoreConan(ConanFile):
     install_dir = None
     this_dir = os.path.dirname(os.path.realpath(__file__))
 
-    requires = ("qt/6.9.3@lkeb/stable")
+    requires = ("qt/6.10.3@lkeb/stable")
 
     scm = {"type": "git", "subfolder": "hdps/core", "url": "auto", "revision": "auto"}
 


### PR DESCRIPTION
- Build with [Qt 6.10.3](https://doc.qt.io/qt-6/whatsnew610.html), [release overview](https://wiki.qt.io/Qt_6.10_Release)
  - First Qt release to know about [macOS 26](https://doc.qt.io/qt-6/qoperatingsystemversion.html#MacOSTahoe-var)
- [`QSortFilterProxyModel::invalidateColumnsFilter`](https://doc.qt.io/qt-6/qsortfilterproxymodel.html#invalidateColumnsFilter) is deprecated since as of Qt 6.10 (this is not mentioned in the docs, but our treat-warnings-as-errors setting is triggered anyways)

~~After https://github.com/ManiVaultStudio/core/pull/1276 is merged, this PR should be rebased on master before merging.~~ (Done)

I tried to create this as a [stacked PR](https://github.github.com/gh-stack/guides/ui/) but the GitHub UI did not provide me the option that the docs were promising...