### PR TITLE
Fix nested plugintrigger title

### DIFF
--- a/ManiVault/src/actions/PluginTriggerAction.cpp
+++ b/ManiVault/src/actions/PluginTriggerAction.cpp
@@ -110,7 +110,7 @@ void PluginTriggerAction::initialize()
 
 void PluginTriggerAction::setText(const QString& text)
 {
-    QAction::setText(text);
+    TriggerAction::setText(text.split("/").back());
 
     switch (_pluginFactory->getType())
     {
@@ -143,7 +143,7 @@ void PluginTriggerAction::setText(const QString& text)
     }
 
     _menuLocation.append("/");
-    _menuLocation.append(this->text());
+    _menuLocation.append(text);
 }
 
 void PluginTriggerAction::setRequestPluginCallback(RequestPluginCallback requestPluginCallback)

--- a/ManiVault/src/actions/PluginTriggerAction.cpp
+++ b/ManiVault/src/actions/PluginTriggerAction.cpp
@@ -20,7 +20,7 @@ PluginTriggerAction::PluginTriggerAction(QObject* parent, const plugin::PluginFa
     _configurationAction(nullptr),
     _requestPluginCallback()
 {
-    setText(title);
+    PluginTriggerAction::setText(title);
     setToolTip(tooltip);
     setIcon(icon);
 
@@ -39,7 +39,7 @@ PluginTriggerAction::PluginTriggerAction(QObject* parent, const plugin::PluginFa
     _configurationAction(nullptr),
     _requestPluginCallback(requestPluginCallback)
 {
-    setText(title);
+    PluginTriggerAction::setText(title);
     setToolTip(tooltip);
     setIcon(icon);
 

--- a/ManiVault/src/actions/PluginTriggerAction.cpp
+++ b/ManiVault/src/actions/PluginTriggerAction.cpp
@@ -54,7 +54,7 @@ PluginTriggerAction::PluginTriggerAction(const PluginTriggerAction& pluginTrigge
     _configurationAction(nullptr),
     _requestPluginCallback()
 {
-    setText(pluginTriggerAction.text());
+    PluginTriggerAction::setText(title);
     setToolTip(pluginTriggerAction.toolTip());
     setIcon(pluginTriggerAction.icon());
 

--- a/ManiVault/src/actions/PluginTriggerAction.h
+++ b/ManiVault/src/actions/PluginTriggerAction.h
@@ -40,7 +40,7 @@ public:
      * Constructor
      * @param parent Pointer to parent object
      * @param pluginFactory Pointer to plugin factory
-     * @param title Title of the plugin trigger action
+     * @param title Title and menu location of the plugin trigger action, 'menu/entry' will create a nested entry
      * @param icon Icon
      * @param tooltip Tooltip of the plugin trigger action
      */
@@ -50,7 +50,7 @@ public:
      * Constructor
      * @param parent Pointer to parent object
      * @param pluginFactory Pointer to plugin factory
-     * @param title Title of the plugin trigger action
+     * @param title Title and menu location of the plugin trigger action, 'menu/entry' will create a nested entry
      * @param tooltip Tooltip of the plugin trigger action
      * @param icon Icon
      * @param requestPluginCallback Callback which is invoked when the trigger action is triggered
@@ -77,7 +77,7 @@ public:
 
     /**
      * Set menu location of the plugin trigger action
-     * @param location Location of the plugin trigger action in a menu
+     * @param menuLocation Location of the plugin trigger action in a menu
      */
     void setMenuLocation(const QString& menuLocation);
 

--- a/ManiVault/src/actions/PluginTriggerAction.h
+++ b/ManiVault/src/actions/PluginTriggerAction.h
@@ -31,7 +31,7 @@ class CORE_EXPORT PluginTriggerAction : public TriggerAction
 {
     Q_OBJECT
     
-        /** Request plugin callback function (invoked when the trigger action is triggered) */
+    /** Request plugin callback function (invoked when the trigger action is triggered) */
     using RequestPluginCallback = std::function<void(PluginTriggerAction&)>;
 
 public:

--- a/ManiVault/src/actions/WidgetActionContextMenu.cpp
+++ b/ManiVault/src/actions/WidgetActionContextMenu.cpp
@@ -146,26 +146,6 @@ WidgetActionContextMenu::WidgetActionContextMenu(QWidget* parent, WidgetActions 
 
                     QHash<QString, QMenu*> menuCache;
 
-                    auto ensureMenuPath = [&](const QStringList& parts) -> QMenu* {
-                        auto current = connectToViewPluginActionMenu;
-
-                        QString currentPath;
-
-                        for (const auto& part : parts) {
-                            currentPath += "/" + part;
-
-                            if (!menuCache.contains(currentPath)) {
-                                auto subMenu = new QMenu(part, current);
-                                current->addMenu(subMenu);
-                                menuCache.insert(currentPath, subMenu);
-                            }
-
-                            current = menuCache[currentPath];
-                        }
-
-                        return current;
-                    };
-
                     for (auto candidateAction : viewPlugin->findChildren<WidgetAction*>()) {
                         if (candidateAction == firstAction)
                             continue;
@@ -189,7 +169,7 @@ WidgetActionContextMenu::WidgetActionContextMenu(QWidget* parent, WidgetActions 
                         if (!parts.isEmpty() && parts.last() == candidateAction->text())
                             parts.removeLast();
 
-                        auto targetMenu = ensureMenuPath(parts);
+                        auto targetMenu = ensureMenuPath(connectToViewPluginActionMenu, parts, menuCache);
                         auto action     = new QAction(candidateAction->text(), targetMenu);
 
                     	targetMenu->addAction(action);


### PR DESCRIPTION
Before: duplicate prefix in menu entry (here: "Conversion")
<img width="424" height="127" alt="Screenshot 2026-07-29 132125" src="https://github.com/user-attachments/assets/b54617f5-cc22-48aa-b9f2-96d5f82334d5" />

After: 
<img width="394" height="118" alt="Screenshot 2026-07-29 145132" src="https://github.com/user-attachments/assets/786976a6-77b9-49ee-82d2-b6497bd209ed" />

What:
When calling `PluginTriggerAction::setText(title)`, use the entire `title` for the menu location but only the last part of the `title`, as split with `/`, for the menu entry title. 
Now, setting the plugin trigger title to `Conversion/log2` will create a `log2` entry under a `Conversion` menu.

Also:
- [Remove duplicate function](https://github.com/ManiVaultStudio/core/commit/5734584e09b58e17aeee156dc15d27d4f04ceed9) (its defined as a static function and as a local lambda, let's remove one of them)