### PR TITLE
Fix SampleScope visibility updates for widget-based sample views

### DIFF
--- a/ManiVault/src/actions/ViewPluginSamplerAction.h
+++ b/ManiVault/src/actions/ViewPluginSamplerAction.h
@@ -307,30 +307,30 @@ signals:
     void canViewChanged(bool canView);
 
 private:
-    plugin::ViewPlugin*             _viewPlugin;                                /** Pointer to view plugin for which to show the tooltips */
-    bool                            _isInitialized;                             /** Boolean determining whether the sampler is initialized or not */
-    PixelSelectionAction*           _pixelSelectionAction;                      /** Pointer to pixel selection tool to use */
-    PixelSelectionAction*           _samplerPixelSelectionAction;               /** Pointer to sampler pixel selection tool to use */
-    ViewGeneratorType               _viewGeneratorType;                         /** Type of view generator */
-    HtmlViewGeneratorFunction       _htmlViewGeneratorFunction;                 /** HTML view generator function which is called periodically when the mouse moves in the view (should return an HTML formatted string) */
-    WidgetViewGeneratorFunction     _widgetViewGeneratorFunction;               /** Widget view generator function (the sampler action does not take ownership of the widget) */
-    ToggleAction                    _enabledAction;                             /** Action to toggle computation on/off */
-    ToggleAction                    _highlightFocusedElementsAction;            /** Action to toggle focus elements highlighting */
-    VerticalGroupAction             _settingsAction;                            /** Additional vertical group action for settings */
-    ToggleAction                    _restrictNumberOfElementsAction;            /** Action to setEnabled the restriction of the maximum number of elements in the focus region */
-    IntegralAction                  _maximumNumberOfElementsAction;             /** Action to restrict the maximum number of elements in the focus region */
-    IntegralAction                  _lazyUpdateIntervalAction;                  /** Action to control the view update timer interval */
-    OptionAction                    _samplingModeAction;                        /** Action to control the sampling mode */
-    OptionAction                    _viewingModeAction;                         /** Action to control the viewing mode */
-    SampleContext                   _sampleContext;                             /** Context for the tooltip */
-    QTimer                          _sampleContextLazyUpdateTimer;              /** Lazily (periodically) updates the sample context tooltip string */
-    bool                            _sampleContextDirty;                        /** Indicates that the sample context is dirty */
-    QString                         _viewString;                                /** Generated HTML-formatted view string */
-    QPointer<QWidget>               _viewWidget;                                /** Pointer to the generated view widget */
-    std::unique_ptr<OverlayWidget>  _toolTipOverlayWidget;                      /** Overlay widget for the tooltip */
-    QLabel                          _toolTipLabel;                              /** The text label which contains the actual tooltip text */
-    TriggerAction                   _openSampleScopeWindow;                     /** Opens a sample scope window */
-    plugin::ViewPlugin*             _sampleScopePlugin;                         /** Pointer to sample scope plugin (maybe nullptr) */
+    plugin::ViewPlugin*             _viewPlugin;                                        /** Pointer to view plugin for which to show the tooltips */
+    bool                            _isInitialized;                                     /** Boolean determining whether the sampler is initialized or not */
+    PixelSelectionAction*           _pixelSelectionAction;                              /** Pointer to pixel selection tool to use */
+    PixelSelectionAction*           _samplerPixelSelectionAction;                       /** Pointer to sampler pixel selection tool to use */
+    ViewGeneratorType               _viewGeneratorType = ViewGeneratorType::HTML;       /** Type of view generator */
+    HtmlViewGeneratorFunction       _htmlViewGeneratorFunction;                         /** HTML view generator function which is called periodically when the mouse moves in the view (should return an HTML formatted string) */
+    WidgetViewGeneratorFunction     _widgetViewGeneratorFunction;                       /** Widget view generator function (the sampler action does not take ownership of the widget) */
+    ToggleAction                    _enabledAction;                                     /** Action to toggle computation on/off */
+    ToggleAction                    _highlightFocusedElementsAction;                    /** Action to toggle focus elements highlighting */
+    VerticalGroupAction             _settingsAction;                                    /** Additional vertical group action for settings */
+    ToggleAction                    _restrictNumberOfElementsAction;                    /** Action to setEnabled the restriction of the maximum number of elements in the focus region */
+    IntegralAction                  _maximumNumberOfElementsAction;                     /** Action to restrict the maximum number of elements in the focus region */
+    IntegralAction                  _lazyUpdateIntervalAction;                          /** Action to control the view update timer interval */
+    OptionAction                    _samplingModeAction;                                /** Action to control the sampling mode */
+    OptionAction                    _viewingModeAction;                                 /** Action to control the viewing mode */
+    SampleContext                   _sampleContext;                                     /** Context for the tooltip */
+    QTimer                          _sampleContextLazyUpdateTimer;                      /** Lazily (periodically) updates the sample context tooltip string */
+    bool                            _sampleContextDirty = false;                        /** Indicates that the sample context is dirty */
+    QString                         _viewString;                                        /** Generated HTML-formatted view string */
+    QPointer<QWidget>               _viewWidget;                                        /** Pointer to the generated view widget */
+    std::unique_ptr<OverlayWidget>  _toolTipOverlayWidget;                              /** Overlay widget for the tooltip */
+    QLabel                          _toolTipLabel;                                      /** The text label which contains the actual tooltip text */
+    TriggerAction                   _openSampleScopeWindow;                             /** Opens a sample scope window */
+    plugin::ViewPlugin*             _sampleScopePlugin;                                 /** Pointer to sample scope plugin (maybe nullptr) */
 };
 
 }

