### PR TITLE
Fix serialization of pinned view plugin dock widgets

### DIFF
--- a/ManiVault/src/private/DockManager.cpp
+++ b/ManiVault/src/private/DockManager.cpp
@@ -69,16 +69,15 @@ DockManager::ViewPluginDockWidgets DockManager::getViewPluginDockWidgets(bool fl
 {
     ViewPluginDockWidgets viewPluginDockWidgets;
 
-    for (auto dockWidget : dockWidgets()) {
+    for (auto dockWidget : dockWidgetsMap()) {
+        if (!dockWidget)
+            continue;
+
+        if (!floating && dockWidget->isFloating())
+            continue;
+
         if (auto viewPluginDockWidget = dynamic_cast<ViewPluginDockWidget*>(dockWidget))
             viewPluginDockWidgets.push_back(viewPluginDockWidget);
-    }
-     
-    if (floating)  {
-        for (auto floatingDockContainer : floatingWidgets())
-            for (auto dockWidget : floatingDockContainer->dockWidgets())
-                if (auto viewPluginDockWidget = dynamic_cast<ViewPluginDockWidget*>(dockWidget))
-                    viewPluginDockWidgets.push_back(viewPluginDockWidget);
     }
 
     return viewPluginDockWidgets;
@@ -96,7 +95,7 @@ ViewPluginDockWidget* DockManager::findViewPluginDockWidget(const mv::plugin::Vi
     if (!viewPlugin)
         return nullptr;
 
-    for (auto dockWidget : dockWidgets()) {
+    for (auto dockWidget : dockWidgetsMap()) {
         if (viewPlugin->getId() == dockWidget->property("ViewPluginId").toString())
             return dynamic_cast<ViewPluginDockWidget*>(dockWidget);
     }
@@ -111,7 +110,7 @@ CDockAreaWidget* DockManager::findDockAreaWidget(const ViewPlugin* viewPlugin) c
     if (!viewPlugin)
         return nullptr;
 
-    for (auto dockWidget : dockWidgets()) {
+    for (auto dockWidget : dockWidgetsMap()) {
         if (viewPlugin->getId() == dockWidget->property("ViewPluginId").toString())
             return dockWidget->dockAreaWidget();
     }


### PR DESCRIPTION
## Summary

Fixes serialization of pinned/auto-hidden view plugin dock widgets.

## Changes

- Enumerate registered ADS dock widgets via `dockWidgetsMap()` instead of only walking visible dock containers.
- Preserve existing behavior for callers that exclude floating dock widgets.
- Use the same lookup source for finding view plugin dock widgets and dock areas.

## Rationale

Pinned/auto-hidden widgets can be registered with ADS without being returned by the previous `dockWidgets()` traversal. As a result, ManiVault could omit pinned view plugins during workspace serialization or skip restoring their plugin state after ADS layout restoration.
