### PR TITLE
Prevent concurrent PointData access during workflow serialization

### DIFF
--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -114,6 +114,8 @@ mv::Dataset<DatasetImpl> PointData::createDataSet(const QString& guid /*= ""*/) 
 
 std::uint64_t PointData::getNumPoints() const
 {
+    const auto dataLock = lockData();
+
     if (_numDimensions == 0)
     {
         qWarning() << "Number of dimensions is 0 in point data ";
@@ -128,17 +130,21 @@ std::uint64_t PointData::getNumPoints() const
 
 std::uint64_t PointData::getNumDimensions() const
 {
+    const auto dataLock = lockData();
     return _numDimensions;
 }
 
 std::uint64_t PointData::getNumberOfElements() const
 {
+    const auto dataLock = lockData();
     return getSizeOfVector();
 }
 
 
 std::uint64_t PointData::getRawDataSize() const
 {
+    const auto dataLock = lockData();
+
     if (_isDense)
     {
         std::uint64_t elementSize = std::visit([](auto& vec) { return vec.empty() ? 0u : sizeof(vec[0]); }, _variantOfVectors);
@@ -152,27 +158,34 @@ std::uint64_t PointData::getRawDataSize() const
 
 void* PointData::getDataVoidPtr()
 {
+    const auto dataLock = lockData();
     return std::visit([](auto& vec) { return (void*)vec.data(); }, _variantOfVectors);
 }
 
 const void* PointData::getDataConstVoidPtr() const
 {
+    const auto dataLock = lockData();
     return std::visit([](const auto& vec) { return (const void*)vec.data(); }, _variantOfVectors);
 }
 
 const std::vector<QString>& PointData::getDimensionNames() const
 {
+    const auto dataLock = lockData();
     return _dimNames;
 }
 
 void PointData::setData(const std::nullptr_t, const std::size_t numPoints, const std::size_t numDimensions)
 {
+    const auto dataLock = lockData();
+
     resizeVector(numPoints * numDimensions);
     _numDimensions = static_cast<std::uint64_t>(numDimensions);
 }
 
 void PointData::setDimensionNames(const std::vector<QString>& dimNames)
 {
+    const auto dataLock = lockData();
+
     if (dimNames.empty())
         return;
 
@@ -184,6 +197,8 @@ void PointData::setDimensionNames(const std::vector<QString>& dimNames)
 
 float PointData::getValueAt(const std::size_t index) const
 {
+    const auto dataLock = lockData();
+
     return std::visit([index](const auto& vec)
         {
             return static_cast<float>(vec[index]);
@@ -193,6 +208,8 @@ float PointData::getValueAt(const std::size_t index) const
 
 void PointData::setValueAt(const std::size_t index, const float newValue)
 {
+    const auto dataLock = lockData();
+
     std::visit([index, newValue](auto& vec)
         {
             using value_type = typename std::remove_reference_t<decltype(vec)>::value_type;
@@ -211,13 +228,16 @@ UniqueWorkflowPlan PointData::fromVariantMapWorkflow(QVariantMap variantMap)
 
     if (appVersion < Version(1, 5, 0)) {
         plan->addSequentialStage("Load legacy point data (< 1.5.0)", [this, variantMap](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext& executionContext) {
+            const auto dataLock = lockData();
             legacy::PointDataLegacySerializer::fromVariantMapPre150(*this, variantMap, executionContext);
         });
 
         return plan;
     }
 
-    plan->addSequentialStage("Allocate storage", [this, variantMap](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext&) {
+    plan->addSequentialStage("Allocate and populate storage", [this, variantMap](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext&) {
+        const auto dataLock = lockData();
+
         variantMapMustContain(variantMap, "Data");
         variantMapMustContain(variantMap, "NumberOfPoints");
         variantMapMustContain(variantMap, "NumberOfDimensions");
@@ -233,25 +253,17 @@ UniqueWorkflowPlan PointData::fromVariantMapWorkflow(QVariantMap variantMap)
 
         setElementTypeSpecifier(elementTypeIndex);
         resizeVector(numberOfElements);
-    });
 
-    plan->addNestedWorkflowStage("Populate data", [this, variantMap](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext& executionContext) -> UniqueWorkflowPlan {
-        QVariant rawData;
+        if (dataMap.contains("Raw") && dataMap["Raw"].canConvert<QVariantMap>()) {
+            // Keep allocation and all writes to the exposed buffer mutually
+            // exclusive. The synchronous decoder is intentional here: a
+            // std::mutex lock may not be handed from this workflow worker to
+            // the parallel workers used by populateBytesFromBlobMapWorkflow().
+            const auto rawDataSize = getRawDataSize();
 
-        if (variantMap.contains("Data") && variantMap["Data"].canConvert<QVariantMap>()) {
-            const auto dataMap = variantMap["Data"].toMap();
-
-            if (dataMap.contains("Raw") && dataMap["Raw"].canConvert<QVariantMap>()) {
-                rawData = dataMap["Raw"];
-            }
+            if (rawDataSize > 0)
+                populateBytesFromBlobMap(dataMap["Raw"].toMap(), static_cast<char*>(getDataVoidPtr()), rawDataSize);
         }
-
-        if (rawData.canConvert<QVariantMap>()) {
-            const auto rawDataMap = rawData.toMap();
-            return populateBytesFromBlobMapWorkflow(rawDataMap, static_cast<char*>(getDataVoidPtr()), getRawDataSize(), executionContext->getOptions());
-        }
-
-        return std::make_unique<WorkflowPlan>("Populate data (no raw data found in variant map)");
     });
 
     return plan;
@@ -260,6 +272,12 @@ UniqueWorkflowPlan PointData::fromVariantMapWorkflow(QVariantMap variantMap)
 UniqueWorkflowPlan PointData::toVariantMapWorkflow() const
 {
     auto plan = std::make_unique<WorkflowPlan>(__FUNCTION__);
+    bool isDense;
+
+    {
+        const auto dataLock = lockData();
+        isDense = _isDense;
+    }
 
     //const auto baseSaveStage = plan->addNestedWorkflowStage("Save raw data base", [this](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext&) -> UniqueWorkflowPlan {
     //    return this->Plugin::toVariantMapWorkflow();
@@ -268,12 +286,21 @@ UniqueWorkflowPlan PointData::toVariantMapWorkflow() const
     //
     //;
 
-    if (_isDense) {
-        const auto storeRawStage = plan->addNestedWorkflowStage("Save raw", [this](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext& executionContext) {
-            return bytesToBlobVariantMapWorkflow(static_cast<const char*>(getDataConstVoidPtr()), getRawDataSize());
+    if (isDense) {
+        const auto storeRawStage = plan->addNestedWorkflowStage("Save raw", [this](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext&) {
+            const auto dataLock = lockData();
+            const auto rawMap   = bytesToBlobVariantMap(static_cast<const char*>(getDataConstVoidPtr()), getRawDataSize());
+            auto storePlan      = std::make_unique<WorkflowPlan>("Publish point data blob");
+
+            storePlan->addSequentialStage("Publish point data blob", [rawMap](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext& storeExecutionContext) {
+                storeExecutionContext->setOutput(rawMap);
+            });
+
+            return storePlan;
         });
 
         plan->addSequentialStage("Build map", [this, storeRawStage](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext& executionContext) {
+            const auto dataLock = lockData();
             QVariantMap outputMap;
 
             const auto typeSpecifier        = getElementTypeSpecifier();
@@ -307,6 +334,7 @@ UniqueWorkflowPlan PointData::toVariantMapWorkflow() const
         });
     } else {
         plan->addSequentialStage("Build map", [this](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext& executionContext) {
+            const auto dataLock = lockData();
             QVariantMap outputMap;
 
             std::vector<char> bytes;
@@ -334,6 +362,8 @@ UniqueWorkflowPlan PointData::toVariantMapWorkflow() const
 
 void PointData::extractFullDataForDimension(std::vector<float>& result, const int dimensionIndex) const
 {
+    const auto dataLock = lockData();
+
     CheckDimensionIndex(dimensionIndex);
 
     result.resize(getNumPoints());
@@ -353,6 +383,8 @@ void PointData::extractFullDataForDimension(std::vector<float>& result, const in
 
 void PointData::extractFullDataForDimensions(std::vector<mv::Vector2f>& result, const int dimensionIndex1, const int dimensionIndex2) const
 {
+    const auto dataLock = lockData();
+
     if (_isDense)
     {
         CheckDimensionIndex(dimensionIndex1);
@@ -407,6 +439,8 @@ void PointData::extractDataForDimension(std::vector<float> &result, const int di
 
 void PointData::extractDataForDimensions(std::vector<mv::Vector2f>& result, const int dimensionIndex1, const int dimensionIndex2, const std::vector<std::uint32_t>& indices) const
 {
+    const auto dataLock = lockData();
+
     CheckDimensionIndex(dimensionIndex1);
     CheckDimensionIndex(dimensionIndex2);
 

--- a/ManiVault/src/plugins/PointData/src/PointData.h
+++ b/ManiVault/src/plugins/PointData/src/PointData.h
@@ -24,6 +24,7 @@
 
 #include <array>
 #include <cassert>
+#include <mutex>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -61,6 +62,8 @@ class ClusterAction;
 class POINTDATA_EXPORT PointData : public mv::plugin::RawData
 {
 public:
+    using DataLock = std::unique_lock<std::recursive_mutex>;
+
     enum class ElementTypeSpecifier
     {
         float32,
@@ -215,6 +218,17 @@ public:
     PointData(mv::plugin::PluginFactory* factory) : RawData(factory, PointType) { }
     ~PointData() override = default;
 
+    /**
+     * Acquires exclusive access to the point-data storage and its metadata.
+     *
+     * Keep the returned lock alive for the complete lifetime of any pointer,
+     * iterator or reference obtained from this PointData instance.
+     */
+    [[nodiscard]] DataLock lockData() const
+    {
+        return DataLock(_dataMutex);
+    }
+
     void init() override;
 
     mv::Dataset<mv::DatasetImpl> createDataSet(const QString& guid = "") const override;
@@ -256,6 +270,8 @@ public:
     template <typename ReturnType = void, typename FunctionObject>
     ReturnType constVisitFromBeginToEnd(FunctionObject functionObject) const
     {
+        const auto dataLock = lockData();
+
         return std::visit([functionObject](const auto& vec) -> ReturnType
             {
                 return functionObject(std::cbegin(vec), std::cend(vec));
@@ -267,6 +283,8 @@ public:
     template <typename ReturnType = void, typename FunctionObject>
     ReturnType visitFromBeginToEnd(FunctionObject functionObject)
     {
+        const auto dataLock = lockData();
+
         return std::visit([functionObject](auto& vec) -> ReturnType
             {
                 return functionObject(std::begin(vec), std::end(vec));
@@ -282,6 +300,8 @@ public:
     template <typename ResultContainer, typename DimensionIndices>
     void populateFullDataForDimensions(ResultContainer& resultContainer, const DimensionIndices& dimensionIndices) const
     {
+        const auto dataLock = lockData();
+
         CheckDimensionIndices(dimensionIndices);
         std::visit([&resultContainer, this, &dimensionIndices](const auto& vec)
             {
@@ -305,6 +325,8 @@ public:
     template <typename ResultContainer, typename DimensionIndices, typename Indices>
     void populateDataForDimensions(ResultContainer& resultContainer, const DimensionIndices& dimensionIndices, const Indices& indices) const
     {
+        const auto dataLock = lockData();
+
         CheckDimensionIndices(dimensionIndices);
 
         std::visit([&resultContainer, this, &dimensionIndices, &indices](const auto& vec)
@@ -336,17 +358,20 @@ public:
 
     ElementTypeSpecifier getElementType() const
     {
+        const auto dataLock = lockData();
         return getElementTypeSpecifier();
     }
 
     void setElementType(const ElementTypeSpecifier elementTypSpecifier)
     {
+        const auto dataLock = lockData();
         setElementTypeSpecifier(elementTypSpecifier);
     }
 
     template <typename T>
     void setElementType()
     {
+        const auto dataLock = lockData();
         constexpr auto elementTypSpecifier = getElementTypeSpecifier<T>();
         setElementType(elementTypSpecifier);
     }
@@ -359,6 +384,8 @@ public:
     template <typename T>
     void convertData(const T* const data, const std::size_t numPoints, const std::size_t numDimensions)
     {
+        const auto dataLock = lockData();
+
         convertData(data, numPoints * numDimensions);
         _numDimensions = static_cast<std::uint64_t>(numDimensions);
     }
@@ -369,6 +396,8 @@ public:
     template <typename T>
     void convertData(const T& inputDataContainer, const std::size_t numDimensions)
     {
+        const auto dataLock = lockData();
+
         convertData(inputDataContainer.data(), inputDataContainer.size());
         _numDimensions = static_cast<std::uint64_t>(numDimensions);
     }
@@ -379,6 +408,8 @@ public:
     template <typename T>
     void setData(const T* const data, const std::size_t numPoints, const std::size_t numDimensions)
     {
+         const auto dataLock = lockData();
+
          _variantOfVectors = VariantOfVectors( std::vector<T>(data, data + numPoints * numDimensions) );
          _numDimensions = static_cast<std::uint64_t>(numDimensions);
     }
@@ -394,6 +425,8 @@ public:
     template <typename T>
     void setData(const std::vector<T>& data, const std::size_t numDimensions)
     {
+        const auto dataLock = lockData();
+
         _variantOfVectors = VariantOfVectors(data);
         _numDimensions = static_cast<std::uint64_t>(numDimensions);
     }
@@ -404,6 +437,8 @@ public:
     template <typename T>
     void setData(std::vector<T>&& data, const std::size_t numDimensions)
     {
+        const auto dataLock = lockData();
+
         _variantOfVectors = VariantOfVectors(std::move(data));
         _numDimensions = static_cast<std::uint64_t>(numDimensions);
     }
@@ -429,6 +464,7 @@ public: // Sparse data, test implementation
 
         static void setSparseData(PointData* points, size_t numRows, size_t numCols, const std::vector<size_t>& rowPointers, const std::vector<size_t>& colIndices, const std::vector<float>& values)
         {
+            const auto dataLock = points->lockData();
             points->_sparseData.setData(numRows, numCols, rowPointers, colIndices, values);
             points->_numRows = static_cast<uint64_t>(numRows);
             points->setData(std::vector<float> {}, numCols);
@@ -437,6 +473,7 @@ public: // Sparse data, test implementation
 
         static void setSparseData(PointData* points, size_t numRows, size_t numCols, std::vector<size_t>&& rowPointers, std::vector<size_t>&& colIndices, std::vector<float>&& values)
         {
+            const auto dataLock = points->lockData();
             points->_sparseData.setData(numRows, numCols, std::move(rowPointers), std::move(colIndices), std::move(values));
             points->_numRows = static_cast<uint64_t>(numRows);
             points->setData(std::vector<float> {}, numCols);
@@ -444,27 +481,34 @@ public: // Sparse data, test implementation
         }
 
         static SparseMatrix<size_t, size_t, float>& getSparseData(PointData* points)
-        { 
+        {
+            // The returned reference is only safe while the caller retains a
+            // lock acquired with PointData::lockData().
             return points->_sparseData; 
         }
 
         static bool isDense(const PointData* points)
         {
+            const auto dataLock = points->lockData();
             return points->_isDense;
         }
 
         static void setIsDense(PointData* points, bool isDense)
         {
+            const auto dataLock = points->lockData();
             points->_isDense = isDense;
         }
 
         static size_t getNumNonZeroElements(const PointData* points)
         {
+            const auto dataLock = points->lockData();
             return points->_sparseData.getNumNonZeros();
         }
 
         static std::vector<float> row(const PointData* points, size_t rowIndex)
         {
+            const auto dataLock = points->lockData();
+
             if (points->_isDense)
             {
                 qWarning() << ".row() not implemented for dense data";
@@ -499,6 +543,8 @@ public: // Serialization
     mv::workflow::UniqueWorkflowPlan toVariantMapWorkflow() const final;
 
 private:
+    mutable std::recursive_mutex _dataMutex;
+
     VariantOfVectors _variantOfVectors;
 
     /** Number of features of each data point */


### PR DESCRIPTION
## Summary

Adds provisional thread-safety protections to `PointData` to address the crash reported in #1290.

The change:

- Introduces mutex-protected access to point-data storage and related metadata.
- Provides an RAII locking API for callers accessing pointers, iterators, or references.
- Protects point-data reads, writes, conversions, extraction, and sparse-data operations.
- Holds one lock across allocation, vector resizing, and blob population during project loading.
- Protects the raw point-data buffer during serialization.

Blob decoding is performed synchronously while holding the lock. This avoids transferring mutex ownership between Taskflow worker threads and prevents the underlying vector from being resized while its buffer is being populated.

## Status

This is intended as a temporary, pragmatic solution for the current `PointData` implementation.

When the new point-data model is introduced, thread safety and data-access ownership will be revisited as part of that design. Until then, this change provides a working solution that protects the existing storage model against concurrent access and vector invalidation.

Fixes #1290.