### PR TITLE
Restore DatasetPickerAction signal semantics

### DIFF
--- a/ManiVault/src/actions/DatasetPickerAction.cpp
+++ b/ManiVault/src/actions/DatasetPickerAction.cpp
@@ -36,7 +36,8 @@ DatasetPickerAction::DatasetPickerAction(QObject* parent, const QString& title) 
 
         if (currentIndex < 0) {
             _currentDatasetId.clear();
-            emit datasetPicked({});
+
+            emit currentDatasetChanged({});
             return;
         }
 
@@ -45,7 +46,8 @@ DatasetPickerAction::DatasetPickerAction(QObject* parent, const QString& title) 
 
         if (!sourceIndex.isValid()) {
             _currentDatasetId.clear();
-            emit datasetPicked({});
+
+            emit currentDatasetChanged({});
             return;
         }
 
@@ -63,7 +65,12 @@ DatasetPickerAction::DatasetPickerAction(QObject* parent, const QString& title) 
 
         _currentDatasetId = dataset.isValid() ? dataset->getId() : QString{};
 
-        emit datasetPicked(dataset);
+        emit currentDatasetChanged(dataset);
+
+        if (dataset.isValid()) {
+            Q_ASSERT(dataset.isValid());
+            emit datasetPicked(dataset);
+        }
     });
 
     const auto filterModelChanged = [this]() -> void {
@@ -315,8 +322,8 @@ void DatasetPickerAction::connectToPublicAction(WidgetAction* publicAction, bool
     if (publicDatasetPickerAction == nullptr)
         return;
 
-    connect(this, &DatasetPickerAction::datasetPicked, publicDatasetPickerAction, qOverload<mv::Dataset<mv::DatasetImpl>>(&DatasetPickerAction::setCurrentDataset));
-    connect(publicDatasetPickerAction, &DatasetPickerAction::datasetPicked, this, qOverload<mv::Dataset<mv::DatasetImpl>>(&DatasetPickerAction::setCurrentDataset));
+    connect(this, &DatasetPickerAction::currentDatasetChanged, publicDatasetPickerAction, qOverload<mv::Dataset<mv::DatasetImpl>>(&DatasetPickerAction::setCurrentDataset));
+    connect(publicDatasetPickerAction, &DatasetPickerAction::currentDatasetChanged, this, qOverload<mv::Dataset<mv::DatasetImpl>>(&DatasetPickerAction::setCurrentDataset));
 
     setCurrentDataset(publicDatasetPickerAction->getCurrentDataset());
 
@@ -335,8 +342,8 @@ void DatasetPickerAction::disconnectFromPublicAction(bool recursive)
     if (publicDatasetPickerAction == nullptr)
         return;
 
-    disconnect(this, &DatasetPickerAction::datasetPicked, publicDatasetPickerAction, qOverload<mv::Dataset<mv::DatasetImpl>>(&DatasetPickerAction::setCurrentDataset));
-    disconnect(publicDatasetPickerAction, &DatasetPickerAction::datasetPicked, this, qOverload<mv::Dataset<mv::DatasetImpl>>(&DatasetPickerAction::setCurrentDataset));
+    disconnect(this, &DatasetPickerAction::currentDatasetChanged, publicDatasetPickerAction, qOverload<mv::Dataset<mv::DatasetImpl>>(&DatasetPickerAction::setCurrentDataset));
+    disconnect(publicDatasetPickerAction, &DatasetPickerAction::currentDatasetChanged, this, qOverload<mv::Dataset<mv::DatasetImpl>>(&DatasetPickerAction::setCurrentDataset));
 
     OptionAction::disconnectFromPublicAction(recursive);
 }

--- a/ManiVault/src/actions/DatasetPickerAction.h
+++ b/ManiVault/src/actions/DatasetPickerAction.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later 
-// A corresponding LICENSE file is located in the root directory of this source tree 
-// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// A corresponding LICENSE file is located in the root directory of this source tree
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft)
 
 #pragma once
 
@@ -16,7 +16,8 @@
 
 #include <QAbstractListModel>
 
