### PR TITLE
Update child widget on button action changes

### DIFF
--- a/ManiVault/src/actions/WidgetActionToolButtonMenu.cpp
+++ b/ManiVault/src/actions/WidgetActionToolButtonMenu.cpp
@@ -7,7 +7,9 @@
 #include "WidgetAction.h"
 #include "WidgetActionToolButton.h"
 
+#include <QActionEvent>
 #include <QCloseEvent>
+#include <QCoreApplication>
 #include <QDebug>
 #include <QEvent>
 #include <QVBoxLayout>
@@ -74,12 +76,25 @@ WidgetActionToolButtonMenu::DeferredLoadWidgetAction::ActionWidget::ActionWidget
     layout->setContentsMargins(0, 0, 0, 0);
 
     setLayout(layout);
+
+    // _widget for a button is built for one specific action.
+    // If a different action is assigned to the button, it needs to be invalidated.
+    connect(&_widgetActionToolButton, &WidgetActionToolButton::actionChanged, this, [this]() -> void {
+        delete _widget;
+        _widget = nullptr;
+    });
 }
 
 QSize WidgetActionToolButtonMenu::DeferredLoadWidgetAction::ActionWidget::sizeHint() const
 {
-    if (auto currentAction = _widgetActionToolButton.getAction())
-        return currentAction->getPopupSizeHint();
+    // Most actions leave the popup size hint unset.
+    // If the contained action changes this is needed to resize properly
+    if (auto currentAction = _widgetActionToolButton.getAction()) {
+        const auto popupSizeHint = currentAction->getPopupSizeHint();
+
+        if (popupSizeHint.isValid())
+            return popupSizeHint;
+    }
 
     if (_widget)
         return _widget->sizeHint();
@@ -96,6 +111,13 @@ void WidgetActionToolButtonMenu::DeferredLoadWidgetAction::ActionWidget::initial
             _widget->setProperty("Popup", true);
 
             layout()->addWidget(_widget);
+
+            // QMenu measures its items once. Changing the contained action needs to be communicated to to update geometry aftrer init.
+            auto& menu = _widgetActionToolButton.getMenu();
+
+            QActionEvent actionChangedEvent(QEvent::ActionChanged, &menu.getDeferredLoadWidgetAction());
+
+            QCoreApplication::sendEvent(&menu, &actionChangedEvent);
         }
     }
 }


### PR DESCRIPTION
In the current core, a `WidgetActionToolButton` that is re-pointed at a different action keeps showing  the action it was first opened with. Changing the action is ignored, for the lifetime of the button.

This appeared when using `PluginTriggerPickerAction` in the FcsLoader to provide transformation plugins in the loader (e.g., do a log transform after loading in a single (user facing) step). `PluginTriggerPickerAction` for transformations uses a `WidgetActionToolButton` to provide access to transformation plugins' settings.  If multiple transformation plugins with different settings are present, only the first shown settings widget would be shown.

This is fixed by connecting the already existing `actionChanged` signal to delete the child widget. (ll. 79-85)


The fix surfaced a second issue; the size of the widget would only be set once on start, so deleting the child and adding a bigger one would squish the ui (I already noticed similar behavior when modifying visible UI in these widgets, instead of disabling, I did not pursue this, but this might also fix, or be useful for that case).

This behavior is fixed by return `sizeHint` from popups if available and notifying menu on init. (rest of changes)

Example of correct widgets for two different transformations (centering and derivative) exposed through the `PluginTriggerPickerAction`.

<img width="1005" height="212" alt="Screenshot 2026-07-28 at 13 02 28" src="https://github.com/user-attachments/assets/e830dd7e-e92f-41c8-b4f2-1ae0a869286d" />
<img width="1232" height="402" alt="Screenshot 2026-07-28 at 13 02 54" src="https://github.com/user-attachments/assets/087a671c-237b-45ec-825f-a5480eaf1985" />


When first opening the panel for the centering transform then switching to derivative and opening the panel (note the panel must be opened in both steps, due to its lazy loading behavior). The panel does not update and derivate transform shows the centering panel.

<img width="1017" height="242" alt="Screenshot 2026-07-28 at 13 02 37" src="https://github.com/user-attachments/assets/1fb9da2b-431c-48f2-bc22-e874acc17e63" />