### PR TITLE
Restore legacy PointData accessor behavior for backwards compatibility

### DIFF
--- a/ManiVault/src/plugins/PointData/src/PointData.cpp
+++ b/ManiVault/src/plugins/PointData/src/PointData.cpp
@@ -197,7 +197,14 @@ void PointData::setDimensionNames(const std::vector<QString>& dimNames)
 
 float PointData::getValueAt(const std::size_t index) const
 {
-    const auto dataLock = lockData();
+    // Intentionally not locking here.
+   //
+   // This is a fine-grained legacy accessor and is frequently used from
+   // parallel loops. Callers must ensure that the underlying point-data
+   // storage is not modified concurrently.
+   //
+   // Use lockData() / the bulk-access APIs when synchronized access is
+   // required.
 
     return std::visit([index](const auto& vec)
         {
@@ -208,7 +215,14 @@ float PointData::getValueAt(const std::size_t index) const
 
 void PointData::setValueAt(const std::size_t index, const float newValue)
 {
-    const auto dataLock = lockData();
+    // Intentionally not locking here.
+   //
+   // This is a fine-grained legacy setter and is frequently used from
+   // parallel loops. Callers must ensure that the underlying point-data
+   // storage is not modified concurrently.
+   //
+   // Use lockData() / the bulk-access APIs when synchronized access is
+   // required.
 
     std::visit([index, newValue](auto& vec)
         {


### PR DESCRIPTION
## Summary

This PR restores the historical behavior of `PointData::getValueAt()` by removing its implicit locking.

The recent thread-safety work introduced internal locking on many public accessors. While this improves safety, it also unintentionally changed the synchronization semantics of a long-established API and introduced heavy lock contention in existing code.

## Motivation

A large part of the existing plugin ecosystem assumes that `getValueAt()` is a lightweight accessor.

Algorithms that iterate over millions of values—often from OpenMP parallel loops—now acquire the same mutex for every element access, resulting in excessive lock contention and blocking when structural write operations are in progress.

## Changes

- Remove implicit locking from `PointData::getValueAt()`.
- Restore the historical behavior of this legacy accessor.
- Continue protecting structural operations such as allocation, resizing, deserialization, and storage mutation.

## Notes

This PR does **not** attempt to provide complete thread safety for all `PointData` access patterns.

Instead, it restores backwards compatibility while keeping synchronization around operations that modify the underlying storage.

Longer term, callers that require synchronized bulk access should use explicit locking or dedicated bulk-access APIs rather than relying on implicit locking inside individual element accessors.