### PR TITLE
Fix random point selections after reopening projects

### DIFF
--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -1175,15 +1175,16 @@ UniqueWorkflowPlan Points::fromVariantMapWorkflow(QVariantMap variantMap)
 
         const auto count = selectionMap["Count"].value<std::uint64_t>();
 
-        if (isFull()) {
+        if (count > 0 && isFull()) {
             auto selectionSet = getSelection<Points>();
 
-            selectionSet->indices.resize(count);
+            if (selectionSet.isValid()) {
+                selectionSet->indices.resize(count);
 
-            if (count > 0)
-                populateBytesFromBlobMap(selectionMap["Raw"].toMap(), (char*)selectionSet->indices.data(), count * sizeof(uint32_t));
+            	populateBytesFromBlobMap(selectionMap["Raw"].toMap(), (char*)selectionSet->indices.data(), count * sizeof(uint32_t));
 
-            events().notifyDatasetDataSelectionChanged(this);
+                events().notifyDatasetDataSelectionChanged(this);
+            }
         }
     }, WorkflowPlan::JobThreadAffinity::GuiThread);
 

--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -1175,12 +1175,13 @@ UniqueWorkflowPlan Points::fromVariantMapWorkflow(QVariantMap variantMap)
 
         const auto count = selectionMap["Count"].value<std::uint64_t>();
 
-        if (count > 0) {
+        if (isFull()) {
             auto selectionSet = getSelection<Points>();
 
             selectionSet->indices.resize(count);
 
-            populateBytesFromBlobMap(selectionMap["Raw"].toMap(), (char*)selectionSet->indices.data(), count * sizeof(uint32_t));
+            if (count > 0)
+                populateBytesFromBlobMap(selectionMap["Raw"].toMap(), (char*)selectionSet->indices.data(), count * sizeof(uint32_t));
 
             events().notifyDatasetDataSelectionChanged(this);
         }

--- a/ManiVault/src/plugins/PointData/src/PointDataLegacySerialization.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointDataLegacySerialization.cpp
@@ -158,15 +158,14 @@ void PointsLegacySerializer::fromVariantMapPre150(Points& points, const QVariant
 
         const auto count = selectionMap["Count"].toUInt();
 
-        if (count > 0) {
-            auto selectionSet = points.getSelection<Points>();
+        auto selectionSet = points.getSelection<Points>();
 
-            selectionSet->indices.resize(count);
+        selectionSet->indices.resize(count);
 
+        if (count > 0)
             populateBytesFromBlobMap(selectionMap["Raw"].toMap(), (char*)selectionSet->indices.data(), selectionSet->indices.size() * sizeof(decltype(selectionSet->indices)::value_type));
 
-            events().notifyDatasetDataSelectionChanged(points);
-        }
+        events().notifyDatasetDataSelectionChanged(points);
     }
 }
 

--- a/ManiVault/src/plugins/PointData/src/PointDataLegacySerialization.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointDataLegacySerialization.cpp
@@ -160,12 +160,13 @@ void PointsLegacySerializer::fromVariantMapPre150(Points& points, const QVariant
 
         auto selectionSet = points.getSelection<Points>();
 
-        selectionSet->indices.resize(count);
+        if (count > 0 &&selectionSet.isValid()) {
+	        selectionSet->indices.resize(count);
 
-        if (count > 0)
-            populateBytesFromBlobMap(selectionMap["Raw"].toMap(), (char*)selectionSet->indices.data(), selectionSet->indices.size() * sizeof(decltype(selectionSet->indices)::value_type));
+			populateBytesFromBlobMap(selectionMap["Raw"].toMap(), (char*)selectionSet->indices.data(), selectionSet->indices.size() * sizeof(decltype(selectionSet->indices)::value_type));
 
-        events().notifyDatasetDataSelectionChanged(points);
+        	events().notifyDatasetDataSelectionChanged(points);
+        }
     }
 }
 


### PR DESCRIPTION
### Summary

Fixes an issue where reopening a project with an empty point selection could result in stale or seemingly random points being selected.

### Cause

Point selection deserialization only updated the selection when the saved selection count was greater than zero. Consequently, an explicitly saved empty selection did not clear selection indices introduced earlier during project loading.

### Changes

- Clear the existing point selection when the saved selection count is zero.
- Restore selections only for full point datasets, preventing subsets from clearing the shared selection.
- Apply the same empty-selection handling to legacy project deserialization.
- Notify listeners after restoring or clearing the selection.
