### PR TITLE
Fix: Icon not visible, show text instead

### DIFF
--- a/ManiVault/src/plugins/PointData/src/DimensionsPickerSelectAction.cpp
+++ b/ManiVault/src/plugins/PointData/src/DimensionsPickerSelectAction.cpp
@@ -38,12 +38,6 @@ DimensionsPickerSelectAction::DimensionsPickerSelectAction(DimensionsPickerActio
     _saveSelectionAction.setToolTip("Save dimension selection to file");
     _loadExclusionAction.setToolTip("Load dimension exclusion selection to file");
 
-    _selectVisibleAction.setIconByName("eye");
-    _selectNonVisibleAction.setIconByName("eye-slash");
-
-    _selectVisibleAction.setDefaultWidgetFlags(TriggerAction::Icon);
-    _selectNonVisibleAction.setDefaultWidgetFlags(TriggerAction::Icon);
-
     const auto selectionFileFilter = tr("Text files (*.txt);;All files (*.*)");
 
     // Update the visible dimensions when the selection threshold changes


### PR DESCRIPTION
Icons in the the `DimensionsPickerSelectAction::DimensionsPickerSelectAction` popup in the `PointData` are not visible. Let's just show the explaining text instead. Just showing the icons is also not very insightful for new users.

Before (current):
<img width="483" height="123" alt="image" src="https://github.com/user-attachments/assets/2756e0de-6c16-4036-b474-c03073f71eb3" />

After:
<img width="503" height="124" alt="image" src="https://github.com/user-attachments/assets/e9c02646-95d4-4476-8144-a7a125aaddb3" />
