### PR TITLE
Remove Release build and install steps

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -206,11 +206,6 @@ class HdpsCoreConan(ConanFile):
         print("**** Install RELWITHDEBINFO *****")
         cmake.install(build_type="RelWithDebInfo")
 
-        print("**** Build RELEASE *****")
-        cmake.build(build_type="Release")
-        print("**** Install RELEASE *****")
-        cmake.install(build_type="Release")
-
     def package(self):
         # if just running package
         if self.install_dir is None:
@@ -237,10 +232,6 @@ class HdpsCoreConan(ConanFile):
             # remove the bundle before packaging -
             # it contains the complete QtWebEngine > 1GB
             shutil.rmtree(str(pathlib.Path(self.install_dir, "RelWithDebInfo/ManiVault Studio.app")))
-            shutil.rmtree(str(pathlib.Path(self.install_dir, "Release/ManiVault Studio.app")))
-        elif self.settings.os == "Macos":
-            # also remove Release even in bundle build to keep package size down
-            shutil.rmtree(str(pathlib.Path(self.install_dir, "Release/ManiVault Studio.app")))
 
         # Add the pdb files next to the libs for RelWithDebInfo linking
         if tools.os_info.is_windows:
@@ -256,6 +247,3 @@ class HdpsCoreConan(ConanFile):
         self.cpp_info.relwithdebinfo.libdirs = ["RelWithDebInfo/lib"]
         self.cpp_info.relwithdebinfo.bindirs = ["RelWithDebInfo/Plugins", "RelWithDebInfo"]
         self.cpp_info.relwithdebinfo.includedirs = ["RelWithDebInfo/include", "RelWithDebInfo"]
-        self.cpp_info.release.libdirs = ["Release/lib"]
-        self.cpp_info.release.bindirs = ["Release/Plugins", "Release"]
-        self.cpp_info.release.includedirs = ["Release/include", "Release"]


### PR DESCRIPTION
Removed build and install steps for the 'Release' configuration, same as in https://github.com/ManiVaultStudio/t-SNE-Analysis/commit/5f6db3468f931158200c13fbb58c16eb468f05c1.