--- a/ManiVault/src/plugins/SampleScopePlugin/src/SampleScopePlugin.cpp
+++ b/ManiVault/src/plugins/SampleScopePlugin/src/SampleScopePlugin.cpp
@@ -82,7 +82,7 @@ SampleScopePlugin::SampleScopePlugin(const PluginFactory* factory) :
             const auto updateViewWidget = [this]() -> void {
                 _freezeViewAction.setVisible(false);
 
-                _sampleScopeWidget.setViewWidget(_viewPluginSamplerAction->getViewWidget());
+                _sampleScopeWidget.setViewWidget(const_cast<QWidget*>(_viewPluginSamplerAction->getViewWidget()));
             };
 
             if (_viewPluginSamplerAction->getViewGeneratorType() == ViewPluginSamplerAction::ViewGeneratorType::Widget)

--- a/ManiVault/src/plugins/SampleScopePlugin/src/SampleScopeWidget.cpp
+++ b/ManiVault/src/plugins/SampleScopePlugin/src/SampleScopeWidget.cpp
@@ -52,17 +52,31 @@ void SampleScopeWidget::initialize()
     _noSamplesOverlayWidget.show();
 
     connect(&_sampleScopePlugin->getSourcePluginPickerAction(), &PluginPickerAction::pluginPicked, this, [this](plugin::Plugin* plugin) -> void {
-        if (_currentViewPlugin) {
-            disconnect(&_currentViewPlugin->getSamplerAction(), &ViewPluginSamplerAction::viewGeneratorTypeChanged, this, nullptr);
-            _previousViewPlugin = _currentViewPlugin;
+        if (_currentViewPlugin)
+        {
+            auto& samplerAction = _currentViewPlugin->getSamplerAction();
+
+            connect(&samplerAction, &ViewPluginSamplerAction::viewGeneratorTypeChanged, this, [this]() {
+                updateVisibility();
+            });
+
+            connect(&samplerAction, &ViewPluginSamplerAction::canViewChanged, this, [this](bool) {
+                updateVisibility();
+            });
+
+            updateVisibility();
         }
 
         _currentViewPlugin = dynamic_cast<ViewPlugin*>(plugin);
 
-        if (_currentViewPlugin) {
-            connect(&_currentViewPlugin->getSamplerAction(), &ViewPluginSamplerAction::viewGeneratorTypeChanged, this, &SampleScopeWidget::updateVisibility);
+        if (_currentViewPlugin)
+        {
+            auto& samplerAction = _currentViewPlugin->getSamplerAction();
 
-            updateVisibility();
+            disconnect(&samplerAction, &ViewPluginSamplerAction::viewGeneratorTypeChanged, this, nullptr);
+            disconnect(&samplerAction, &ViewPluginSamplerAction::canViewChanged, this, nullptr);
+
+            _previousViewPlugin = _currentViewPlugin;
         }
     });
 
@@ -77,35 +91,46 @@ void SampleScopeWidget::setViewHtml(const QString& html)
     _htmlView.setHtml(html);
 }
 
-void SampleScopeWidget::setViewWidget(const QWidget* widget)
+void SampleScopeWidget::setViewWidget(QWidget* widget)
 {
     Q_ASSERT(widget);
 
     if (!widget)
         return;
 
+    if (_currentViewWidget == widget && _proxyWidget)
+    {
+        updateViewWidgetProxySize();
+        _proxyWidget->show();
+        _widgetView.viewport()->update();
+        return;
+    }
+
     if (_proxyWidget)
     {
-        if (auto previousWidget = _proxyWidget->widget()) {
+        if (QWidget* previousWidget = _proxyWidget->widget())
+        {
+            previousWidget->hide();
             _proxyWidget->setWidget(nullptr);
-            previousWidget->setParent(nullptr);
         }
 
         _widgetViewScene.removeItem(_proxyWidget);
-
         delete _proxyWidget;
-
         _proxyWidget = nullptr;
     }
 
-    _widgetViewScene.clear();
-
-    _currentViewWidget = const_cast<QWidget*>(widget);
+    _currentViewWidget = widget;
 
     _proxyWidget = _widgetViewScene.addWidget(_currentViewWidget);
-    _proxyWidget->setPos(0, 0);
+    _proxyWidget->setPos(0.0, 0.0);
 
     updateViewWidgetProxySize();
+
+    _proxyWidget->show();
+    _currentViewWidget->show();
+
+    _widgetViewScene.invalidate();
+    _widgetView.viewport()->update();
 }
 
 InfoOverlayWidget& SampleScopeWidget::getNoSamplesOverlayWidget()

--- a/ManiVault/src/plugins/SampleScopePlugin/src/SampleScopeWidget.h
+++ b/ManiVault/src/plugins/SampleScopePlugin/src/SampleScopeWidget.h
@@ -47,7 +47,7 @@ public:
      * Set widget to \p widget
      * @param widget Pointer to widget
      */
-    void setViewWidget(const QWidget* widget);
+    void setViewWidget(QWidget* widget);
 
     /**
      * Get no samples overlay widget


### PR DESCRIPTION
## Summary

This PR fixes an issue where widget-based Sample Scope views could intermittently remain hidden, even though the underlying widget and proxy were correctly created and sized.

The root cause was that `SampleScopeWidget` only updated its visibility in response to `viewGeneratorTypeChanged`, while the actual visibility depends on `canView()`, which is influenced by additional state such as the viewing mode, enabled state, and availability of a valid view generator.

As a result, the following initialization sequence could occur:

1. The widget view generator is assigned.
2. `viewGeneratorTypeChanged` is emitted.
3. `SampleScopeWidget::updateVisibility()` is called.
4. `canView()` still returns `false` because the viewing mode has not yet been updated.
5. The widget view is hidden.
6. The viewing mode changes to `Windowed`.
7. `canViewChanged(true)` is emitted.
8. The Sample Scope widget does not react to this signal, leaving the widget view hidden.

This resulted in an intermittent blank Sample Scope window despite the embedded `QWebEngineView` and its `QGraphicsProxyWidget` being present and correctly sized.

## Changes

- Update Sample Scope visibility when `canView()` changes.
- Continue updating visibility when the view generator type changes.
- Properly disconnect all visibility-related signal connections when switching source plugins.
- Ensure widget visibility is always recalculated from the current sampler state.

## Notes

This issue became more noticeable after upgrading to Qt 6.10.x, likely due to differences in initialization timing. However, the underlying issue was an order-dependent application logic bug rather than a Qt regression.