### PR TITLE
Add extractDataForDimension for subset point data

### DIFF
--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -386,6 +386,25 @@ void PointData::extractFullDataForDimensions(std::vector<mv::Vector2f>& result, 
 }
 
 
+void PointData::extractDataForDimension(std::vector<float> &result, const int dimensionIndex, const std::vector<std::uint32_t> &indices) const
+{
+    CheckDimensionIndex(dimensionIndex);
+
+    result.resize(indices.size());
+
+    std::visit(
+        [&result, this, dimensionIndex,
+         indices](const auto &vec) {
+          const auto resultSize = result.size();
+
+          for (std::size_t i{}; i < resultSize; ++i) {
+            const auto n = std::size_t{indices[i]} * _numDimensions;
+            result[i] = vec[n + dimensionIndex];
+          }
+        },
+        _variantOfVectors);
+}
+
 void PointData::extractDataForDimensions(std::vector<mv::Vector2f>& result, const int dimensionIndex1, const int dimensionIndex2, const std::vector<std::uint32_t>& indices) const
 {
     CheckDimensionIndex(dimensionIndex1);
@@ -516,10 +535,6 @@ void Points::setData(std::nullptr_t, const std::size_t numPoints, const std::siz
 
 void Points::extractDataForDimension(std::vector<float>& result, const int dimensionIndex) const
 {
-    // This overload assumes that the data set is "full".
-    // Please remove the assert once non-full support is implemented (if necessary).
-    assert(isFull());
-
     if (isProxy()) {
         result.resize(getNumPoints());
 
@@ -540,7 +555,13 @@ void Points::extractDataForDimension(std::vector<float>& result, const int dimen
         }
     }
     else {
-        getRawData<PointData>()->extractFullDataForDimension(result, dimensionIndex);
+        const auto rawPointData = getRawData<PointData>();
+
+        if (isFull())
+            rawPointData->extractFullDataForDimension(result, dimensionIndex);
+        else
+            rawPointData->extractDataForDimension(result, dimensionIndex, indices);
+
     }
 }
 

--- a/ManiVault/src/plugins/PointData/src/PointData.h
+++ b/ManiVault/src/plugins/PointData/src/PointData.h
@@ -276,6 +276,7 @@ public:
 
     void extractFullDataForDimension(std::vector<float>& result, const int dimensionIndex) const;
     void extractFullDataForDimensions(std::vector<mv::Vector2f>& result, const int dimensionIndex1, const int dimensionIndex2) const;
+    void extractDataForDimension(std::vector<float> &result, const int dimensionIndex, const std::vector<std::uint32_t> &indices) const;
     void extractDataForDimensions(std::vector<mv::Vector2f>& result, const int dimensionIndex1, const int dimensionIndex2, const std::vector<std::uint32_t>& indices) const;
     
     template <typename ResultContainer, typename DimensionIndices>


### PR DESCRIPTION
`Points::extractDataForDimension` only handles full data sets since `PointData::extractDataForDimension` was missing. This PR adds the latter.

You can recreate this by e.g. loading MNIST and creating a subset from a selection (e.g. via the scatterplot). When displaying that subset in the scatterplot and recoloring it with one of its dimensions, it's colored mostly with null values.
This is dim 73 (in both x and y axis) recolored by dim 73, so there should be a gradient upwards:
<img width="1058" height="550" alt="image" src="https://github.com/user-attachments/assets/702824c5-3a86-4525-bb75-46482427974c" />

After this PR (slightly different subset, but you can see the correct color gradient now):
<img width="1273" height="743" alt="image" src="https://github.com/user-attachments/assets/bd8955ee-2f51-4cb4-92d2-2446ded38a10" />