-namespace mv::gui {
+namespace mv::gui
+{
 
 /**
  * @brief Picks a dataset.
@@ -31,6 +32,11 @@ namespace mv::gui {
  * The action tracks the selected dataset by identifier for serialization and
  * emits dataset selection signals when the current dataset changes.
  *
+ * currentDatasetChanged() is the complete state-change signal. It emits a
+ * valid dataset when a dataset is selected and an invalid dataset when the
+ * selection is cleared. datasetPicked() is retained as the selection-specific
+ * compatibility signal and is emitted only for valid datasets.
+ *
  * @maintainer Thomas Kroes (BioVault - Biomedical Visual Analytics Unit LUMC - TU Delft)
  */
 class CORE_EXPORT DatasetPickerAction : public OptionAction
@@ -40,20 +46,20 @@ class CORE_EXPORT DatasetPickerAction : public OptionAction
 public:
 
     /**
-     * @brief Construct a dataset picker action.
+     * @brief Constructs a dataset picker action.
      * @param parent Parent object.
      * @param title Action title.
      */
     Q_INVOKABLE DatasetPickerAction(QObject* parent, const QString& title);
 
     /**
-     * @brief Get selectable datasets.
+     * @brief Returns selectable datasets.
      * @return Datasets currently visible through the picker after filtering.
      */
-    mv::Datasets getDatasets() const;
+    [[nodiscard]] mv::Datasets getDatasets() const;
 
     /**
-     * @brief Set selectable datasets.
+     * @brief Sets selectable datasets.
      *
      * Assigning datasets switches the action to manual population mode.
      *
@@ -63,76 +69,77 @@ public:
     void setDatasets(mv::Datasets datasets, bool silent = false);
 
     /**
-     * @brief Set the dataset filter function.
+     * @brief Sets the dataset filter function.
      * @param filterFunction Function used by the filter model to decide which datasets are selectable.
      */
     void setFilterFunction(const DatasetsFilterModel::FilterFunction& filterFunction);
 
     /**
-     * @brief Get the current dataset.
+     * @brief Returns the current dataset.
      * @return Currently selected dataset, or an invalid dataset when no dataset is selected.
      */
-    mv::Dataset<> getCurrentDataset() const;
+    [[nodiscard]] mv::Dataset<> getCurrentDataset() const;
 
     /**
-     * @brief Get the current dataset as a typed dataset.
+     * @brief Returns the current dataset as a typed dataset.
+     * @tparam DatasetType Target dataset implementation type.
      * @return Currently selected dataset cast to \p DatasetType.
      */
     template<typename DatasetType>
-    mv::Dataset<DatasetType> getCurrentDataset() const
+    [[nodiscard]] mv::Dataset<DatasetType> getCurrentDataset() const
     {
         return mv::Dataset<DatasetType>(DatasetPickerAction::getCurrentDataset());
     }
 
     /**
-     * @brief Set the current dataset.
+     * @brief Sets the current dataset.
      * @param currentDataset Dataset to select, or an invalid dataset to clear the selection.
      */
     void setCurrentDataset(mv::Dataset<mv::DatasetImpl> currentDataset);
 
     /**
-     * @brief Set the current dataset by identifier.
+     * @brief Sets the current dataset by identifier.
      * @param datasetId Globally unique identifier of the dataset to select, or an empty string to clear the selection.
      */
     void setCurrentDataset(const QString& datasetId);
 
     /**
-     * @brief Get the current dataset identifier.
+     * @brief Returns the current dataset identifier.
      * @return Globally unique identifier of the selected dataset, or an empty string when no dataset is selected.
      */
-    QString getCurrentDatasetId() const;
+    [[nodiscard]] QString getCurrentDatasetId() const;
 
     /**
-     * @brief Get selectable dataset identifiers.
+     * @brief Returns selectable dataset identifiers.
      * @return Globally unique identifiers of all currently selectable datasets.
      */
-    QStringList getCurrentDatasetIds() const;
+    [[nodiscard]] QStringList getCurrentDatasetIds() const;
 
     /**
-     * @brief Get a dataset by identifier.
+     * @brief Returns a dataset by identifier.
      * @param datasetId Globally unique dataset identifier to look up.
      * @return Dataset with the requested identifier, or an invalid dataset when it is not selectable.
      */
-    Dataset<DatasetImpl> getDataset(const QString& datasetId) const;
+    [[nodiscard]] Dataset<DatasetImpl> getDataset(const QString& datasetId) const;
 
     /**
-     * @brief Refresh the dataset filter.
+     * @brief Refreshes the dataset filter.
      *
      * Invalidates the internal filter model so the selectable dataset list is
      * recomputed. This is primarily useful in automatic population mode.
      */
     void invalidateFilter();
 
-public: // Population
+public:
 
     /**
-     * @brief Get the population mode.
+     * @brief Returns the population mode.
      * @return Current population mode.
      */
-    AbstractDatasetsModel::PopulationMode getPopulationMode() const;
+    [[nodiscard]] AbstractDatasetsModel::PopulationMode getPopulationMode() const;
 
     /**
-     * @brief Set the population mode.
+     * @brief Sets the population mode.
      * @param populationMode Population mode to use for selectable datasets.
      */
     void setPopulationMode(AbstractDatasetsModel::PopulationMode populationMode);
@@ -140,7 +147,7 @@ public: // Population
 private:
 
     /**
-     * @brief Apply the current population mode.
+     * @brief Applies the current population mode.
      *
      * Reconnects the filter model to either the manual datasets model or the
      * global datasets model.
@@ -148,63 +155,83 @@ private:
     void populationModeChanged();
 
     /**
-     * @brief Block datasetsChanged().
+     * @brief Blocks datasetsChanged().
      */
     void blockDatasetsChangedSignal();
 
     /**
-     * @brief Unblock datasetsChanged().
+     * @brief Unblocks datasetsChanged().
      */
     void unblockDatasetsChangedSignal();
 
     /**
-     * @brief Get whether datasetsChanged() is blocked.
+     * @brief Returns whether datasetsChanged() is blocked.
      * @return Whether datasetsChanged() is currently blocked.
      */
-    bool isDatasetsChangedSignalBlocked() const;
+    [[nodiscard]] bool isDatasetsChangedSignalBlocked() const;
 
-protected: // Linking
+protected:
 
     /**
-     * @brief Connect this action to a public action.
+     * @brief Connects this action to a public action.
      * @param publicAction Public action to connect to.
      * @param recursive Whether to also connect descendant child actions.
      */
     void connectToPublicAction(WidgetAction* publicAction, bool recursive) override;
 
     /**
-     * @brief Disconnect this action from its public action.
+     * @brief Disconnects this action from its public action.
      * @param recursive Whether to also disconnect descendant child actions.
      */
     void disconnectFromPublicAction(bool recursive) override;
 
-public: // Serialization
+public:
 
     /**
-     * @brief Load the action from a variant map.
+     * @brief Loads the action from a variant map.
      * @param variantMap Variant map representation of the action.
      */
     void fromVariantMap(const QVariantMap& variantMap) override;
 
     /**
-     * @brief Save the action to a variant map.
+     * @brief Saves the action to a variant map.
      * @return Variant map representation of the action.
      */
-    QVariantMap toVariantMap() const override;
+    [[nodiscard]] QVariantMap toVariantMap() const override;
 
 signals:
 
     /**
      * @brief Signals that the current dataset is about to change.
+     *
+     * The signal carries the previously selected dataset. The dataset can be
+     * invalid when no dataset was selected.
+     *
      * @param currentDataset Previously selected dataset, or an invalid dataset when no dataset was selected.
      */
     void datasetAboutToBePicked(mv::Dataset<> currentDataset);
 
     /**
-     * @brief Signals that a dataset has been picked.
-     * @param pickedDataset Newly selected dataset, or an invalid dataset when the selection was cleared.
+     * @brief Signals that a valid dataset has been picked.
+     *
+     * This compatibility signal is emitted only for valid dataset selections.
+     * Code that also needs to react to cleared selections should use
+     * currentDatasetChanged().
+     *
+     * @param pickedDataset Newly selected dataset. The dataset is guaranteed to be valid.
      */
     void datasetPicked(mv::Dataset<> pickedDataset);
+
+    /**
+     * @brief Signals that the current dataset changed.
+     *
+     * This is the canonical state-change signal. A valid dataset means a
+     * dataset is selected; an invalid dataset means the selection was cleared
+     * or could no longer be resolved.
+     *
+     * @param dataset Newly selected dataset, or an invalid dataset when the selection was cleared.
+     */
+    void currentDatasetChanged(Dataset<DatasetImpl> dataset);
 
     /**
      * @brief Signals that selectable datasets changed.
@@ -220,12 +247,13 @@ signals:
     void populationModeChanged(AbstractDatasetsModel::PopulationMode previousPopulationMode, AbstractDatasetsModel::PopulationMode currentPopulationMode);
 
 private:
-    AbstractDatasetsModel::PopulationMode   _populationMode;                /**< Selectable dataset population mode */
-    DatasetsListModel                       _datasetsListModel;             /**< Manual datasets model */
-    DatasetsFilterModel                     _datasetsFilterModel;           /**< Filter model applied to the active datasets model */
-    bool                                    _blockDatasetsChangedSignal;    /**< Whether datasetsChanged() is temporarily blocked */
-    QStringList                             _currentDatasetsIds;            /**< Cached selectable dataset identifiers */
-    QString                                 _currentDatasetId;              /**< Identifier of the currently selected dataset */
+
+    AbstractDatasetsModel::PopulationMode   _populationMode;                /**< Selectable dataset population mode. */
+    DatasetsListModel                       _datasetsListModel;             /**< Manual datasets model. */
+    DatasetsFilterModel                     _datasetsFilterModel;           /**< Filter model applied to the active datasets model. */
+    bool                                    _blockDatasetsChangedSignal;    /**< Whether datasetsChanged() is temporarily blocked. */
+    QStringList                             _currentDatasetsIds;            /**< Cached selectable dataset identifiers. */
+    QString                                 _currentDatasetId;              /**< Identifier of the currently selected dataset. */
 
     friend class AbstractActionsManager;
 };


### PR DESCRIPTION
# Summary

This pull request restores the original semantics of `DatasetPickerAction` signals while introducing a new signal that explicitly represents changes to the current dataset state.

## Changes

- Added a new `currentDatasetChanged` signal that is emitted whenever the current dataset changes, including when the current selection is cleared.
- Restored the original contract of `datasetPicked` so that it is only emitted when a valid dataset has been selected.
- Updated the synchronization between public and private `DatasetPickerAction` instances to use `currentDatasetChanged`, ensuring that dataset deselection is propagated correctly.
- Added documentation describing the intended semantics of both signals.

## Rationale

Recent changes caused `datasetPicked` to be emitted with an invalid dataset when the current selection was cleared. This changed the established behavior of the signal and introduced regressions in plugins that assumed `datasetPicked` always carried a valid dataset.

The new `currentDatasetChanged` signal provides a complete representation of the current dataset state, while `datasetPicked` retains its original semantics for backward compatibility.

This preserves the existing plugin API while providing a clearer and more expressive signal model for future development.