### PR TITLE
Fix number of elements in subset point data serialization

### DIFF
--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -241,14 +241,15 @@ UniqueWorkflowPlan PointData::fromVariantMapWorkflow(QVariantMap variantMap)
         variantMapMustContain(variantMap, "Data");
         variantMapMustContain(variantMap, "NumberOfPoints");        // not used
         variantMapMustContain(variantMap, "NumberOfDimensions");
-        variantMapMustContain(variantMap, "NumberOfElements");
 
         const auto dataMap  = variantMap["Data"].toMap();
         _isDense            = variantMap.value("Dense", true).toBool();
         _numDimensions      = static_cast<std::size_t>( variantMap["NumberOfDimensions"].toULongLong());
 
         if (dataMap.contains("Raw") && dataMap["Raw"].canConvert<QVariantMap>()) {
-            const auto numberOfRawElements = static_cast<std::size_t>(
+          variantMapMustContain(dataMap, "NumberOfElements");
+
+          const auto numberOfElements = static_cast<std::size_t>(
                 dataMap["NumberOfElements"].toULongLong());
 
             const auto elementTypeIndex = dataMap.contains("TypeName") 
@@ -256,7 +257,7 @@ UniqueWorkflowPlan PointData::fromVariantMapWorkflow(QVariantMap variantMap)
               : static_cast<ElementTypeSpecifier>(dataMap.value("TypeIndex").toInt());
 
             setElementTypeSpecifier(elementTypeIndex);
-            resizeVector(numberOfRawElements);
+            resizeVector(numberOfElements);
           
             // Keep allocation and all writes to the exposed buffer mutually
             // exclusive. The synchronous decoder is intentional here: a

--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -239,22 +239,25 @@ UniqueWorkflowPlan PointData::fromVariantMapWorkflow(QVariantMap variantMap)
         const auto dataLock = lockData();
 
         variantMapMustContain(variantMap, "Data");
-        variantMapMustContain(variantMap, "NumberOfPoints");
+        variantMapMustContain(variantMap, "NumberOfPoints");        // not used
         variantMapMustContain(variantMap, "NumberOfDimensions");
+        variantMapMustContain(variantMap, "NumberOfElements");
 
-        const auto dataMap              = variantMap["Data"].toMap();
-        const auto numberOfPoints       = static_cast<std::size_t>(variantMap["NumberOfPoints"].toULongLong());
-        const auto numberOfDimensions   = static_cast<std::size_t>(variantMap["NumberOfDimensions"].toULongLong());
-        const auto numberOfElements     = numberOfPoints * numberOfDimensions;
-        const auto elementTypeIndex     = dataMap.contains("TypeName") ? elementTypeSpecifier(dataMap.value("TypeName").toString()) : static_cast<ElementTypeSpecifier>(dataMap.value("TypeIndex").toInt());
-
-        _isDense        = variantMap.value("Dense", true).toBool();
-        _numDimensions  = numberOfDimensions;
-
-        setElementTypeSpecifier(elementTypeIndex);
-        resizeVector(numberOfElements);
+        const auto dataMap  = variantMap["Data"].toMap();
+        _isDense            = variantMap.value("Dense", true).toBool();
+        _numDimensions      = static_cast<std::size_t>( variantMap["NumberOfDimensions"].toULongLong());
 
         if (dataMap.contains("Raw") && dataMap["Raw"].canConvert<QVariantMap>()) {
+            const auto numberOfRawElements = static_cast<std::size_t>(
+                dataMap["NumberOfElements"].toULongLong());
+
+            const auto elementTypeIndex = dataMap.contains("TypeName") 
+              ? elementTypeSpecifier(dataMap.value("TypeName").toString()) 
+              : static_cast<ElementTypeSpecifier>(dataMap.value("TypeIndex").toInt());
+
+            setElementTypeSpecifier(elementTypeIndex);
+            resizeVector(numberOfRawElements);
+          
             // Keep allocation and all writes to the exposed buffer mutually
             // exclusive. The synchronous decoder is intentional here: a
             // std::mutex lock may not be handed from this workflow worker to


### PR DESCRIPTION
This PR fixes an issues with loading subset point data.
Currently, the number of elements in the point data raw storage are determined via the point data's `numberOfPoints * numberOfDimensions`. But a subset shares its raw data with its source while having fewer number of points. If you use this smaller number to resize the raw data vector when loading subset data, we are losing part of the raw data. This will result in out of bound indexing errors in e.g. `PointData::extractDataForDimensions` where the subset indices of the original data are used to access raw data.

Since at least version `1.0` [we have serialized `NumberOfElements`](https://github.com/ManiVaultStudio/core/blob/v1.0/ManiVault/src/plugins/PointData/src/PointData.cpp#L157). We can simply use that instead of calculating it from the number of points and dimensions. This will be correct for full and subset data.

Also, I've moved all operations related to loading the raw data into the respective if-clause.

---

To reproduce the current mismatch you can add some debug prints to `ScatterplotPlugin::updateData()` from the scatterplot plugin:
```cpp
qDebug() << "ScatterplotPlugin::updateData:" << _positionDataset->getGuiName() << "(" << _positionDataset->getId() << ")";
qDebug() << "ScatterplotPlugin::updateData:" << _positionDataset->getNumPoints() << "(" << _positionDataset->getNumRawPoints() << ")";
```
Now for some subset of MNIST this gives:
```
ScatterplotPlugin::updateData: "SUB" ( "b40756be-5920-47b6-8d27-840957bb50c5" )
ScatterplotPlugin::updateData: 3894 ( 10000 )
```
which makes sense since the source data had 10,000 data points and the subset now has 3894
Now when saving that project and loading is again we get:
```
ScatterplotPlugin::updateData: "SUB" ( "b40756be-5920-47b6-8d27-840957bb50c5" )
ScatterplotPlugin::updateData: 3894 ( 3894 )
```
And this leads to a crash when calling `_positionDataset->extractDataForDimensions` in `ScatterplotPlugin::updateData`.
There, the point data checks if it's full (which it is not), but now the internal data vector is too short, only 3894 items, which clashes with the indices vector that refers to the positions of the source data in the 10,000 items long original data vector.
