### PR TITLE
Improve Sentry crash reporting, user feedback, and developer testing

### DIFF
--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -449,6 +449,27 @@ if(${MV_USE_ERROR_LOGGING})
         
         add_dependencies(${MV_EXE} crashpad_handler)
     endif()
+
+    if(NOT APPLE)
+        set(MV_CRASH_REPORTER MV_CrashReporter)
+
+        add_executable(${MV_CRASH_REPORTER} WIN32
+            src/private/CrashReporterMain.cpp
+            src/private/CrashReportDialog.cpp
+            src/private/CrashReportDialog.h
+        )
+
+        set_target_properties(${MV_CRASH_REPORTER} PROPERTIES
+            AUTOMOC ON
+            OUTPUT_NAME "ManiVault Crash Reporter"
+        )
+
+        target_include_directories(${MV_CRASH_REPORTER} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        target_compile_features(${MV_CRASH_REPORTER} PRIVATE cxx_std_${MV_CXX_STANDARD})
+        target_link_libraries(${MV_CRASH_REPORTER} PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets ${MV_PUBLIC_LIB} sentry)
+
+        add_dependencies(${MV_EXE} ${MV_CRASH_REPORTER})
+    endif()
 endif()
 
 if(MV_ENABLE_CPPTRACE)
@@ -582,6 +603,12 @@ else()
     install(TARGETS ${MV_EXE}
         RUNTIME DESTINATION . COMPONENT MV_EXECUTABLE
     )
+
+    if(MV_USE_ERROR_LOGGING)
+        install(TARGETS ${MV_CRASH_REPORTER}
+            RUNTIME DESTINATION . COMPONENT MV_EXECUTABLE
+        )
+    endif()
 endif()
 
 # Install public headers

--- a/ManiVault/CMakeLists.txt
+++ b/ManiVault/CMakeLists.txt
@@ -457,6 +457,7 @@ if(${MV_USE_ERROR_LOGGING})
             src/private/CrashReporterMain.cpp
             src/private/CrashReportDialog.cpp
             src/private/CrashReportDialog.h
+            ${RESOURCE_FILES}
         )
 
         set_target_properties(${MV_CRASH_REPORTER} PROPERTIES

--- a/ManiVault/cmake/CMakeMvSourcesApplication.cmake
+++ b/ManiVault/cmake/CMakeMvSourcesApplication.cmake
@@ -299,6 +299,12 @@ set(PRIVATE_APPLICATION_HEADERS
     src/private/NoProxyRectanglesFusionStyle.h
 )
 
+if(WIN32)
+    list(APPEND PRIVATE_APPLICATION_HEADERS
+        src/private/DeveloperMenu.h
+    )
+endif()
+
 if(MV_USE_ERROR_LOGGING)
 	list(APPEND PRIVATE_APPLICATION_HEADERS
 		src/private/SentryErrorLogger.h
@@ -317,6 +323,12 @@ set(PRIVATE_APPLICATION_SOURCES
     src/private/HelpMenu.cpp
     src/private/NoProxyRectanglesFusionStyle.cpp
 )
+
+if(WIN32)
+    list(APPEND PRIVATE_APPLICATION_SOURCES
+        src/private/DeveloperMenu.cpp
+    )
+endif()
 
 if(MV_USE_ERROR_LOGGING)
 	list(APPEND PRIVATE_APPLICATION_SOURCES

--- a/ManiVault/cmake/CMakeMvSourcesApplication.cmake
+++ b/ManiVault/cmake/CMakeMvSourcesApplication.cmake
@@ -296,6 +296,7 @@ set(PRIVATE_APPLICATION_HEADERS
     src/private/LoadedViewsMenu.h
     src/private/ProjectsMenu.h
     src/private/HelpMenu.h
+    src/private/UserFeedbackDialog.h
     src/private/NoProxyRectanglesFusionStyle.h
 )
 
@@ -321,6 +322,7 @@ set(PRIVATE_APPLICATION_SOURCES
     src/private/LoadedViewsMenu.cpp
     src/private/ProjectsMenu.cpp
     src/private/HelpMenu.cpp
+    src/private/UserFeedbackDialog.cpp
     src/private/NoProxyRectanglesFusionStyle.cpp
 )
 

--- a/ManiVault/src/AbstractErrorLogger.h
+++ b/ManiVault/src/AbstractErrorLogger.h
@@ -11,6 +11,8 @@
 #include "CoreInterface.h"
 
 #include "util/StyledIcon.h"
+#include "util/SeverityLevel.h"
+#include "util/StackFrame.h"
 
 #include <QTimer>
 
@@ -67,6 +69,18 @@ public:
 
     /** Connects to the error logging global settings */
     virtual void initialize() = 0;
+
+    /** Reports an exception that was caught and presented to the user. */
+    virtual void reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, util::SeverityLevel severity, const util::StackTrace& stackTrace, const QString& diagnosticId = {}, const QString& where = {})
+    {
+        Q_UNUSED(title)
+        Q_UNUSED(exceptionType)
+        Q_UNUSED(reason)
+        Q_UNUSED(severity)
+        Q_UNUSED(stackTrace)
+        Q_UNUSED(diagnosticId)
+        Q_UNUSED(where)
+    }
 
     /**
      * Get the logger name

--- a/ManiVault/src/AbstractErrorLogger.h
+++ b/ManiVault/src/AbstractErrorLogger.h
@@ -67,10 +67,21 @@ public:
         _notificationTimer.start();
     }
 
-    /** Connects to the error logging global settings */
+    /**
+     * @brief Initializes the error logger and connects it to the global error-reporting settings.
+     */
     virtual void initialize() = 0;
 
-    /** Reports an exception that was caught and presented to the user. */
+    /**
+     * @brief Reports an exception that was caught and presented to the user.
+     * @param title User-facing title of the exception dialog.
+     * @param exceptionType Exception class or category name.
+     * @param reason Technical reason supplied by the exception.
+     * @param severity Severity assigned to the exception.
+     * @param stackTrace Structured stack trace captured for the exception.
+     * @param diagnosticId Identifier shown to the user for support correlation.
+     * @param where Optional source context in which the exception was handled.
+     */
     virtual void reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, util::SeverityLevel severity, const util::StackTrace& stackTrace, const QString& diagnosticId = {}, const QString& where = {})
     {
         Q_UNUSED(title)
@@ -83,6 +94,21 @@ public:
     }
 
     /**
+     * @brief Sends standalone user feedback when the logger is available.
+     * @param type Feedback category, such as a problem report or feature request.
+     * @param message User-provided feedback description.
+     * @param email Optional email address for follow-up.
+     * @return Boolean determining whether the feedback was accepted for transmission.
+     */
+    virtual bool submitUserFeedback(const QString& type, const QString& message, const QString& email)
+    {
+        Q_UNUSED(type)
+        Q_UNUSED(message)
+        Q_UNUSED(email)
+        return false;
+    }
+
+    /**
      * Get the logger name
      * @return Logger name
      */
@@ -90,7 +116,9 @@ public:
         return _loggerName;
     }
 
-    /** Starts the error logger if the pre-flight conditions are met */
+    /**
+     * @brief Starts the error logger when the user has opted in and reporting is enabled.
+     */
     void requestStart()
     {
         if (getUserHasOptedAction().isChecked() && getEnabledAction().isChecked()) {
@@ -98,7 +126,9 @@ public:
         }
     }
 
-    /** Stops the error logger if it exists */
+    /**
+     * @brief Stops the error logger and completes its shutdown procedure.
+     */
     void requestStop()
     {
         stop();
@@ -113,7 +143,7 @@ public:
     }
 
     /**
-     * Add /p notification
+     * @brief Adds or replaces a delayed user notification.
      * @param name Name of the notification
      * @param notification Notification
      */
@@ -121,7 +151,9 @@ public:
         _notifications[name] = notification;
     }
 
-    /** Begin the initialization of the error logger */
+    /**
+     * @brief Begins initialization and connects common error-reporting setting notifications.
+     */
     virtual void beginInitialization() {
         if (!mv::errors().getLoggingUserHasOptedAction().isChecked())
             return;
@@ -159,17 +191,23 @@ public:
         });
     }
 
-    /** End the initialization of the error logger */
+    /**
+     * @brief Completes initialization and marks the logger as initialized.
+     */
     virtual void endInitialization() {
         _initialized = true;
     }
 
 private:
 
-    /** Starts the error logger */
+    /**
+     * @brief Starts the concrete error-logging backend.
+     */
     virtual void start() = 0;
 
-    /** Shuts down the error logger */
+    /**
+     * @brief Shuts down the concrete error-logging backend.
+     */
     virtual void stop() = 0;
 
     /**

--- a/ManiVault/src/AbstractErrorLogger.h
+++ b/ManiVault/src/AbstractErrorLogger.h
@@ -133,13 +133,13 @@ public:
             if (toggled)
                 addNotification("ShowCrashReportDialog", {
                     QString("%1 error logging").arg(_loggerName),
-                    QString("A window will popup when a fatal error occurs in which you can give details surrounding the crash. This setting will take effect after restarting the application."),
+                    QString("A feedback window will open on the next launch after a crash. This setting will take effect after restarting the application."),
                     util::StyledIcon("bug")
                 });
             else
                 addNotification("ShowCrashReportDialog", {
                     QString("%1 error logging").arg(_loggerName),
-                    QString("You will not be asked for details surrounding a crash, a report will be sent automatically to the Sentry server. This setting will take effect after restarting the application."),
+                    QString("You will not be asked for optional feedback after a crash. Technical crash reporting remains controlled by the error logging setting. This setting will take effect after restarting the application."),
                     util::StyledIcon("bug")
                 });
         });

--- a/ManiVault/src/AbstractErrorManager.h
+++ b/ManiVault/src/AbstractErrorManager.h
@@ -7,6 +7,7 @@
 #include "AbstractManager.h"
 
 #include "util/StackFrame.h"
+#include "util/SeverityLevel.h"
 
 #include "actions/ToggleAction.h"
 #include "actions/StringAction.h"
@@ -83,6 +84,18 @@ public:
         return {};
     }
 
+    /** Reports a caught exception to the active error logger, when available. */
+    virtual void reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, util::SeverityLevel severity, const util::StackTrace& stackTrace, const QString& diagnosticId = {}, const QString& where = {})
+    {
+        Q_UNUSED(title)
+        Q_UNUSED(exceptionType)
+        Q_UNUSED(reason)
+        Q_UNUSED(severity)
+        Q_UNUSED(stackTrace)
+        Q_UNUSED(diagnosticId)
+        Q_UNUSED(where)
+    }
+
 protected:
 
     /**
@@ -109,6 +122,7 @@ public: // Const action getters
     virtual const gui::ToggleAction& getLoggingUserHasOptedAction()  const { return const_cast<AbstractErrorManager*>(this)->getLoggingUserHasOptedAction(); };                     /** Get action for user has opted */
     virtual const gui::ToggleAction& getLoggingEnabledAction()  const { return const_cast<AbstractErrorManager*>(this)->getLoggingEnabledAction(); };                               /** Get action for logging enabled */
     virtual const gui::StringAction& getLoggingDsnAction()  const { return const_cast<AbstractErrorManager*>(this)->getLoggingDsnAction(); };                                       /** Get action for logging data source name (DSN) */
+    virtual const gui::ToggleAction& getLoggingReportHandledExceptionsAction() const { return const_cast<AbstractErrorManager*>(this)->getLoggingReportHandledExceptionsAction(); } /** Get action for reporting handled exceptions */
     virtual const gui::ToggleAction& getLoggingShowCrashReportDialogAction()  const { return const_cast<AbstractErrorManager*>(this)->getLoggingShowCrashReportDialogAction(); };   /** Get action for showing a crash report dialog when the application fails */
 
 protected: // Non-const action getters
@@ -117,6 +131,7 @@ protected: // Non-const action getters
     virtual gui::ToggleAction& getLoggingUserHasOptedAction() = 0;              /** Get action for user has opted */
     virtual gui::ToggleAction& getLoggingEnabledAction() = 0;                   /** Get action for logging enabled */
     virtual gui::StringAction& getLoggingDsnAction() = 0;                       /** Get action for logging data source name (DSN) */
+    virtual gui::ToggleAction& getLoggingReportHandledExceptionsAction() = 0;   /** Get action for reporting handled exceptions */
     virtual gui::ToggleAction& getLoggingShowCrashReportDialogAction() = 0;     /** Get action for showing a crash report dialog when the application fails */
 
 private:

--- a/ManiVault/src/AbstractErrorManager.h
+++ b/ManiVault/src/AbstractErrorManager.h
@@ -84,7 +84,7 @@ public:
         return {};
     }
 
-    /** Reports a caught exception to the active error logger, when available. */
+    /** Reports an eligible caught exception to the active error logger, when available. */
     virtual void reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, util::SeverityLevel severity, const util::StackTrace& stackTrace, const QString& diagnosticId = {}, const QString& where = {})
     {
         Q_UNUSED(title)

--- a/ManiVault/src/AbstractErrorManager.h
+++ b/ManiVault/src/AbstractErrorManager.h
@@ -45,7 +45,9 @@ public:
     {
     }
 
-    /** Show the error logging consent dialog */
+    /**
+     * @brief Shows the error-reporting consent dialog.
+     */
     virtual void showErrorLoggingConsentDialog() = 0;
 
     /**
@@ -84,7 +86,16 @@ public:
         return {};
     }
 
-    /** Reports an eligible caught exception to the active error logger, when available. */
+    /**
+     * @brief Reports an eligible caught exception to the active error logger.
+     * @param title User-facing title of the exception dialog.
+     * @param exceptionType Exception class or category name.
+     * @param reason Technical reason supplied by the exception.
+     * @param severity Severity assigned to the exception.
+     * @param stackTrace Structured stack trace captured for the exception.
+     * @param diagnosticId Identifier shown to the user for support correlation.
+     * @param where Optional source context in which the exception was handled.
+     */
     virtual void reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, util::SeverityLevel severity, const util::StackTrace& stackTrace, const QString& diagnosticId = {}, const QString& where = {})
     {
         Q_UNUSED(title)
@@ -94,6 +105,21 @@ public:
         Q_UNUSED(stackTrace)
         Q_UNUSED(diagnosticId)
         Q_UNUSED(where)
+    }
+
+    /**
+     * @brief Sends a standalone problem report or feature request to the active error logger.
+     * @param type Feedback category, such as a problem report or feature request.
+     * @param message User-provided feedback description.
+     * @param email Optional email address for follow-up.
+     * @return Boolean determining whether the feedback was accepted for transmission.
+     */
+    virtual bool submitUserFeedback(const QString& type, const QString& message, const QString& email)
+    {
+        Q_UNUSED(type)
+        Q_UNUSED(message)
+        Q_UNUSED(email)
+        return false;
     }
 
 protected:

--- a/ManiVault/src/ErrorLoggingSettingsAction.cpp
+++ b/ManiVault/src/ErrorLoggingSettingsAction.cpp
@@ -34,6 +34,11 @@ const gui::StringAction& ErrorLoggingSettingsAction::getDsnAction() const
     return mv::errors().getLoggingDsnAction();
 }
 
+const gui::ToggleAction& ErrorLoggingSettingsAction::getReportHandledExceptionsAction() const
+{
+    return mv::errors().getLoggingReportHandledExceptionsAction();
+}
+
 const gui::ToggleAction& ErrorLoggingSettingsAction::getShowCrashReportDialogAction() const
 {
     return mv::errors().getLoggingShowCrashReportDialogAction();

--- a/ManiVault/src/ErrorLoggingSettingsAction.h
+++ b/ManiVault/src/ErrorLoggingSettingsAction.h
@@ -36,6 +36,7 @@ public: // Action getters
     const gui::ToggleAction& getUserHasOptedAction() const;                 /** Get action for user has opted */  
     const gui::ToggleAction& getEnabledAction() const;                      /** Get action for logging enabled */
     const gui::StringAction& getDsnAction() const;                          /** Get action for logging data source name (DSN) */
+    const gui::ToggleAction& getReportHandledExceptionsAction() const;      /** Get action for reporting handled exceptions */
     const gui::ToggleAction& getShowCrashReportDialogAction() const;        /** Get action for showing a crash report dialog when the application fails */
 };
 

--- a/ManiVault/src/ErrorLoggingSettingsAction.h
+++ b/ManiVault/src/ErrorLoggingSettingsAction.h
@@ -32,12 +32,41 @@ public:
 
 public: // Action getters
 
-    const gui::TriggerAction& getLoggingAskConsentDialogAction() const;     /** Get action for asking the user for consent to log errors */
-    const gui::ToggleAction& getUserHasOptedAction() const;                 /** Get action for user has opted */  
-    const gui::ToggleAction& getEnabledAction() const;                      /** Get action for logging enabled */
-    const gui::StringAction& getDsnAction() const;                          /** Get action for logging data source name (DSN) */
-    const gui::ToggleAction& getReportHandledExceptionsAction() const;      /** Get action for reporting handled exceptions */
-    const gui::ToggleAction& getShowCrashReportDialogAction() const;        /** Get action for showing a crash report dialog when the application fails */
+    /**
+     * @brief Gets the action that opens the error-reporting consent dialog.
+     * @return Consent-dialog trigger action.
+     */
+    const gui::TriggerAction& getLoggingAskConsentDialogAction() const;
+
+    /**
+     * @brief Gets the action that stores whether the user opted into reporting.
+     * @return User consent toggle action.
+     */
+    const gui::ToggleAction& getUserHasOptedAction() const;
+
+    /**
+     * @brief Gets the action that enables or disables error reporting.
+     * @return Error-reporting enabled toggle action.
+     */
+    const gui::ToggleAction& getEnabledAction() const;
+
+    /**
+     * @brief Gets the configured Sentry Data Source Name action.
+     * @return Sentry DSN string action.
+     */
+    const gui::StringAction& getDsnAction() const;
+
+    /**
+     * @brief Gets the action controlling handled-exception reporting.
+     * @return Handled-exception reporting toggle action.
+     */
+    const gui::ToggleAction& getReportHandledExceptionsAction() const;
+
+    /**
+     * @brief Gets the action controlling whether crash feedback is requested.
+     * @return Crash-feedback dialog toggle action.
+     */
+    const gui::ToggleAction& getShowCrashReportDialogAction() const;
 };
 
 }

--- a/ManiVault/src/models/AbstractProjectsModel.cpp
+++ b/ManiVault/src/models/AbstractProjectsModel.cpp
@@ -191,7 +191,6 @@ void AbstractProjectsModel::addProject(ProjectsModelProjectSharedPtr project, co
         {
             updateTags();
 
-            project->setParent(this);
             project->updateMetadata();
 
             if (parentIndex.isValid()) {
@@ -280,7 +279,7 @@ void AbstractProjectsModel::addDsn(const QUrl& dsn)
                     if (watcher->future().isCanceled() || watcher->future().isFinished() == false)
                         throw std::runtime_error("Future is cancelled or did not finish");
 
-                    QMetaObject::invokeMethod(qApp, [this, future, data, dsnIndex, dsn]() {
+                    QMetaObject::invokeMethod(this, [this, future, data, dsnIndex, dsn]() {
                         purge();
                         populateFromJsonByteArray(data, dsnIndex, dsn.toString());
                     });

--- a/ManiVault/src/models/ProjectsModelProject.cpp
+++ b/ManiVault/src/models/ProjectsModelProject.cpp
@@ -353,7 +353,7 @@ void ProjectsModelProject::determineDownloadSize()
             if (watcher->future().isCanceled() || watcher->future().isFinished() == false)
                 throw std::runtime_error("Future is cancelled or did not finish");
 
-            QMetaObject::invokeMethod(qApp, [this, future]() {
+            QMetaObject::invokeMethod(this, [this, future]() {
                 _serverDownloadSize = future.result();
 
                 emit downloadSizeDetermined(_serverDownloadSize);
@@ -398,7 +398,7 @@ void ProjectsModelProject::determineLastModified()
             if (watcher->future().isCanceled() || watcher->future().isFinished() == false)
                 throw std::runtime_error("Future is cancelled or did not finish");
 
-            QMetaObject::invokeMethod(qApp, [this, future]() {
+            QMetaObject::invokeMethod(this, [this, future]() {
                 _serverLastModified = future.result();
 
                 emit lastModifiedDetermined(_serverLastModified);

--- a/ManiVault/src/private/CrashReportDialog.cpp
+++ b/ManiVault/src/private/CrashReportDialog.cpp
@@ -6,8 +6,12 @@
 
 #include <util/StyledIcon.h>
 
+#include <QApplication>
+#include <QClipboard>
+#include <QPainter>
 #include <QRegularExpression>
 #include <QRegularExpressionValidator>
+#include <QTimer>
 
 #ifdef _DEBUG
     #define CRASH_REPORT_DIALOG_VERBOSE
@@ -15,17 +19,44 @@
 
 using namespace mv::util;
 
-QIcon CrashReportDialog::windowIcon         = QIcon();
-QIcon CrashReportDialog::frownIcon          = QIcon();
-QIcon CrashReportDialog::exclamationIcon    = QIcon();
+namespace
+{
+    QIcon createStandaloneFontAwesomeIcon(const QString& iconName)
+    {
+        QPixmap pixmap(64, 64);
 
-CrashReportDialog::CrashReportDialog(QWidget* parent):
+        pixmap.fill(Qt::transparent);
+
+        QPainter painter(&pixmap);
+
+        painter.setRenderHint(QPainter::Antialiasing);
+        painter.setPen(QApplication::palette().color(QPalette::WindowText));
+        painter.setFont(StyledIcon::getIconFont(42));
+        painter.drawText(pixmap.rect(), Qt::AlignCenter, StyledIcon::getIconCharacter(iconName));
+
+        return QIcon(pixmap);
+    }
+}
+
+QIcon CrashReportDialog::windowIcon         = QIcon();
+QIcon CrashReportDialog::exclamationIcon    = QIcon();
+QIcon CrashReportDialog::copyIcon           = QIcon();
+QIcon CrashReportDialog::checkIcon          = QIcon();
+
+CrashReportDialog::CrashReportDialog(const QString& eventId, QWidget* parent):
     QDialog(parent),
-    _notificationLabel("ManiVault Studio closed unexpectedly during its previous run. A technical crash report was recorded because error reporting is enabled. You can optionally help us improve by providing some information about what happened.\n"),
+    _notificationLabel("ManiVault Studio closed unexpectedly. Because error reporting is enabled, the technical crash report has already been sent automatically. You can optionally help us improve by providing information about what happened.\n"),
     _feedbackLabel("What were you doing before ManiVault Studio closed?"),
     _contactLabel("\nYour email (optional):"),
+    _privacyLabel("Crash data is processed according to the <a href=\"https://sentry.io/privacy/\">Sentry privacy policy</a>."),
+    _eventIdTitleLabel("Crash event ID:"),
+    _eventIdLabel(eventId),
     _sendButton("Submit feedback"),
-    _cancelButton("Not now")
+    _restartButton("Restart ManiVault Studio"),
+    _cancelButton("Close"),
+    _submitFeedback(false),
+    _restartApplication(false),
+    _eventId(eventId)
 {
     setWindowTitle("Crash report");
     setWindowModality(Qt::ApplicationModal);
@@ -34,15 +65,9 @@ CrashReportDialog::CrashReportDialog(QWidget* parent):
     setWindowFlag(Qt::WindowStaysOnTopHint);
     setWindowIcon(windowIcon);
 
-    _notificationIcon.setPixmap(frownIcon.pixmap(QSize(32, 32)));
-    _notificationIcon.setAlignment(Qt::AlignTop);
-
     _notificationLabel.setWordWrap(true);
 
-    _notificationLayout.addWidget(&_notificationIcon);
-    _notificationLayout.addWidget(&_notificationLabel, 1);
-
-    _layout.addLayout(&_notificationLayout);
+    _layout.addWidget(&_notificationLabel);
 
     _layout.addWidget(&_feedbackLabel);
 
@@ -52,7 +77,7 @@ CrashReportDialog::CrashReportDialog(QWidget* parent):
 
     _layout.addWidget(&_contactLabel);
 
-    QRegularExpression emailRegularExpression("\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}\\b", QRegularExpression::CaseInsensitiveOption);
+    QRegularExpression emailRegularExpression("\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,63}\\b", QRegularExpression::CaseInsensitiveOption);
 
     _contactLineEdit.setValidator(new QRegularExpressionValidator(emailRegularExpression, this));
     _contactLineEdit.setPlaceholderText("Enter your email if you'd like us to follow up...");
@@ -67,34 +92,100 @@ CrashReportDialog::CrashReportDialog(QWidget* parent):
         } else {
             _trailingAction.setVisible(false);
         }
+
+        updateSubmitButton();
     });
+
+    connect(&_feedbackTextEdit, &QPlainTextEdit::textChanged, this, &CrashReportDialog::updateSubmitButton);
 
     _layout.addWidget(&_contactLineEdit);
 
+    _privacyLabel.setOpenExternalLinks(true);
+    _privacyLabel.setTextInteractionFlags(Qt::TextBrowserInteraction);
+
+    auto eventIdTitleFont = _eventIdTitleLabel.font();
+
+    eventIdTitleFont.setWeight(QFont::DemiBold);
+    _eventIdTitleLabel.setFont(eventIdTitleFont);
+
+    _eventIdLabel.setTextFormat(Qt::PlainText);
+    _eventIdLabel.setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+    _eventIdSeparator.setFrameShape(QFrame::VLine);
+    _eventIdSeparator.setFrameShadow(QFrame::Sunken);
+
+    _copyEventIdButton.setIcon(copyIcon);
+    _copyEventIdButton.setAutoRaise(true);
+    _copyEventIdButton.setToolTip("Copy crash event ID");
+
+    _eventIdLayout.setContentsMargins(0, 0, 0, 0);
+    _eventIdLayout.addWidget(&_eventIdTitleLabel);
+    _eventIdLayout.addWidget(&_eventIdLabel);
+    _eventIdLayout.addStretch(1);
+    _eventIdLayout.addWidget(&_eventIdSeparator);
+    _eventIdLayout.addWidget(&_copyEventIdButton);
+
+    _layout.addWidget(&_privacyLabel);
+    _layout.addLayout(&_eventIdLayout);
+
     _buttonsLayout.addStretch(1);
     _buttonsLayout.addWidget(&_sendButton);
+    _buttonsLayout.addWidget(&_restartButton);
     _buttonsLayout.addWidget(&_cancelButton);
 
     _layout.addLayout(&_buttonsLayout);
 
     setLayout(&_layout);
 
-    connect(&_sendButton, &QPushButton::clicked, this, &CrashReportDialog::accept);
+    updateSubmitButton();
+
+    connect(&_sendButton, &QPushButton::clicked, this, [this] {
+        _submitFeedback = true;
+        accept();
+    });
+
+    connect(&_restartButton, &QPushButton::clicked, this, [this] {
+        _submitFeedback = _sendButton.isEnabled();
+        _restartApplication = true;
+        accept();
+    });
+
+    connect(&_copyEventIdButton, &QToolButton::clicked, this, [this] {
+        QApplication::clipboard()->setText(_eventId);
+        _copyEventIdButton.setIcon(checkIcon);
+        _copyEventIdButton.setToolTip("Copied");
+
+        QTimer::singleShot(2000, this, [this] {
+            _copyEventIdButton.setIcon(copyIcon);
+            _copyEventIdButton.setToolTip("Copy crash event ID");
+        });
+    });
+
     connect(&_cancelButton, &QPushButton::clicked, this, &CrashReportDialog::reject);
 }
 
 CrashReportDialog::CrashUserInfo CrashReportDialog::getCrashUserInfo() const
 {
     return {
-        result() == DialogCode::Accepted,
+        _submitFeedback,
+        _restartApplication,
         _feedbackTextEdit.toPlainText(),
-        _contactLineEdit.text()
+        _contactLineEdit.hasAcceptableInput() ? _contactLineEdit.text() : QString()
     };
+}
+
+void CrashReportDialog::updateSubmitButton()
+{
+    const auto hasFeedback = !_feedbackTextEdit.toPlainText().trimmed().isEmpty();
+    const auto hasValidEmail = !_contactLineEdit.text().trimmed().isEmpty() && _contactLineEdit.hasAcceptableInput();
+
+    _sendButton.setEnabled(hasFeedback || hasValidEmail);
 }
 
 void CrashReportDialog::initialize()
 {
-    windowIcon      = StyledIcon("bug");
-    frownIcon       = StyledIcon("frown");
-    exclamationIcon = StyledIcon("exclamation");
+    windowIcon      = createStandaloneFontAwesomeIcon("bug");
+    exclamationIcon = createStandaloneFontAwesomeIcon("exclamation");
+    copyIcon        = createStandaloneFontAwesomeIcon("copy");
+    checkIcon       = createStandaloneFontAwesomeIcon("check");
 }

--- a/ManiVault/src/private/CrashReportDialog.cpp
+++ b/ManiVault/src/private/CrashReportDialog.cpp
@@ -4,15 +4,15 @@
 
 #include "CrashReportDialog.h"
 
-#include <CoreInterface.h>
+#include <util/StyledIcon.h>
 
-#include <Application.h>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 
 #ifdef _DEBUG
     #define CRASH_REPORT_DIALOG_VERBOSE
 #endif
 
-using namespace mv;
 using namespace mv::util;
 
 QIcon CrashReportDialog::windowIcon         = QIcon();
@@ -21,11 +21,11 @@ QIcon CrashReportDialog::exclamationIcon    = QIcon();
 
 CrashReportDialog::CrashReportDialog(QWidget* parent):
     QDialog(parent),
-    _notificationLabel("ManiVault Studio has encountered an error and needs to close. Please help us improve by providing some information about what happened.\n"),
-    _feedbackLabel("What were you doing when the crash occurred?"),
+    _notificationLabel("ManiVault Studio closed unexpectedly during its previous run. A technical crash report was recorded because error reporting is enabled. You can optionally help us improve by providing some information about what happened.\n"),
+    _feedbackLabel("What were you doing before ManiVault Studio closed?"),
     _contactLabel("\nYour email (optional):"),
-    _sendButton("Send report"),
-    _cancelButton("Cancel")
+    _sendButton("Submit feedback"),
+    _cancelButton("Not now")
 {
     setWindowTitle("Crash report");
     setWindowModality(Qt::ApplicationModal);
@@ -46,7 +46,7 @@ CrashReportDialog::CrashReportDialog(QWidget* parent):
 
     _layout.addWidget(&_feedbackLabel);
 
-    _feedbackTextEdit.setPlaceholderText("Describe the steps leading to the crash...");
+    _feedbackTextEdit.setPlaceholderText("Describe the steps leading up to the crash...");
 
     _layout.addWidget(&_feedbackTextEdit);
 
@@ -71,7 +71,6 @@ CrashReportDialog::CrashReportDialog(QWidget* parent):
 
     _layout.addWidget(&_contactLineEdit);
 
-    _buttonsLayout.addWidget(const_cast<gui::ToggleAction&>(mv::settings().getErrorLoggingSettingsAction().getShowCrashReportDialogAction()).createWidget(this));
     _buttonsLayout.addStretch(1);
     _buttonsLayout.addWidget(&_sendButton);
     _buttonsLayout.addWidget(&_cancelButton);

--- a/ManiVault/src/private/CrashReportDialog.h
+++ b/ManiVault/src/private/CrashReportDialog.h
@@ -27,7 +27,9 @@ class CrashReportDialog : public QDialog
 
 public:
 
-    /** Crash user-supplied additional information */
+    /**
+     * @brief Stores the choices and optional information supplied by the user.
+     */
     struct CrashUserInfo
     {
         bool        _submitFeedback;    /** Whether the user chose to submit optional feedback */
@@ -39,32 +41,43 @@ public:
 public:
 
     /**
-     * Construct with pointer to \p parent widget
+     * @brief Constructs a crash feedback dialog for a reported Sentry event.
+     * @param eventId Sentry event identifier associated with the crash.
      * @param parent Pointer to parent widget (maybe nullptr)
      */
     explicit CrashReportDialog(const QString& eventId, QWidget* parent = nullptr);
 
-    /** Get preferred size */
+    /**
+     * @brief Gets the preferred dialog size.
+     * @return Preferred dialog size in device-independent pixels.
+     */
     QSize sizeHint() const override {
         return { 640, 480 };
     }
 
-    /** Get minimum size hint*/
+    /**
+     * @brief Gets the minimum dialog size.
+     * @return Minimum dialog size in device-independent pixels.
+     */
     QSize minimumSizeHint() const override {
         return sizeHint();
     }
 
     /**
-     * Get crash info provided by the user
-     * @return Crash info
+     * @brief Gets the crash information and actions selected by the user.
+     * @return User-supplied crash information.
      */
     CrashUserInfo getCrashUserInfo() const;
 
-    /** For initializing icons etc. */
+    /**
+     * @brief Initializes the standalone Font Awesome icons used by the dialog.
+     */
     static void initialize();
 
 private:
-    /** Updates feedback submission availability from the current input. */
+    /**
+     * @brief Updates feedback submission availability from the current input.
+     */
     void updateSubmitButton();
 
 private:

--- a/ManiVault/src/private/CrashReportDialog.h
+++ b/ManiVault/src/private/CrashReportDialog.h
@@ -5,9 +5,11 @@
 #pragma once
 
 #include <QDialog>
+#include <QFrame>
 #include <QLineEdit>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QToolButton>
 #include <QVBoxLayout>
 #include <QLabel>
 #include <QAction>
@@ -29,6 +31,7 @@ public:
     struct CrashUserInfo
     {
         bool        _submitFeedback;    /** Whether the user chose to submit optional feedback */
+        bool        _restartApplication;/** Whether the user chose to restart ManiVault Studio */
         QString     _feedback;          /** Feedback on the crash */
         QString     _contactDetails;    /** Contact details of the issuer */
     };
@@ -39,7 +42,7 @@ public:
      * Construct with pointer to \p parent widget
      * @param parent Pointer to parent widget (maybe nullptr)
      */
-    explicit CrashReportDialog(QWidget* parent = nullptr);
+    explicit CrashReportDialog(const QString& eventId, QWidget* parent = nullptr);
 
     /** Get preferred size */
     QSize sizeHint() const override {
@@ -61,20 +64,33 @@ public:
     static void initialize();
 
 private:
+    /** Updates feedback submission availability from the current input. */
+    void updateSubmitButton();
+
+private:
     QVBoxLayout     _layout;                /** Main layout */
-    QHBoxLayout     _notificationLayout;    /** Notification layout */
-    QLabel          _notificationIcon;      /** Notification icon */
     QLabel          _notificationLabel;     /** Notification label */
     QLabel          _feedbackLabel;         /** Feedback label */
     QLabel          _contactLabel;          /** Contact label */
+    QLabel          _privacyLabel;          /** Link to the Sentry privacy policy */
+    QLabel          _eventIdTitleLabel;     /** Crash event identifier title */
+    QLabel          _eventIdLabel;          /** Crash event identifier */
     QPlainTextEdit  _feedbackTextEdit;      /** Feedback text multi line input */
     QLineEdit       _contactLineEdit;       /** Issuer contact details single line text input */
+    QHBoxLayout     _eventIdLayout;          /** Crash event identifier and copy action layout */
+    QFrame          _eventIdSeparator;       /** Separator before the copy action */
+    QToolButton     _copyEventIdButton;      /** Copies the crash event identifier */
     QHBoxLayout     _buttonsLayout;         /** Bottom buttons layout */
     QPushButton     _sendButton;            /** Sends the crash report when triggered  */
+    QPushButton     _restartButton;         /** Restarts ManiVault Studio */
     QPushButton     _cancelButton;          /** Cancels the dialog when triggered */
     QAction         _trailingAction;        /** Action at the end of the contact line input */
+    bool            _submitFeedback;        /** Whether optional feedback should be submitted */
+    bool            _restartApplication;    /** Whether ManiVault Studio should be restarted */
+    QString         _eventId;                /** Crash event identifier */
 
     static QIcon    windowIcon;         /** Window bug icon */
-    static QIcon    frownIcon;          /** Frown icon */
     static QIcon    exclamationIcon;    /** Exclamation icon */
+    static QIcon    copyIcon;           /** Copy-to-clipboard icon */
+    static QIcon    checkIcon;          /** Successful-copy icon */
 };

--- a/ManiVault/src/private/CrashReportDialog.h
+++ b/ManiVault/src/private/CrashReportDialog.h
@@ -28,7 +28,7 @@ public:
     /** Crash user-supplied additional information */
     struct CrashUserInfo
     {
-        bool        _sendReport;        /** Boolean determining whether to send a crash report or not */
+        bool        _submitFeedback;    /** Whether the user chose to submit optional feedback */
         QString     _feedback;          /** Feedback on the crash */
         QString     _contactDetails;    /** Contact details of the issuer */
     };

--- a/ManiVault/src/private/CrashReporterMain.cpp
+++ b/ManiVault/src/private/CrashReporterMain.cpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// A corresponding LICENSE file is located in the root directory of this source tree
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft)
+
+#include "CrashReportDialog.h"
+
+#include "sentry.h"
+
+#include <QApplication>
+#include <QFile>
+
+#include <cstdlib>
+
+namespace {
+
+sentry_envelope_t* readEnvelope(const QString& path)
+{
+#ifdef Q_OS_WIN
+    return sentry_envelope_read_from_filew(
+        reinterpret_cast<const wchar_t*>(path.utf16()));
+#else
+    return sentry_envelope_read_from_file(path.toUtf8().constData());
+#endif
+}
+
+}
+
+int main(int argc, char* argv[])
+{
+    QApplication application(argc, argv);
+
+    if (application.arguments().size() != 2)
+        return EXIT_FAILURE;
+
+    const auto envelopePath = application.arguments().at(1);
+    auto* envelope          = readEnvelope(envelopePath);
+
+    if (!envelope)
+        return EXIT_FAILURE;
+
+    const auto dsnValue     = sentry_envelope_get_header(envelope, "dsn");
+    const auto eventIdValue = sentry_envelope_get_header(envelope, "event_id");
+    const auto dsn          = QByteArray(sentry_value_as_string(dsnValue));
+    const auto eventId      = QByteArray(sentry_value_as_string(eventIdValue));
+
+    if (dsn.isEmpty() || eventId.isEmpty()) {
+        sentry_envelope_free(envelope);
+        return EXIT_FAILURE;
+    }
+
+    auto* options = sentry_options_new();
+
+    sentry_options_set_backend(options, nullptr);
+    sentry_options_set_dsn(options, dsn.constData());
+
+    if (sentry_init(options) != 0) {
+        sentry_envelope_free(envelope);
+        return EXIT_FAILURE;
+    }
+
+    // The user already opted in to technical crash reporting. Submit the
+    // envelope independently of whether they provide additional feedback.
+    sentry_capture_envelope(envelope);
+
+    CrashReportDialog crashReportDialog;
+
+    if (crashReportDialog.exec() == QDialog::Accepted) {
+        const auto crashUserInfo = crashReportDialog.getCrashUserInfo();
+        const auto feedback      = crashUserInfo._feedback.toUtf8();
+        const auto contactInfo   = crashUserInfo._contactDetails.toUtf8();
+        const auto eventUuid     = sentry_uuid_from_string(eventId.constData());
+
+        sentry_capture_feedback(sentry_value_new_feedback(
+            feedback.isEmpty() ? "No additional details were provided." : feedback.constData(),
+            contactInfo.isEmpty() ? nullptr : contactInfo.constData(),
+            nullptr,
+            &eventUuid));
+    }
+
+    sentry_close();
+    QFile::remove(envelopePath);
+
+    return EXIT_SUCCESS;
+}

--- a/ManiVault/src/private/CrashReporterMain.cpp
+++ b/ManiVault/src/private/CrashReporterMain.cpp
@@ -7,7 +7,12 @@
 #include "sentry.h"
 
 #include <QApplication>
+#include <QDir>
 #include <QFile>
+#include <QIcon>
+#include <QProcess>
+#include <QStandardPaths>
+#include <QStyleFactory>
 
 #include <cstdlib>
 
@@ -29,6 +34,12 @@ int main(int argc, char* argv[])
 {
     QApplication application(argc, argv);
 
+    QApplication::setApplicationName("ManiVault Crash Reporter");
+    QApplication::setApplicationDisplayName("ManiVault Crash Reporter");
+    QApplication::setStyle(QStyleFactory::create("Fusion"));
+    QApplication::setWindowIcon(QIcon(":/Icons/AppIcon256"));
+    CrashReportDialog::initialize();
+
     if (application.arguments().size() != 2)
         return EXIT_FAILURE;
 
@@ -49,9 +60,12 @@ int main(int argc, char* argv[])
     }
 
     auto* options = sentry_options_new();
+    const auto sentryDatabasePath = QDir(QStandardPaths::writableLocation(QStandardPaths::CacheLocation)).filePath("Sentry");
 
     sentry_options_set_backend(options, nullptr);
     sentry_options_set_dsn(options, dsn.constData());
+    sentry_options_set_database_path(options, sentryDatabasePath.toUtf8());
+    sentry_options_set_shutdown_timeout(options, 5000);
 
     if (sentry_init(options) != 0) {
         sentry_envelope_free(envelope);
@@ -62,23 +76,35 @@ int main(int argc, char* argv[])
     // envelope independently of whether they provide additional feedback.
     sentry_capture_envelope(envelope);
 
-    CrashReportDialog crashReportDialog;
+    CrashReportDialog crashReportDialog(QString::fromUtf8(eventId));
+    CrashReportDialog::CrashUserInfo crashUserInfo{};
 
     if (crashReportDialog.exec() == QDialog::Accepted) {
-        const auto crashUserInfo = crashReportDialog.getCrashUserInfo();
+        crashUserInfo             = crashReportDialog.getCrashUserInfo();
         const auto feedback      = crashUserInfo._feedback.toUtf8();
         const auto contactInfo   = crashUserInfo._contactDetails.toUtf8();
         const auto eventUuid     = sentry_uuid_from_string(eventId.constData());
 
-        sentry_capture_feedback(sentry_value_new_feedback(
-            feedback.isEmpty() ? "No additional details were provided." : feedback.constData(),
-            contactInfo.isEmpty() ? nullptr : contactInfo.constData(),
-            nullptr,
-            &eventUuid));
+        if (crashUserInfo._submitFeedback) {
+            // Feedback association requires the referenced event to have
+            // reached Sentry first. Flush the previously queued crash envelope
+            // before adding its feedback to the transport queue.
+            sentry_flush(5000);
+            sentry_capture_feedback(sentry_value_new_feedback(feedback.isEmpty() ? "Contact information supplied without additional feedback." : feedback.constData(), contactInfo.isEmpty() ? nullptr : contactInfo.constData(), nullptr, &eventUuid));
+        }
     }
 
     sentry_close();
     QFile::remove(envelopePath);
+
+    if (crashUserInfo._restartApplication) {
+#ifdef Q_OS_WIN
+        const auto applicationExecutable = "ManiVault Studio.exe";
+#else
+        const auto applicationExecutable = "ManiVault Studio";
+#endif
+        QProcess::startDetached(QDir(QCoreApplication::applicationDirPath()).filePath(applicationExecutable), {});
+    }
 
     return EXIT_SUCCESS;
 }

--- a/ManiVault/src/private/DeveloperMenu.cpp
+++ b/ManiVault/src/private/DeveloperMenu.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// A corresponding LICENSE file is located in the root directory of this source tree
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft)
+
+#include "DeveloperMenu.h"
+#include "ParallelPhantomTestSuite.h"
+
+#include <CoreInterface.h>
+#include <exception/ManiVaultException.h>
+#include <util/Exception.h>
+#include <util/StyledIcon.h>
+
+#include <QDir>
+#include <QMessageBox>
+
+#include <cstdlib>
+
+using namespace mv;
+
+DeveloperMenu::DeveloperMenu(QWidget* parent /*= nullptr*/) :
+    QMenu(parent)
+{
+    setTitle("Dev");
+    setToolTip("Development and integration test tools");
+
+    auto workflowTestingMenu = addMenu(util::StyledIcon("diagram-project"), tr("Workflow testing"));
+
+    workflowTestingMenu->setToolTip(tr("Run parallel workflow test scenarios"));
+
+    detail::ParallelPhantomTestSuite::populateMenu(*workflowTestingMenu, parentWidget());
+
+    auto errorReportingMenu = addMenu(util::StyledIcon("bug"), tr("Error reporting testing"));
+    auto handledExceptionAction = errorReportingMenu->addAction(util::StyledIcon("triangle-exclamation"), tr("Handled exception"));
+
+    handledExceptionAction->setToolTip(tr("Create a safe handled exception and show the normal exception dialog"));
+
+    connect(handledExceptionAction, &QAction::triggered, this, [this] {
+        testHandledException();
+    });
+
+#ifdef MV_USE_ERROR_LOGGING
+    auto fatalCrashAction = errorReportingMenu->addAction(util::StyledIcon("skull-crossbones"), tr("Fatal crash..."));
+
+    fatalCrashAction->setToolTip(tr("Deliberately crash ManiVault Studio to test Crashpad and crash feedback"));
+
+    connect(fatalCrashAction, &QAction::triggered, this, [this] {
+        testFatalCrash();
+    });
+#endif
+}
+
+void DeveloperMenu::testHandledException()
+{
+    try {
+        const auto technicalReason = QString("Simulated handled exception containing privacy test values: home=%1, temp=%2, email=test.user@example.com, url=https://test-user:test-password@example.com/private.").arg(QDir::homePath(), QDir::tempPath());
+
+        throw ManiVaultException(util::SeverityLevel::Error, tr("This is a simulated handled exception. The application can continue normally."), technicalReason, QString("Handled exception simulator at %1").arg(QDir::homePath()), { { "test_only", true } });
+    } catch (const ManiVaultException& exception) {
+        util::exceptionMessageBox(tr("Handled exception reporting test"), exception, parentWidget());
+    }
+}
+
+void DeveloperMenu::testFatalCrash()
+{
+#ifdef MV_USE_ERROR_LOGGING
+    const auto& errorManager = mv::errors();
+
+    if (!errorManager.getLoggingUserHasOptedAction().isChecked() || !errorManager.getLoggingEnabledAction().isChecked()) {
+        QMessageBox::information(parentWidget(), tr("Crash reporting test"), tr("Sentry error reporting must be enabled before running the crash reporting test."));
+        return;
+    }
+
+    QMessageBox confirmationDialog(parentWidget());
+
+    confirmationDialog.setWindowIcon(util::StyledIcon("bug"));
+    confirmationDialog.setWindowTitle(tr("Crash reporting test"));
+    confirmationDialog.setText(tr("This test will deliberately crash ManiVault Studio. Any unsaved work will be lost.\n\nImmediately after the crash, a separate crash feedback dialog should appear. Continue?"));
+    confirmationDialog.setIcon(QMessageBox::Warning);
+    confirmationDialog.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
+    confirmationDialog.setDefaultButton(QMessageBox::Cancel);
+
+    if (confirmationDialog.exec() == QMessageBox::Yes)
+        std::abort();
+#endif
+}

--- a/ManiVault/src/private/DeveloperMenu.h
+++ b/ManiVault/src/private/DeveloperMenu.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// A corresponding LICENSE file is located in the root directory of this source tree
+// Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft)
+
+#pragma once
+
+#include <QMenu>
+
+/** Menu containing development and integration test tools. */
+class DeveloperMenu : public QMenu
+{
+public:
+    /** Constructs the developer menu with an optional parent widget. */
+    DeveloperMenu(QWidget* parent = nullptr);
+
+private:
+    /** Runs the safe handled-exception reporting test. */
+    void testHandledException();
+
+    /** Runs the destructive fatal-crash reporting test after confirmation. */
+    void testFatalCrash();
+};

--- a/ManiVault/src/private/ErrorLoggingConsentDialog.h
+++ b/ManiVault/src/private/ErrorLoggingConsentDialog.h
@@ -26,8 +26,8 @@ class ErrorLoggingConsentDialog : public QDialog
 public:
 
     /**
-     * Construct with pointer to \p parent widget
-     * @param parent Pointer to parent widget (maybe nullptr)
+     * @brief Constructs the error-reporting consent dialog.
+     * @param parent Pointer to the parent widget (maybe nullptr).
      */
     explicit ErrorLoggingConsentDialog(QWidget* parent = nullptr);
 

--- a/ManiVault/src/private/ErrorManager.cpp
+++ b/ManiVault/src/private/ErrorManager.cpp
@@ -48,8 +48,13 @@ ErrorManager::ErrorManager(QObject* parent) :
 //#endif
     
     _loggingDsnAction.setSettingsPrefix(QString("%1Logging/DSN").arg(getSettingsPrefix()));
-    _loggingDsnAction.setToolTip("The Sentry error logging data source name");
-    _loggingDsnAction.getValidator().setRegularExpression(QRegularExpression(R"(^https?://[a-f0-9]{32}@[a-z0-9\.-]+(:\d+)?/[\d]+$)"));
+    _loggingDsnAction.setToolTip("The Sentry Data Source Name (DSN). Hosted and self-hosted HTTP(S) DSNs with optional ports and path prefixes are supported.");
+
+    // Current Sentry DSNs do not require a 32-character hexadecimal public
+    // key or a numeric project identifier. Keep this structural validator in
+    // line with sentry-native: scheme, public key, optional secret, host and
+    // optional port/path prefix, followed by a non-empty project identifier.
+    _loggingDsnAction.getValidator().setRegularExpression(QRegularExpression(R"(^https?://[A-Z0-9._~%-]+(?::[A-Z0-9._~%-]+)?@(?:\[[0-9A-F:.]+\]|[A-Z0-9.-]+)(?::[0-9]{1,5})?/(?:[A-Z0-9._~!$&'()*+,;=:@%-]+/)*[A-Z0-9._~!$&'()*+,;=:@%-]+/?$)", QRegularExpression::CaseInsensitiveOption));
 
     _loggingReportHandledExceptionsAction.setSettingsPrefix(QString("%1Logging/ReportHandledExceptions").arg(getSettingsPrefix()));
     _loggingReportHandledExceptionsAction.setToolTip("Send handled error- and fatal-level exceptions shown in an exception dialog to Sentry. Informational and warning-level exceptions remain local.");

--- a/ManiVault/src/private/ErrorManager.cpp
+++ b/ManiVault/src/private/ErrorManager.cpp
@@ -203,4 +203,12 @@ void ErrorManager::reportHandledException(const QString& title, const QString& e
         errorLogger->reportHandledException(title, exceptionType, reason, severity, stackTrace, diagnosticId, where);
 }
 
+bool ErrorManager::submitUserFeedback(const QString& type, const QString& message, const QString& email)
+{
+    if (auto* errorLogger = getErrorLogger())
+        return errorLogger->submitUserFeedback(type, message, email);
+
+    return false;
+}
+
 }

--- a/ManiVault/src/private/ErrorManager.cpp
+++ b/ManiVault/src/private/ErrorManager.cpp
@@ -52,7 +52,7 @@ ErrorManager::ErrorManager(QObject* parent) :
     _loggingDsnAction.getValidator().setRegularExpression(QRegularExpression(R"(^https?://[a-f0-9]{32}@[a-z0-9\.-]+(:\d+)?/[\d]+$)"));
 
     _loggingReportHandledExceptionsAction.setSettingsPrefix(QString("%1Logging/ReportHandledExceptions").arg(getSettingsPrefix()));
-    _loggingReportHandledExceptionsAction.setToolTip("Send non-fatal exceptions that the application catches and shows in an exception dialog to Sentry");
+    _loggingReportHandledExceptionsAction.setToolTip("Send handled error- and fatal-level exceptions shown in an exception dialog to Sentry. Informational and warning-level exceptions remain local.");
 
     _loggingShowCrashReportDialogAction.setSettingsPrefix(QString("%1Logging/ShowCrashReportDialog").arg(getSettingsPrefix()));
     _loggingShowCrashReportDialogAction.setToolTip("Ask for optional feedback on the next launch after a crash");
@@ -183,6 +183,16 @@ void ErrorManager::reportHandledException(const QString& title, const QString& e
 {
     if (!getLoggingReportHandledExceptionsAction().isChecked())
         return;
+
+    switch (severity) {
+        case util::SeverityLevel::Info:
+        case util::SeverityLevel::Warning:
+            return;
+
+        case util::SeverityLevel::Error:
+        case util::SeverityLevel::Fatal:
+            break;
+    }
 
     if (auto* errorLogger = getErrorLogger())
         errorLogger->reportHandledException(title, exceptionType, reason, severity, stackTrace, diagnosticId, where);

--- a/ManiVault/src/private/ErrorManager.cpp
+++ b/ManiVault/src/private/ErrorManager.cpp
@@ -119,7 +119,7 @@ void ErrorManager::reset()
 
 void ErrorManager::showErrorLoggingConsentDialog()
 {
-#ifdef MV_ERROR_LOGGING
+#ifdef MV_USE_ERROR_LOGGING
     ErrorLoggingConsentDialog errorLoggingConsentDialog;
     errorLoggingConsentDialog.exec();
 #endif

--- a/ManiVault/src/private/ErrorManager.cpp
+++ b/ManiVault/src/private/ErrorManager.cpp
@@ -119,7 +119,7 @@ void ErrorManager::reset()
 
 void ErrorManager::showErrorLoggingConsentDialog()
 {
-#ifdef ERROR_LOGGING
+#ifdef MV_ERROR_LOGGING
     ErrorLoggingConsentDialog errorLoggingConsentDialog;
     errorLoggingConsentDialog.exec();
 #endif

--- a/ManiVault/src/private/ErrorManager.cpp
+++ b/ManiVault/src/private/ErrorManager.cpp
@@ -4,6 +4,7 @@
 
 #include "ErrorManager.h"
 #include "ErrorLoggingConsentDialog.h"
+#include "AbstractErrorLogger.h"
 
 #include <QRegularExpression>
 
@@ -30,6 +31,7 @@ ErrorManager::ErrorManager(QObject* parent) :
     _loggingUserHasOptedAction(this, "User has opted", false),
     _loggingEnabledAction(this, "Toggle error reporting", false),
     _loggingDsnAction(this, "Sentry DSN", "https://211289c773dcc267b1bb536b6c3a23f7@lkebsentry.nl/2"),
+    _loggingReportHandledExceptionsAction(this, "Report handled exceptions", false),
     _loggingShowCrashReportDialogAction(this, "Ask for feedback after a crash", true)
 {
     _loggingAskConsentDialogAction.setToolTip("Show the error logging consent dialog");
@@ -49,11 +51,15 @@ ErrorManager::ErrorManager(QObject* parent) :
     _loggingDsnAction.setToolTip("The Sentry error logging data source name");
     _loggingDsnAction.getValidator().setRegularExpression(QRegularExpression(R"(^https?://[a-f0-9]{32}@[a-z0-9\.-]+(:\d+)?/[\d]+$)"));
 
+    _loggingReportHandledExceptionsAction.setSettingsPrefix(QString("%1Logging/ReportHandledExceptions").arg(getSettingsPrefix()));
+    _loggingReportHandledExceptionsAction.setToolTip("Send non-fatal exceptions that the application catches and shows in an exception dialog to Sentry");
+
     _loggingShowCrashReportDialogAction.setSettingsPrefix(QString("%1Logging/ShowCrashReportDialog").arg(getSettingsPrefix()));
     _loggingShowCrashReportDialogAction.setToolTip("Ask for optional feedback on the next launch after a crash");
 
     const auto allowErrorReportingChanged = [this]() -> void {
         _loggingShowCrashReportDialogAction.setEnabled(_loggingEnabledAction.isChecked());
+        _loggingReportHandledExceptionsAction.setEnabled(_loggingEnabledAction.isChecked());
         _loggingDsnAction.setEnabled(_loggingEnabledAction.isChecked());
     };
 
@@ -85,6 +91,7 @@ void ErrorManager::initialize()
         errorLoggingSettingsAction.addAction(&getLoggingAskConsentDialogAction());
         errorLoggingSettingsAction.addAction(&getLoggingEnabledAction());
         errorLoggingSettingsAction.addAction(&getLoggingDsnAction());
+        errorLoggingSettingsAction.addAction(&getLoggingReportHandledExceptionsAction());
         errorLoggingSettingsAction.addAction(&getLoggingShowCrashReportDialogAction());
 
 #ifdef MV_USE_ERROR_LOGGING
@@ -170,6 +177,15 @@ util::StackTrace ErrorManager::getDebugStackTrace() const
 #endif
 
     return stackTrace;
+}
+
+void ErrorManager::reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, util::SeverityLevel severity, const util::StackTrace& stackTrace, const QString& diagnosticId, const QString& where)
+{
+    if (!getLoggingReportHandledExceptionsAction().isChecked())
+        return;
+
+    if (auto* errorLogger = getErrorLogger())
+        errorLogger->reportHandledException(title, exceptionType, reason, severity, stackTrace, diagnosticId, where);
 }
 
 }

--- a/ManiVault/src/private/ErrorManager.cpp
+++ b/ManiVault/src/private/ErrorManager.cpp
@@ -30,7 +30,7 @@ ErrorManager::ErrorManager(QObject* parent) :
     _loggingUserHasOptedAction(this, "User has opted", false),
     _loggingEnabledAction(this, "Toggle error reporting", false),
     _loggingDsnAction(this, "Sentry DSN", "https://211289c773dcc267b1bb536b6c3a23f7@lkebsentry.nl/2"),
-    _loggingShowCrashReportDialogAction(this, "Show crash report dialog", true)
+    _loggingShowCrashReportDialogAction(this, "Ask for feedback after a crash", true)
 {
     _loggingAskConsentDialogAction.setToolTip("Show the error logging consent dialog");
     _loggingAskConsentDialogAction.setDefaultWidgetFlags(TriggerAction::IconText);
@@ -50,7 +50,7 @@ ErrorManager::ErrorManager(QObject* parent) :
     _loggingDsnAction.getValidator().setRegularExpression(QRegularExpression(R"(^https?://[a-f0-9]{32}@[a-z0-9\.-]+(:\d+)?/[\d]+$)"));
 
     _loggingShowCrashReportDialogAction.setSettingsPrefix(QString("%1Logging/ShowCrashReportDialog").arg(getSettingsPrefix()));
-    _loggingShowCrashReportDialogAction.setToolTip("Show the crash report dialog prior to sending an error report");
+    _loggingShowCrashReportDialogAction.setToolTip("Ask for optional feedback on the next launch after a crash");
 
     const auto allowErrorReportingChanged = [this]() -> void {
         _loggingShowCrashReportDialogAction.setEnabled(_loggingEnabledAction.isChecked());

--- a/ManiVault/src/private/ErrorManager.h
+++ b/ManiVault/src/private/ErrorManager.h
@@ -9,6 +9,14 @@
 namespace mv
 {
 
+/**
+ * @brief Manages application error handling and the configured reporting backend.
+ *
+ * Owns the global error-reporting settings, initializes the active logger and
+ * forwards handled exceptions and standalone feedback when reporting is allowed.
+ *
+ * @author Thomas Kroes
+ */
 class ErrorManager : public mv::AbstractErrorManager
 {
     Q_OBJECT
@@ -21,16 +29,24 @@ public:
      */
     ErrorManager(QObject* parent);
 
-    /** Resets the manager when destructed. */
+    /**
+     * @brief Shuts down error reporting and destroys the manager.
+     */
     ~ErrorManager() override;
 
-    /** Performs error manager startup initialization. */
+    /**
+     * @brief Initializes settings, consent handling and the configured logger.
+     */
     void initialize() override;
 
-    /** Resets the contents of the error manager. */
+    /**
+     * @brief Stops the configured logger and resets the manager.
+     */
     void reset() override;
 
-    /** Shows the error logging consent dialog. */
+    /**
+     * @brief Shows the error-reporting consent dialog.
+     */
     void showErrorLoggingConsentDialog() override;
 
     /**
@@ -64,8 +80,26 @@ public:
      */
     util::StackTrace getDebugStackTrace() const override;
 
-    /** Forwards a caught exception to the configured error logger. */
-    void reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, util::SeverityLevel severity, const util::StackTrace& stackTrace, const QString& diagnosticId = {},const QString& where = {}) override;
+    /**
+     * @brief Forwards a caught exception to the configured error logger.
+     * @param title User-facing title of the exception dialog.
+     * @param exceptionType Exception class or category name.
+     * @param reason Technical reason supplied by the exception.
+     * @param severity Severity assigned to the exception.
+     * @param stackTrace Structured stack trace captured for the exception.
+     * @param diagnosticId Identifier shown to the user for support correlation.
+     * @param where Optional source context in which the exception was handled.
+     */
+    void reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, util::SeverityLevel severity, const util::StackTrace& stackTrace, const QString& diagnosticId = {}, const QString& where = {}) override;
+
+    /**
+     * @brief Forwards standalone user feedback to the configured error logger.
+     * @param type Feedback category, such as a problem report or feature request.
+     * @param message User-provided feedback description.
+     * @param email Optional email address for follow-up.
+     * @return Boolean determining whether the feedback was accepted for transmission.
+     */
+    bool submitUserFeedback(const QString& type, const QString& message, const QString& email) override;
 
 public: // Action getters
 

--- a/ManiVault/src/private/ErrorManager.h
+++ b/ManiVault/src/private/ErrorManager.h
@@ -64,12 +64,16 @@ public:
      */
     util::StackTrace getDebugStackTrace() const override;
 
+    /** Forwards a caught exception to the configured error logger. */
+    void reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, util::SeverityLevel severity, const util::StackTrace& stackTrace, const QString& diagnosticId = {},const QString& where = {}) override;
+
 public: // Action getters
 
     gui::TriggerAction& getLoggingAskConsentDialogAction() override { return _loggingAskConsentDialogAction; }              /**< Returns the action for asking error logging consent */
     gui::ToggleAction& getLoggingUserHasOptedAction() override  { return _loggingUserHasOptedAction; }                      /**< Returns the action tracking whether the user has opted in */
     gui::ToggleAction& getLoggingEnabledAction() override { return _loggingEnabledAction; }                                 /**< Returns the action for enabling error logging */
     gui::StringAction& getLoggingDsnAction() override { return _loggingDsnAction; }                                         /**< Returns the error logging data source name action */
+    gui::ToggleAction& getLoggingReportHandledExceptionsAction() override { return _loggingReportHandledExceptionsAction; } /**< Returns the action for reporting handled exceptions */
     gui::ToggleAction& getLoggingShowCrashReportDialogAction() override { return _loggingShowCrashReportDialogAction; }     /**< Returns the crash report dialog toggle action */
 
 private:
@@ -78,6 +82,7 @@ private:
     gui::ToggleAction   _loggingUserHasOptedAction;             /**< Tracks whether the user has opted in or out */
     gui::ToggleAction   _loggingEnabledAction;                  /**< Toggles error logging on or off */
     gui::StringAction   _loggingDsnAction;                      /**< Error logging data source name action */
+    gui::ToggleAction   _loggingReportHandledExceptionsAction;  /**< Toggles reporting of handled exceptions */
     gui::ToggleAction   _loggingShowCrashReportDialogAction;    /**< Toggles crash report dialog visibility */
 };
 

--- a/ManiVault/src/private/HelpManager.cpp
+++ b/ManiVault/src/private/HelpManager.cpp
@@ -248,8 +248,18 @@ void HelpManager::addNotificationLinkHandler(const QString& route, const Notific
 void HelpManager::handleNotificationLink(const QUrl& url)
 {
     qDebug() << "Handling notification link with URL:" << url;
-    if (url.scheme() != "app")
+
+    if (url.scheme() == "http" || url.scheme() == "https") {
+        if (!QDesktopServices::openUrl(url))
+            qWarning() << "Unable to open external notification link:" << url;
+
         return;
+    }
+
+    if (url.scheme() != "app") {
+        qWarning() << "Ignoring notification link with unsupported URL scheme:" << url;
+        return;
+    }
 
     const QString route = url.host() + url.path();
     // app://open/reporting -> "open/reporting"

--- a/ManiVault/src/private/HelpMenu.cpp
+++ b/ManiVault/src/private/HelpMenu.cpp
@@ -55,7 +55,9 @@ void HelpMenu::populate()
     
     addAction(&mv::help().getShowLearningCenterPageAction());
     addAction(&_devDocAction);
+#ifdef MV_USE_ERROR_LOGGING
     addAction(&_sendFeedbackAction);
+#endif
     addSeparator();
     
     QVector<QPointer<TriggerAction>> actions;
@@ -98,7 +100,9 @@ void HelpMenu::populate()
         QDesktopServices::openUrl(QUrl("https://github.com/ManiVaultStudio/PublicWiki", QUrl::TolerantMode));
     });
 
+#ifdef MV_USE_ERROR_LOGGING
     connect(&_sendFeedbackAction, &TriggerAction::triggered, this, &HelpMenu::sendFeedback, Qt::UniqueConnection);
+#endif
     connect(&_aboutAction, &TriggerAction::triggered, this, &HelpMenu::about);
     connect(&_aboutThirdPartiesAction, &TriggerAction::triggered, this, &HelpMenu::aboutThirdParties);
 

--- a/ManiVault/src/private/HelpMenu.cpp
+++ b/ManiVault/src/private/HelpMenu.cpp
@@ -5,6 +5,7 @@
 #include "HelpMenu.h"
 #include "PluginManager.h"
 #include "CoreInterface.h"
+#include "UserFeedbackDialog.h"
 
 #include <util/Miscellaneous.h>
 #include <actions/TriggerAction.h>
@@ -22,6 +23,7 @@ using namespace mv::plugin;
 HelpMenu::HelpMenu(QWidget* parent /*= nullptr*/) :
     QMenu(parent),
     _devDocAction(nullptr, "Developer Documentation"),
+    _sendFeedbackAction(nullptr, "Send feedback..."),
     _aboutAction(nullptr, QString("About %1").arg(Application::getBaseName())),
     _aboutQtAction(nullptr, "About Qt"),
     _aboutThirdPartiesAction(nullptr, "About third-parties"),
@@ -34,6 +36,7 @@ HelpMenu::HelpMenu(QWidget* parent /*= nullptr*/) :
     _aboutQtAction.setMenuRole(QAction::NoRole);
 
     _releaseNotesAction.setIconByName("scroll");
+    _sendFeedbackAction.setIconByName("comment-dots");
 
     populate();
 }
@@ -52,6 +55,7 @@ void HelpMenu::populate()
     
     addAction(&mv::help().getShowLearningCenterPageAction());
     addAction(&_devDocAction);
+    addAction(&_sendFeedbackAction);
     addSeparator();
     
     QVector<QPointer<TriggerAction>> actions;
@@ -94,6 +98,7 @@ void HelpMenu::populate()
         QDesktopServices::openUrl(QUrl("https://github.com/ManiVaultStudio/PublicWiki", QUrl::TolerantMode));
     });
 
+    connect(&_sendFeedbackAction, &TriggerAction::triggered, this, &HelpMenu::sendFeedback, Qt::UniqueConnection);
     connect(&_aboutAction, &TriggerAction::triggered, this, &HelpMenu::about);
     connect(&_aboutThirdPartiesAction, &TriggerAction::triggered, this, &HelpMenu::aboutThirdParties);
 
@@ -106,6 +111,14 @@ void HelpMenu::populate()
 
         QDesktopServices::openUrl(QUrl("https://github.com/ManiVaultStudio/core/releases/", QUrl::TolerantMode));
     });
+}
+
+void HelpMenu::sendFeedback()
+{
+    auto feedbackDialog = new UserFeedbackDialog(this->parentWidget());
+
+    feedbackDialog->setAttribute(Qt::WA_DeleteOnClose);
+    feedbackDialog->open();
 }
 
 void HelpMenu::about() const

--- a/ManiVault/src/private/HelpMenu.h
+++ b/ManiVault/src/private/HelpMenu.h
@@ -37,6 +37,11 @@ public:
 
 private slots:
 
+    /**
+     * @brief Opens the standalone problem-report and feature-request dialog.
+     */
+    void sendFeedback();
+
     /** Display ManiVault About Messagebox
      * Invoked when trigger _aboutAction is clicked in the help menu
      */
@@ -56,6 +61,7 @@ private:
 
 private:
     mv::gui::TriggerAction  _devDocAction;              /** Menu entry for ManiVault About Messagebox */
+    mv::gui::TriggerAction  _sendFeedbackAction;        /** Opens the problem and feature-request feedback dialog */
     mv::gui::TriggerAction  _aboutAction;               /** Menu entry for ManiVault About Messagebox */
     mv::gui::TriggerAction  _aboutQtAction;             /** Menu entry for Qt About Messagebox */
     mv::gui::TriggerAction  _aboutThirdPartiesAction;   /** Menu entry for Third Party About Messagebox */

--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -21,6 +21,8 @@
 #include <actions/ToggleAction.h>
 #include <actions/PluginStatusBarAction.h>
 
+#include <util/StyledIcon.h>
+
 #include "FrontPagesStatusBarAction.h"
 #include "ManiVaultVersionStatusBarAction.h"
 #include "PluginsStatusBarAction.h"
@@ -189,7 +191,7 @@ void MainWindow::initialize()
 
 #ifdef MV_USE_ERROR_LOGGING
     // Deliberately undiscoverable in the UI: this exercises the complete
-    // Crashpad and next-launch crash-feedback path for development/testing.
+    // Crashpad and external crash-feedback path for development/testing.
     auto crashReportingTestShortcut = new QShortcut(QKeySequence(Qt::ControlModifier | Qt::AltModifier | Qt::ShiftModifier | Qt::Key_C), this);
 
     crashReportingTestShortcut->setContext(Qt::ApplicationShortcut);
@@ -204,12 +206,19 @@ void MainWindow::initialize()
             return;
         }
 
-        const auto response = QMessageBox::warning(this,
-            tr("Crash reporting test"),
-            tr("This test will deliberately crash ManiVault Studio. Any unsaved work will be lost.\n\n"
-               "After restarting, the crash feedback dialog should appear. Continue?"),
-            QMessageBox::Yes | QMessageBox::Cancel,
-            QMessageBox::Cancel);
+        QMessageBox confirmationDialog(this);
+
+        confirmationDialog.setWindowTitle(tr("Crash reporting test"));
+        confirmationDialog.setText(tr("This test will deliberately crash ManiVault Studio. Any unsaved work will be lost.\n\n"
+                                      "Immediately after the crash, a separate crash feedback dialog should appear. Continue?"));
+        const QIcon bugIcon = mv::util::StyledIcon("bug");
+
+        confirmationDialog.setWindowIcon(bugIcon);
+        confirmationDialog.setIcon(QMessageBox::Warning);
+        confirmationDialog.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
+        confirmationDialog.setDefaultButton(QMessageBox::Cancel);
+
+        const auto response = confirmationDialog.exec();
 
         if (response == QMessageBox::Yes)
             std::abort();

--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -11,7 +11,10 @@
 #include "ViewMenu.h"
 #include "ProjectsMenu.h"
 #include "HelpMenu.h"
-#include "ParallelPhantomTestSuite.h"
+
+#ifdef Q_OS_WIN
+    #include "DeveloperMenu.h"
+#endif
 
 #include <Application.h>
 #include <CoreInterface.h>
@@ -20,10 +23,6 @@
 
 #include <actions/ToggleAction.h>
 #include <actions/PluginStatusBarAction.h>
-
-#include <util/StyledIcon.h>
-#include <util/Exception.h>
-#include <exception/ManiVaultException.h>
 
 #include "FrontPagesStatusBarAction.h"
 #include "ManiVaultVersionStatusBarAction.h"
@@ -34,7 +33,6 @@
 #include "WorkspaceStatusBarAction.h"
 
 #include <QDebug>
-#include <QDir>
 #include <QMessageBox>
 #include <QScreen>
 #include <QMenuBar>
@@ -44,8 +42,6 @@
 #include <QStatusBar>
 #include <QRandomGenerator>
 #include <QShortcut>
-
-#include <cstdlib>
 
 #ifdef _DEBUG
     #define MAIN_WINDOW_VERBOSE
@@ -184,82 +180,27 @@ void MainWindow::initialize()
         Application::current()->getConfigurationAction().getConfigureAction().trigger();
     });
 
-    auto parallelPhantomTestShortcut = new QShortcut(QKeySequence(Qt::ControlModifier | Qt::AltModifier | Qt::ShiftModifier | Qt::Key_P), this);
-
-    parallelPhantomTestShortcut->setContext(Qt::ApplicationShortcut);
-
-    connect(parallelPhantomTestShortcut, &QShortcut::activated, this, [this] {
-        mv::detail::ParallelPhantomTestSuite::showMenu(this);
-    });
-
-#ifdef MV_USE_ERROR_LOGGING
-    // Deliberately undiscoverable in the UI: this exercises handled-exception
-    // reporting or the complete Crashpad and external crash-feedback path.
-    auto crashReportingTestShortcut = new QShortcut(QKeySequence(Qt::ControlModifier | Qt::AltModifier | Qt::ShiftModifier | Qt::Key_C), this);
-
-    crashReportingTestShortcut->setContext(Qt::ApplicationShortcut);
-
-    connect(crashReportingTestShortcut, &QShortcut::activated, this, [this] {
-        const auto& errorManager = mv::errors();
-        const QIcon bugIcon = mv::util::StyledIcon("bug");
-        QMessageBox testTypeDialog(this);
-
-        testTypeDialog.setWindowIcon(bugIcon);
-        testTypeDialog.setWindowTitle(tr("Error reporting test"));
-        testTypeDialog.setText(tr("Choose which error-reporting path to test.\n\n"
-                                  "A handled exception is safe and keeps the application running. It is sent to Sentry only when handled-exception reporting is enabled.\n\n"
-                                  "A fatal crash closes the application and may cause unsaved work to be lost."));
-        testTypeDialog.setIcon(QMessageBox::Information);
-
-        auto handledExceptionButton = testTypeDialog.addButton(tr("Handled exception"), QMessageBox::ActionRole);
-        auto fatalCrashButton        = testTypeDialog.addButton(tr("Fatal crash"), QMessageBox::DestructiveRole);
-
-        testTypeDialog.addButton(QMessageBox::Cancel);
-        testTypeDialog.exec();
-
-        if (testTypeDialog.clickedButton() == handledExceptionButton) {
-            try {
-                const auto technicalReason = QString("Simulated handled exception containing privacy test values: home=%1, temp=%2, email=test.user@example.com, url=https://test-user:test-password@example.com/private.").arg(QDir::homePath(), QDir::tempPath());
-
-                throw ManiVaultException(util::SeverityLevel::Error, tr("This is a simulated handled exception. The application can continue normally."), technicalReason, QString("Handled exception simulator at %1").arg(QDir::homePath()), { { "test_only", true } });
-            } catch (const ManiVaultException& exception) {
-                util::exceptionMessageBox(tr("Handled exception reporting test"), exception, this);
-            }
-
-            return;
-        }
-
-        if (testTypeDialog.clickedButton() != fatalCrashButton)
-            return;
-
-        if (!errorManager.getLoggingUserHasOptedAction().isChecked() || !errorManager.getLoggingEnabledAction().isChecked()) {
-            QMessageBox::information(this,
-                tr("Crash reporting test"),
-                tr("Sentry error reporting must be enabled before running the crash reporting test."));
-            return;
-        }
-
-        QMessageBox confirmationDialog(this);
-
-        confirmationDialog.setWindowTitle(tr("Crash reporting test"));
-        confirmationDialog.setText(tr("This test will deliberately crash ManiVault Studio. Any unsaved work will be lost.\n\n"
-                                      "Immediately after the crash, a separate crash feedback dialog should appear. Continue?"));
-        confirmationDialog.setWindowIcon(bugIcon);
-        confirmationDialog.setIcon(QMessageBox::Warning);
-        confirmationDialog.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
-        confirmationDialog.setDefaultButton(QMessageBox::Cancel);
-
-        const auto response = confirmationDialog.exec();
-
-        if (response == QMessageBox::Yes)
-            std::abort();
-    });
-#endif
-
-	auto fileMenuAction     = menuBar()->addMenu(new FileMenu());
+    auto fileMenuAction     = menuBar()->addMenu(new FileMenu());
     auto viewMenuAction     = menuBar()->addMenu(new ViewMenu());
     auto projectsMenuAction = menuBar()->addMenu(new ProjectsMenu());
+
+#ifdef Q_OS_WIN
+    auto developerMenuAction = menuBar()->addMenu(new DeveloperMenu(this));
+#endif
+
     auto helpMenuAction     = menuBar()->addMenu(new HelpMenu());
+
+#ifdef Q_OS_WIN
+    developerMenuAction->setVisible(false);
+
+    auto enableDeveloperMenuShortcut = new QShortcut(QKeySequence(Qt::ControlModifier | Qt::AltModifier | Qt::ShiftModifier | Qt::Key_D), this);
+
+    enableDeveloperMenuShortcut->setContext(Qt::ApplicationShortcut);
+
+    connect(enableDeveloperMenuShortcut, &QShortcut::activated, developerMenuAction, [developerMenuAction] {
+        developerMenuAction->setVisible(true);
+    });
+#endif
     
     loadGuiTask.setSubtaskStarted("Initializing start page");
     

--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -40,6 +40,8 @@
 #include <QRandomGenerator>
 #include <QShortcut>
 
+#include <cstdlib>
+
 #ifdef _DEBUG
     #define MAIN_WINDOW_VERBOSE
 #endif
@@ -184,6 +186,35 @@ void MainWindow::initialize()
     connect(parallelPhantomTestShortcut, &QShortcut::activated, this, [this] {
         mv::detail::ParallelPhantomTestSuite::showMenu(this);
     });
+
+#ifdef MV_USE_ERROR_LOGGING
+    // Deliberately undiscoverable in the UI: this exercises the complete
+    // Crashpad and next-launch crash-feedback path for development/testing.
+    auto crashReportingTestShortcut = new QShortcut(QKeySequence(Qt::ControlModifier | Qt::AltModifier | Qt::ShiftModifier | Qt::Key_C), this);
+
+    crashReportingTestShortcut->setContext(Qt::ApplicationShortcut);
+
+    connect(crashReportingTestShortcut, &QShortcut::activated, this, [this] {
+        const auto& errorManager = mv::errors();
+
+        if (!errorManager.getLoggingUserHasOptedAction().isChecked() || !errorManager.getLoggingEnabledAction().isChecked()) {
+            QMessageBox::information(this,
+                tr("Crash reporting test"),
+                tr("Sentry error reporting must be enabled before running the crash reporting test."));
+            return;
+        }
+
+        const auto response = QMessageBox::warning(this,
+            tr("Crash reporting test"),
+            tr("This test will deliberately crash ManiVault Studio. Any unsaved work will be lost.\n\n"
+               "After restarting, the crash feedback dialog should appear. Continue?"),
+            QMessageBox::Yes | QMessageBox::Cancel,
+            QMessageBox::Cancel);
+
+        if (response == QMessageBox::Yes)
+            std::abort();
+    });
+#endif
 
 	auto fileMenuAction     = menuBar()->addMenu(new FileMenu());
     auto viewMenuAction     = menuBar()->addMenu(new ViewMenu());

--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -22,6 +22,8 @@
 #include <actions/PluginStatusBarAction.h>
 
 #include <util/StyledIcon.h>
+#include <util/Exception.h>
+#include <exception/ManiVaultException.h>
 
 #include "FrontPagesStatusBarAction.h"
 #include "ManiVaultVersionStatusBarAction.h"
@@ -32,6 +34,7 @@
 #include "WorkspaceStatusBarAction.h"
 
 #include <QDebug>
+#include <QDir>
 #include <QMessageBox>
 #include <QScreen>
 #include <QMenuBar>
@@ -190,14 +193,44 @@ void MainWindow::initialize()
     });
 
 #ifdef MV_USE_ERROR_LOGGING
-    // Deliberately undiscoverable in the UI: this exercises the complete
-    // Crashpad and external crash-feedback path for development/testing.
+    // Deliberately undiscoverable in the UI: this exercises handled-exception
+    // reporting or the complete Crashpad and external crash-feedback path.
     auto crashReportingTestShortcut = new QShortcut(QKeySequence(Qt::ControlModifier | Qt::AltModifier | Qt::ShiftModifier | Qt::Key_C), this);
 
     crashReportingTestShortcut->setContext(Qt::ApplicationShortcut);
 
     connect(crashReportingTestShortcut, &QShortcut::activated, this, [this] {
         const auto& errorManager = mv::errors();
+        const QIcon bugIcon = mv::util::StyledIcon("bug");
+        QMessageBox testTypeDialog(this);
+
+        testTypeDialog.setWindowIcon(bugIcon);
+        testTypeDialog.setWindowTitle(tr("Error reporting test"));
+        testTypeDialog.setText(tr("Choose which error-reporting path to test.\n\n"
+                                  "A handled exception is safe and keeps the application running. It is sent to Sentry only when handled-exception reporting is enabled.\n\n"
+                                  "A fatal crash closes the application and may cause unsaved work to be lost."));
+        testTypeDialog.setIcon(QMessageBox::Information);
+
+        auto handledExceptionButton = testTypeDialog.addButton(tr("Handled exception"), QMessageBox::ActionRole);
+        auto fatalCrashButton        = testTypeDialog.addButton(tr("Fatal crash"), QMessageBox::DestructiveRole);
+
+        testTypeDialog.addButton(QMessageBox::Cancel);
+        testTypeDialog.exec();
+
+        if (testTypeDialog.clickedButton() == handledExceptionButton) {
+            try {
+                const auto technicalReason = QString("Simulated handled exception containing privacy test values: home=%1, temp=%2, email=test.user@example.com, url=https://test-user:test-password@example.com/private.").arg(QDir::homePath(), QDir::tempPath());
+
+                throw ManiVaultException(util::SeverityLevel::Error, tr("This is a simulated handled exception. The application can continue normally."), technicalReason, QString("Handled exception simulator at %1").arg(QDir::homePath()), { { "test_only", true } });
+            } catch (const ManiVaultException& exception) {
+                util::exceptionMessageBox(tr("Handled exception reporting test"), exception, this);
+            }
+
+            return;
+        }
+
+        if (testTypeDialog.clickedButton() != fatalCrashButton)
+            return;
 
         if (!errorManager.getLoggingUserHasOptedAction().isChecked() || !errorManager.getLoggingEnabledAction().isChecked()) {
             QMessageBox::information(this,
@@ -211,8 +244,6 @@ void MainWindow::initialize()
         confirmationDialog.setWindowTitle(tr("Crash reporting test"));
         confirmationDialog.setText(tr("This test will deliberately crash ManiVault Studio. Any unsaved work will be lost.\n\n"
                                       "Immediately after the crash, a separate crash feedback dialog should appear. Continue?"));
-        const QIcon bugIcon = mv::util::StyledIcon("bug");
-
         confirmationDialog.setWindowIcon(bugIcon);
         confirmationDialog.setIcon(QMessageBox::Warning);
         confirmationDialog.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);

--- a/ManiVault/src/private/ParallelPhantomTestSuite.cpp
+++ b/ManiVault/src/private/ParallelPhantomTestSuite.cpp
@@ -19,7 +19,6 @@
 
 #include <QCoreApplication>
 #include <QAction>
-#include <QCursor>
 #include <QMenu>
 #include <QMetaObject>
 #include <QPointer>
@@ -1061,40 +1060,30 @@ void ParallelPhantomTestSuite::run(QObject* owner)
     runScenarios(owner, makeScenarios(), true);
 }
 
-void ParallelPhantomTestSuite::showMenu(QWidget* parent)
+void ParallelPhantomTestSuite::populateMenu(QMenu& menu, QObject* owner)
 {
     auto scenarios = makeScenarios();
-    QMenu menu(parent);
+    menu.clear();
 
-    menu.setTitle("Parallel Phantom Tests");
+    auto runAllAction = menu.addAction(util::StyledIcon("forward-fast"), "Run all scenarios sequentially");
 
-    auto runAllAction = menu.addAction("Run all scenarios sequentially");
+    QObject::connect(runAllAction, &QAction::triggered, owner, [owner] {
+        run(owner);
+    });
 
-    runAllAction->setData(-1);
     menu.addSeparator();
 
-    auto singleScenarioMenu = menu.addMenu("Run single scenario");
+    auto singleScenarioMenu = menu.addMenu(util::StyledIcon("list-check"), "Run single scenario");
 
     for (auto scenarioIndex = std::size_t{ 0 }; scenarioIndex < scenarios.size(); ++scenarioIndex) {
-        auto action = singleScenarioMenu->addAction(scenarios[scenarioIndex].name);
+        auto action = singleScenarioMenu->addAction(util::StyledIcon("play"), scenarios[scenarioIndex].name);
 
-        action->setData(static_cast<int>(scenarioIndex));
         action->setToolTip(scenarios[scenarioIndex].description);
+
+        QObject::connect(action, &QAction::triggered, owner, [owner, scenarioIndex] {
+            runScenario(owner, scenarioIndex);
+        });
     }
-
-    const auto selectedAction = menu.exec(QCursor::pos());
-
-    if (selectedAction == nullptr)
-        return;
-
-    const auto selectedIndex = selectedAction->data().toInt();
-
-    if (selectedIndex < 0) {
-        run(parent);
-        return;
-    }
-
-    runScenario(parent, static_cast<std::size_t>(selectedIndex));
 }
 
 }

--- a/ManiVault/src/private/ParallelPhantomTestSuite.h
+++ b/ManiVault/src/private/ParallelPhantomTestSuite.h
@@ -5,7 +5,7 @@
 #pragma once
 
 class QObject;
-class QWidget;
+class QMenu;
 
 namespace mv::detail
 {
@@ -25,8 +25,8 @@ public:
     /** Starts the suite if no suite run is already active. */
     static void run(QObject* owner);
 
-    /** Shows the hidden scenario picker menu. */
-    static void showMenu(QWidget* parent);
+    /** Populates a menu with the available workflow test scenarios. */
+    static void populateMenu(QMenu& menu, QObject* owner);
 
 private:
 

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -238,7 +238,7 @@ ProjectManager::ProjectManager(QObject* parent) :
 
 ProjectManager::~ProjectManager()
 {
-    //reset();
+    reset();
 }
 
 void ProjectManager::initialize()

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -60,7 +60,7 @@ ProjectManager::ProjectManager(QObject* parent) :
     _pluginManagerAction(nullptr, "Plugin Browser..."),
     _showStartPageAction(nullptr, "Start Page...", true),
     _backToProjectAction(nullptr, "Back to project"),
-    _projectsListModel(StandardItemModel::PopulationMode::AutomaticSynchronous, this)
+    _projectsListModel(StandardItemModel::PopulationMode::AutomaticSynchronous)
 {
     //_newBlankProjectAction.setShortcut(QKeySequence("Ctrl+B"));
     //_newBlankProjectAction.setShortcutContext(Qt::ApplicationShortcut);
@@ -238,7 +238,7 @@ ProjectManager::ProjectManager(QObject* parent) :
 
 ProjectManager::~ProjectManager()
 {
-    reset();
+    //reset();
 }
 
 void ProjectManager::initialize()

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -10,6 +10,7 @@
 #include <QOperatingSystemVersion>
 #include <QCoreApplication>
 #include <QDir>
+#include <QFileInfo>
 #include <QStandardPaths>
 
 using namespace mv;
@@ -106,8 +107,23 @@ void SentryErrorLogger::start()
 #else
         const auto crashReporterExecutable = "ManiVault Crash Reporter";
 #endif
-        sentry_options_set_external_crash_reporter_path(options,
-            QDir(QCoreApplication::applicationDirPath()).filePath(crashReporterExecutable).toUtf8());
+        const auto crashReporterPath = QDir(QCoreApplication::applicationDirPath()).filePath(crashReporterExecutable);
+        const auto crashReporterInfo = QFileInfo(crashReporterPath);
+
+        if (crashReporterInfo.exists() && crashReporterInfo.isFile()) {
+            sentry_options_set_external_crash_reporter_path(options, crashReporterPath.toUtf8());
+        } else {
+            qWarning() << "Cannot enable Sentry crash feedback: the external crash reporter was not found at" << crashReporterPath
+                       << "Technical crash reports will still be sent automatically.";
+
+            addNotification("CrashReporterUnavailable", {
+                "Crash feedback unavailable",
+                QString("The crash feedback application could not be found at <code>%1</code>. Technical crash reports will still be sent automatically, but you will not be asked for optional feedback after a crash.")
+                    .arg(crashReporterPath.toHtmlEscaped()),
+                StyledIcon("triangle-exclamation"),
+                5000
+            });
+        }
     }
 
     const auto releaseString = getReleaseString().toUtf8();

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -60,6 +60,11 @@ void SentryErrorLogger::initialize()
 
 void SentryErrorLogger::start()
 {
+    if (_isRunning) {
+        qDebug() << "Sentry error logging is already running";
+        return;
+    }
+
     if (!getUserHasOptedAction().isChecked() || !getEnabledAction().isChecked()) {
         return;
     }
@@ -139,9 +144,19 @@ void SentryErrorLogger::start()
 #endif
 
     if (sentry_init(options) != 0) {
-        qDebug() << "Sentry error logging is not running";
+        qWarning() << "Cannot start Sentry: SDK initialization failed";
+
+        addNotification("InitializationFailed", {
+            "Sentry error logging disabled",
+            "Sentry could not initialize. Error and crash reports will not be sent during this session. See the application log for technical details.",
+            StyledIcon("triangle-exclamation"),
+            5000
+        });
+
         return;
     }
+
+    _isRunning = true;
 
     qDebug() << "Sentry error logging is running, crash reports will send to: " + dsn;
 
@@ -168,7 +183,11 @@ void SentryErrorLogger::start()
 
 void SentryErrorLogger::stop()
 {
+    if (!_isRunning)
+        return;
+
     sentry_close();
+    _isRunning = false;
 }
 
 QString SentryErrorLogger::getReleaseString()

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -27,20 +27,6 @@ namespace
     constexpr auto installationIdSettingsKey          = "ErrorReporting/AnonymousInstallationId";
 
     /**
-     * @brief Gets a stable Sentry package name from the configured application base name.
-     * @return Lower-case, hyphen-separated package name suitable for a Sentry release.
-     */
-    QString getSentryPackageName()
-    {
-        auto packageName = Application::getBaseName().trimmed().toLower();
-
-        packageName.replace(QRegularExpression("[^a-z0-9]+"), "-");
-        packageName.remove(QRegularExpression("^-+|-+$"));
-
-        return packageName.isEmpty() ? QStringLiteral("manivault-studio") : packageName;
-    }
-
-    /**
      * @brief Gets or creates the random identifier used for anonymous installation counts.
      * @return Stable, lower-case UUID stored in the active application's persistent settings.
      */
@@ -228,11 +214,11 @@ void SentryErrorLogger::start()
 #ifdef _DEBUG
     sentry_options_set_debug(options, 1);
     sentry_options_set_environment(options, "debug");
-    sentry_options_set_release(options, releaseString);
+    sentry_options_set_release(options, releaseString + "-debug");
 #else
     sentry_options_set_debug(options, 0);
     sentry_options_set_environment(options, "release");
-    sentry_options_set_release(options, releaseString);
+    sentry_options_set_release(options, releaseString + "-release");
 #endif
 
     if (sentry_init(options) != 0) {
@@ -408,7 +394,7 @@ QString SentryErrorLogger::getReleaseString()
     if (application == nullptr)
         return {};
 
-    return QString("%1@%2").arg(getSentryPackageName(), QString::fromStdString(application->getVersion().getVersionString()));
+    return QString("ManiVaultStudio@%1").arg(QString::fromStdString(application->getVersion().getVersionString()));
 }
 
 bool SentryErrorLogger::isDsnValid() const

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -59,7 +59,7 @@ void SentryErrorLogger::initialize()
 void SentryErrorLogger::start()
 {
     if (!getUserHasOptedAction().isChecked() || !getEnabledAction().isChecked()) {
-        start();
+        return;
     }
 
     qDebug() << "Starting Sentry error logging...";

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -37,8 +37,8 @@ namespace
             sanitized.replace(QDir::toNativeSeparators(QDir::cleanPath(directory)), replacement, Qt::CaseInsensitive);
         };
 
-        redactDirectory(QDir::homePath(), "<home>");
         redactDirectory(QDir::tempPath(), "<temp>");
+        redactDirectory(QDir::homePath(), "<home>");
 
         static const QRegularExpression windowsUserPath(R"(([A-Z]:[\\/](?:Users|Documents and Settings)[\\/])[^\\/\s]+)", QRegularExpression::CaseInsensitiveOption);
         static const QRegularExpression unixUserPath(R"((/(?:home|Users)/)[^/\s]+)", QRegularExpression::CaseInsensitiveOption);
@@ -47,8 +47,8 @@ namespace
 
         sanitized.replace(windowsUserPath, "\\1<user>");
         sanitized.replace(unixUserPath, "\\1<user>");
-        sanitized.replace(emailAddress, "<email>");
         sanitized.replace(urlCredentials, "\\1<credentials>@");
+        sanitized.replace(emailAddress, "<email>");
 
         if (sanitized.size() > maximumSentryTextLength)
             sanitized = sanitized.left(maximumSentryTextLength) + "...[truncated]";
@@ -290,9 +290,6 @@ void SentryErrorLogger::reportHandledException(const QString& title, const QStri
 
         if (!frame.module.isEmpty())
             sentry_value_set_by_key(sentryFrame, "module", sentry_value_new_string(QFileInfo(frame.module).fileName().toUtf8().constData()));
-
-        if (!frame.address.isEmpty())
-            sentry_value_set_by_key(sentryFrame, "instruction_addr", sentry_value_new_string(frame.address.toUtf8().constData()));
 
         sentry_value_append(frames, sentryFrame);
     }

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -9,6 +9,8 @@
 
 #include <QOperatingSystemVersion>
 #include <QCoreApplication>
+#include <QDir>
+#include <QStandardPaths>
 
 using namespace mv;
 using namespace mv::gui;
@@ -71,10 +73,32 @@ void SentryErrorLogger::start()
     const auto dsn = getDsnAction().getString();
 
     sentry_options_t* options = sentry_options_new();
+
+    const auto cachePath          = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    const auto sentryDatabasePath = QDir(cachePath).filePath("Sentry");
+
+    if (cachePath.isEmpty() || !QDir().mkpath(sentryDatabasePath)) {
+        qWarning() << "Cannot start Sentry: unable to create its cache directory at" << sentryDatabasePath;
+
+        const auto reason = cachePath.isEmpty()
+            ? QString("The operating system did not provide a writable application cache location.")
+            : QString("The cache directory <code>%1</code> could not be created. Check the directory permissions and available disk space.")
+                  .arg(sentryDatabasePath.toHtmlEscaped());
+
+        addNotification("CacheDirectoryUnavailable", {
+            "Sentry error logging disabled",
+            QString("Sentry could not start. %1 Error and crash reports will not be sent during this session.").arg(reason),
+            StyledIcon("triangle-exclamation"),
+            5000
+        });
+
+        sentry_options_free(options);
+        return;
+    }
     
     sentry_options_set_dsn(options, dsn.toUtf8());
     sentry_options_set_handler_path(options, QDir(QCoreApplication::applicationDirPath()).filePath(getCrashpadHandlerExecutableName()).toUtf8());
-    sentry_options_set_database_path(options, ".sentry-native");
+    sentry_options_set_database_path(options, sentryDatabasePath.toUtf8());
 
     if (getShowCrashReportDialogAction().isChecked()) {
 #ifdef Q_OS_WIN

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -3,13 +3,12 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "SentryErrorLogger.h"
-#include "CrashReportDialog.h"
-
 #include <ManiVaultVersion.h>
 
 #include "sentry.h"
 
 #include <QOperatingSystemVersion>
+#include <QCoreApplication>
 
 using namespace mv;
 using namespace mv::gui;
@@ -74,8 +73,18 @@ void SentryErrorLogger::start()
     sentry_options_t* options = sentry_options_new();
     
     sentry_options_set_dsn(options, dsn.toUtf8());
-    sentry_options_set_handler_path(options, QString("%1/%2").arg(QDir::currentPath(), getCrashpadHandlerExecutableName()).toUtf8());
+    sentry_options_set_handler_path(options, QDir(QCoreApplication::applicationDirPath()).filePath(getCrashpadHandlerExecutableName()).toUtf8());
     sentry_options_set_database_path(options, ".sentry-native");
+
+    if (getShowCrashReportDialogAction().isChecked()) {
+#ifdef Q_OS_WIN
+        const auto crashReporterExecutable = "ManiVault Crash Reporter.exe";
+#else
+        const auto crashReporterExecutable = "ManiVault Crash Reporter";
+#endif
+        sentry_options_set_external_crash_reporter_path(options,
+            QDir(QCoreApplication::applicationDirPath()).filePath(crashReporterExecutable).toUtf8());
+    }
 
     const auto releaseString = getReleaseString().toUtf8();
 
@@ -83,50 +92,28 @@ void SentryErrorLogger::start()
     sentry_options_set_debug(options, 1);
     sentry_options_set_environment(options, "debug");
     sentry_options_set_release(options, releaseString + "-debug");
-    sentry_set_tag("build_type", "debug");
 #else
     sentry_options_set_debug(options, 0);
     sentry_options_set_environment(options, "release");
     sentry_options_set_release(options, releaseString + "-release");
+#endif
+
+    if (sentry_init(options) != 0) {
+        qDebug() << "Sentry error logging is not running";
+        return;
+    }
+
+    qDebug() << "Sentry error logging is running, crash reports will send to: " + dsn;
+
+#ifdef _DEBUG
+    sentry_set_tag("build_type", "debug");
+#else
     sentry_set_tag("build_type", "release");
 #endif
 
-    static const bool showCrashReportDialog = getShowCrashReportDialogAction().isChecked();
-
-    qDebug() << "showCrashReportDialog" << showCrashReportDialog;
-
-    sentry_options_set_before_send(options, [](sentry_value_t event, void* hint, void* closure) -> sentry_value_t {
-        //auto showCrashReportDialog = static_cast<bool*>(closure);
-
-        //qDebug() << "Sending crash report..." << showCrashReportDialog;
-        if (!showCrashReportDialog)
-            return event;
-
-        CrashReportDialog crashReportDialog;
-
-        if (crashReportDialog.exec() == QDialog::Accepted) {
-            const auto crashUserInfo = crashReportDialog.getCrashUserInfo();
-
-            if (crashUserInfo._sendReport) {
-                sentry_value_t extra = sentry_value_new_object();
-
-                sentry_value_set_by_key(extra, "feedback", sentry_value_new_string(crashUserInfo._feedback.toUtf8()));
-                sentry_value_set_by_key(extra, "contactInfo", sentry_value_new_string(crashUserInfo._contactDetails.toUtf8()));
-
-                sentry_value_set_by_key(event, "extra", extra);
-
-                if (auto eventJson = sentry_value_to_json(event))
-                    sentry_free(eventJson);
-            }
-        }
-
-        return event;
-    }, nullptr);
-
-    if (sentry_init(options) == 0)
-        qDebug() << "Sentry error logging is running, crash reports will send to: " + dsn;
-    else
-        qDebug() << "Sentry error logging is not running";
+    // The external crash reporter handles feedback and owns the crash envelope.
+    // Clear the marker so a handled crash does not prompt again on later runs.
+    sentry_clear_crashed_last_run();
     
     addNotification("Started", {
         QString("%1 error logging").arg(getLoggerName()),

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -3,7 +3,6 @@
 // Copyright (C) 2023 BioVault (Biomedical Visual Analytics Unit LUMC - TU Delft) 
 
 #include "SentryErrorLogger.h"
-#include <ManiVaultVersion.h>
 
 #include "sentry.h"
 
@@ -13,6 +12,7 @@
 #include <QFileInfo>
 #include <QRegularExpression>
 #include <QStandardPaths>
+#include <QUuid>
 
 using namespace mv;
 using namespace mv::gui;
@@ -24,6 +24,48 @@ namespace
     constexpr qsizetype maximumHandledExceptionsPerSession = 50;
     constexpr qint64 handledExceptionCooldownMilliseconds = 60 * 1000;
     constexpr uint64_t sentryShutdownTimeoutMilliseconds = 2000;
+    constexpr auto installationIdSettingsKey          = "ErrorReporting/AnonymousInstallationId";
+
+    /**
+     * @brief Gets a stable Sentry package name from the configured application base name.
+     * @return Lower-case, hyphen-separated package name suitable for a Sentry release.
+     */
+    QString getSentryPackageName()
+    {
+        auto packageName = Application::getBaseName().trimmed().toLower();
+
+        packageName.replace(QRegularExpression("[^a-z0-9]+"), "-");
+        packageName.remove(QRegularExpression("^-+|-+$"));
+
+        return packageName.isEmpty() ? QStringLiteral("manivault-studio") : packageName;
+    }
+
+    /**
+     * @brief Gets or creates the random identifier used for anonymous installation counts.
+     * @return Stable, lower-case UUID stored in the active application's persistent settings.
+     */
+    QString getAnonymousInstallationId()
+    {
+        const auto application = Application::current();
+
+        if (application == nullptr)
+            return {};
+
+        const auto storedInstallationId = application->getSetting(installationIdSettingsKey).toString();
+        const QUuid storedUuid(storedInstallationId);
+
+        if (!storedUuid.isNull() && storedUuid.toString(QUuid::WithoutBraces) == storedInstallationId)
+            return storedInstallationId;
+
+        const auto installationId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+
+        application->setSetting(installationIdSettingsKey, installationId);
+
+        if (application->getSetting(installationIdSettingsKey).toString() != installationId)
+            return {};
+
+        return installationId;
+    }
 
     QString sanitizeForSentry(const QString& text)
     {
@@ -92,6 +134,10 @@ void SentryErrorLogger::initialize()
     if (isInitialized())
         return;
 
+    // Create the identifier on the first launch of a Sentry-enabled build,
+    // independently of whether the user chooses to enable transmission.
+    (void)getAnonymousInstallationId();
+
     beginInitialization();
     {
     }
@@ -146,6 +192,11 @@ void SentryErrorLogger::start()
     sentry_options_set_handler_path(options, QDir(QCoreApplication::applicationDirPath()).filePath(getCrashpadHandlerExecutableName()).toUtf8());
     sentry_options_set_database_path(options, sentryDatabasePath.toUtf8());
     sentry_options_set_shutdown_timeout(options, sentryShutdownTimeoutMilliseconds);
+    // sentry-native starts its automatic session from sentry_init(), before an
+    // application-defined user can be installed. Start it explicitly after
+    // setting the anonymous installation ID so Release Health receives a
+    // stable distinct user without collecting machine-derived identifiers.
+    sentry_options_set_auto_session_tracking(options, 0);
 
     if (getShowCrashReportDialogAction().isChecked()) {
 #ifdef Q_OS_WIN
@@ -177,11 +228,11 @@ void SentryErrorLogger::start()
 #ifdef _DEBUG
     sentry_options_set_debug(options, 1);
     sentry_options_set_environment(options, "debug");
-    sentry_options_set_release(options, releaseString + "-debug");
+    sentry_options_set_release(options, releaseString);
 #else
     sentry_options_set_debug(options, 0);
     sentry_options_set_environment(options, "release");
-    sentry_options_set_release(options, releaseString + "-release");
+    sentry_options_set_release(options, releaseString);
 #endif
 
     if (sentry_init(options) != 0) {
@@ -201,6 +252,15 @@ void SentryErrorLogger::start()
     _handledExceptionSessionTimer.start();
     _handledExceptionLastSent.clear();
     _handledExceptionsSent = 0;
+
+    const auto anonymousInstallationId = getAnonymousInstallationId().toUtf8();
+
+    if (anonymousInstallationId.isEmpty()) {
+        qWarning() << "Sentry Release Health disabled: the anonymous installation ID could not be persisted";
+    } else {
+        sentry_set_user(sentry_value_new_user(anonymousInstallationId.constData(), nullptr, nullptr, nullptr));
+        sentry_start_session();
+    }
 
     qDebug() << "Sentry error logging is running, crash reports will send to: " + dsn;
 
@@ -326,14 +386,29 @@ void SentryErrorLogger::reportHandledException(const QString& title, const QStri
     sentry_capture_event(event);
 }
 
+bool SentryErrorLogger::submitUserFeedback(const QString& type, const QString& message, const QString& email)
+{
+    if (!_isRunning || message.trimmed().isEmpty())
+        return false;
+
+    const auto feedback = QString("[%1]\n%2").arg(type, message.trimmed()).toUtf8();
+    const auto contact  = email.trimmed().toUtf8();
+
+    sentry_capture_feedback(sentry_value_new_feedback(feedback.constData(), contact.isEmpty() ? nullptr : contact.constData(), nullptr, nullptr));
+    return true;
+}
+
 QString SentryErrorLogger::getReleaseString()
 {
     if (!getEnabledAction().isChecked())
         return {};
 
-    const auto suffix = QString(MV_VERSION_SUFFIX.data());
+    const auto application = Application::current();
 
-    return QString("ManiVaultStudio@%1.%2.%3%4").arg(QString::number(MV_VERSION_MAJOR), QString::number(MV_VERSION_MINOR), QString::number(MV_VERSION_PATCH), suffix.isEmpty() ? "" : QString("-%1").arg(suffix));
+    if (application == nullptr)
+        return {};
+
+    return QString("%1@%2").arg(getSentryPackageName(), QString::fromStdString(application->getVersion().getVersionString()));
 }
 
 bool SentryErrorLogger::isDsnValid() const

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -11,11 +11,50 @@
 #include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
+#include <QRegularExpression>
 #include <QStandardPaths>
 
 using namespace mv;
 using namespace mv::gui;
 using namespace mv::util;
+
+namespace
+{
+    constexpr qsizetype maximumSentryTextLength = 4096;
+    constexpr qsizetype maximumHandledExceptionsPerSession = 50;
+    constexpr qint64 handledExceptionCooldownMilliseconds = 60 * 1000;
+
+    QString sanitizeForSentry(const QString& text)
+    {
+        auto sanitized = text;
+
+        const auto redactDirectory = [&sanitized](const QString& directory, const QString& replacement) {
+            if (directory.isEmpty() || QDir(directory).isRoot())
+                return;
+
+            sanitized.replace(QDir::cleanPath(directory), replacement, Qt::CaseInsensitive);
+            sanitized.replace(QDir::toNativeSeparators(QDir::cleanPath(directory)), replacement, Qt::CaseInsensitive);
+        };
+
+        redactDirectory(QDir::homePath(), "<home>");
+        redactDirectory(QDir::tempPath(), "<temp>");
+
+        static const QRegularExpression windowsUserPath(R"(([A-Z]:[\\/](?:Users|Documents and Settings)[\\/])[^\\/\s]+)", QRegularExpression::CaseInsensitiveOption);
+        static const QRegularExpression unixUserPath(R"((/(?:home|Users)/)[^/\s]+)", QRegularExpression::CaseInsensitiveOption);
+        static const QRegularExpression emailAddress(R"(\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b)", QRegularExpression::CaseInsensitiveOption);
+        static const QRegularExpression urlCredentials(R"((\b[A-Z][A-Z0-9+.-]*://)[^/\s:@]+(?::[^/\s@]*)?@)", QRegularExpression::CaseInsensitiveOption);
+
+        sanitized.replace(windowsUserPath, "\\1<user>");
+        sanitized.replace(unixUserPath, "\\1<user>");
+        sanitized.replace(emailAddress, "<email>");
+        sanitized.replace(urlCredentials, "\\1<credentials>@");
+
+        if (sanitized.size() > maximumSentryTextLength)
+            sanitized = sanitized.left(maximumSentryTextLength) + "...[truncated]";
+
+        return sanitized;
+    }
+}
 
 SentryErrorLogger::SentryErrorLogger(QObject* parent /*= nullptr*/) :
     AbstractErrorLogger("Sentry", parent)
@@ -157,6 +196,9 @@ void SentryErrorLogger::start()
     }
 
     _isRunning = true;
+    _handledExceptionSessionTimer.start();
+    _handledExceptionLastSent.clear();
+    _handledExceptionsSent = 0;
 
     qDebug() << "Sentry error logging is running, crash reports will send to: " + dsn;
 
@@ -188,23 +230,42 @@ void SentryErrorLogger::stop()
 
     sentry_close();
     _isRunning = false;
+    _handledExceptionSessionTimer.invalidate();
+    _handledExceptionLastSent.clear();
+    _handledExceptionsSent = 0;
 }
 
-void SentryErrorLogger::reportHandledException(const QString& title,
-                                               const QString& exceptionType,
-                                               const QString& reason,
-                                               util::SeverityLevel severity,
-                                               const util::StackTrace& stackTrace,
-                                               const QString& diagnosticId,
-                                               const QString& where)
+void SentryErrorLogger::reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, util::SeverityLevel severity, const util::StackTrace& stackTrace, const QString& diagnosticId, const QString& where)
 {
     if (!_isRunning)
         return;
 
+    const auto sanitizedReason = sanitizeForSentry(reason);
+    const auto fingerprint = exceptionType + QLatin1Char('\n') + sanitizedReason;
+    const auto now = _handledExceptionSessionTimer.elapsed();
+
+    for (auto iterator = _handledExceptionLastSent.begin(); iterator != _handledExceptionLastSent.end();) {
+        if (now - iterator.value() >= handledExceptionCooldownMilliseconds)
+            iterator = _handledExceptionLastSent.erase(iterator);
+        else
+            ++iterator;
+    }
+
+    if (_handledExceptionsSent >= maximumHandledExceptionsPerSession || _handledExceptionLastSent.contains(fingerprint))
+        return;
+
+    _handledExceptionLastSent.insert(fingerprint, now);
+    ++_handledExceptionsSent;
+
     auto event     = sentry_value_new_event();
-    auto exception = sentry_value_new_exception(exceptionType.toUtf8().constData(), reason.toUtf8().constData());
+    auto exception = sentry_value_new_exception(exceptionType.toUtf8().constData(), sanitizedReason.toUtf8().constData());
     auto sentryStackTrace = sentry_value_new_object();
     auto frames = sentry_value_new_list();
+    auto sentryFingerprint = sentry_value_new_list();
+
+    sentry_value_append(sentryFingerprint, sentry_value_new_string("{{ default }}"));
+    sentry_value_append(sentryFingerprint, sentry_value_new_string("handled-exception"));
+    sentry_value_set_by_key(event, "fingerprint", sentryFingerprint);
 
     // Sentry expects frames from the oldest call to the point where the
     // exception occurred; cpptrace provides them in the opposite order.
@@ -250,13 +311,13 @@ void SentryErrorLogger::reportHandledException(const QString& title,
     auto extra = sentry_value_new_object();
 
     if (!title.isEmpty())
-        sentry_value_set_by_key(extra, "dialog_title", sentry_value_new_string(title.toUtf8().constData()));
+        sentry_value_set_by_key(extra, "dialog_title", sentry_value_new_string(sanitizeForSentry(title).toUtf8().constData()));
 
     if (!diagnosticId.isEmpty())
         sentry_value_set_by_key(extra, "diagnostic_id", sentry_value_new_string(diagnosticId.toUtf8().constData()));
 
     if (!where.isEmpty())
-        sentry_value_set_by_key(extra, "where", sentry_value_new_string(where.toUtf8().constData()));
+        sentry_value_set_by_key(extra, "where", sentry_value_new_string(sanitizeForSentry(where).toUtf8().constData()));
 
     sentry_value_set_by_key(event, "extra", extra);
     sentry_capture_event(event);

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -23,6 +23,7 @@ namespace
     constexpr qsizetype maximumSentryTextLength = 4096;
     constexpr qsizetype maximumHandledExceptionsPerSession = 50;
     constexpr qint64 handledExceptionCooldownMilliseconds = 60 * 1000;
+    constexpr uint64_t sentryShutdownTimeoutMilliseconds = 2000;
 
     QString sanitizeForSentry(const QString& text)
     {
@@ -144,6 +145,7 @@ void SentryErrorLogger::start()
     sentry_options_set_dsn(options, dsn.toUtf8());
     sentry_options_set_handler_path(options, QDir(QCoreApplication::applicationDirPath()).filePath(getCrashpadHandlerExecutableName()).toUtf8());
     sentry_options_set_database_path(options, sentryDatabasePath.toUtf8());
+    sentry_options_set_shutdown_timeout(options, sentryShutdownTimeoutMilliseconds);
 
     if (getShowCrashReportDialogAction().isChecked()) {
 #ifdef Q_OS_WIN
@@ -228,7 +230,11 @@ void SentryErrorLogger::stop()
     if (!_isRunning)
         return;
 
-    sentry_close();
+    const auto dumpedEnvelopes = sentry_close();
+
+    if (dumpedEnvelopes > 0)
+        qWarning() << "Sentry shutdown timed out;" << dumpedEnvelopes << "envelope(s) were persisted for delivery during a later session";
+
     _isRunning = false;
     _handledExceptionSessionTimer.invalidate();
     _handledExceptionLastSent.clear();

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -190,6 +190,78 @@ void SentryErrorLogger::stop()
     _isRunning = false;
 }
 
+void SentryErrorLogger::reportHandledException(const QString& title,
+                                               const QString& exceptionType,
+                                               const QString& reason,
+                                               util::SeverityLevel severity,
+                                               const util::StackTrace& stackTrace,
+                                               const QString& diagnosticId,
+                                               const QString& where)
+{
+    if (!_isRunning)
+        return;
+
+    auto event     = sentry_value_new_event();
+    auto exception = sentry_value_new_exception(exceptionType.toUtf8().constData(), reason.toUtf8().constData());
+    auto sentryStackTrace = sentry_value_new_object();
+    auto frames = sentry_value_new_list();
+
+    // Sentry expects frames from the oldest call to the point where the
+    // exception occurred; cpptrace provides them in the opposite order.
+    for (auto frameIterator = stackTrace.crbegin(); frameIterator != stackTrace.crend(); ++frameIterator) {
+        const auto& frame = *frameIterator;
+        auto sentryFrame = sentry_value_new_object();
+
+        if (!frame.function.isEmpty())
+            sentry_value_set_by_key(sentryFrame, "function", sentry_value_new_string(frame.function.toUtf8().constData()));
+
+        if (!frame.file.isEmpty())
+            sentry_value_set_by_key(sentryFrame, "filename", sentry_value_new_string(QFileInfo(frame.file).fileName().toUtf8().constData()));
+
+        if (frame.line >= 0)
+            sentry_value_set_by_key(sentryFrame, "lineno", sentry_value_new_int32(frame.line));
+
+        if (!frame.module.isEmpty())
+            sentry_value_set_by_key(sentryFrame, "module", sentry_value_new_string(QFileInfo(frame.module).fileName().toUtf8().constData()));
+
+        if (!frame.address.isEmpty())
+            sentry_value_set_by_key(sentryFrame, "instruction_addr", sentry_value_new_string(frame.address.toUtf8().constData()));
+
+        sentry_value_append(frames, sentryFrame);
+    }
+
+    sentry_value_set_by_key(sentryStackTrace, "frames", frames);
+    sentry_value_set_by_key(exception, "stacktrace", sentryStackTrace);
+    sentry_event_add_exception(event, exception);
+
+    const auto level = [&severity]() {
+        switch (severity) {
+            case util::SeverityLevel::Info:    return "info";
+            case util::SeverityLevel::Warning: return "warning";
+            case util::SeverityLevel::Error:   return "error";
+            case util::SeverityLevel::Fatal:   return "fatal";
+        }
+
+        return "error";
+    }();
+
+    sentry_value_set_by_key(event, "level", sentry_value_new_string(level));
+
+    auto extra = sentry_value_new_object();
+
+    if (!title.isEmpty())
+        sentry_value_set_by_key(extra, "dialog_title", sentry_value_new_string(title.toUtf8().constData()));
+
+    if (!diagnosticId.isEmpty())
+        sentry_value_set_by_key(extra, "diagnostic_id", sentry_value_new_string(diagnosticId.toUtf8().constData()));
+
+    if (!where.isEmpty())
+        sentry_value_set_by_key(extra, "where", sentry_value_new_string(where.toUtf8().constData()));
+
+    sentry_value_set_by_key(event, "extra", extra);
+    sentry_capture_event(event);
+}
+
 QString SentryErrorLogger::getReleaseString()
 {
     if (!getEnabledAction().isChecked())

--- a/ManiVault/src/private/SentryErrorLogger.cpp
+++ b/ManiVault/src/private/SentryErrorLogger.cpp
@@ -175,7 +175,15 @@ void SentryErrorLogger::start()
     }
     
     sentry_options_set_dsn(options, dsn.toUtf8());
-    sentry_options_set_handler_path(options, QDir(QCoreApplication::applicationDirPath()).filePath(getCrashpadHandlerExecutableName()).toUtf8());
+
+    const auto crashpadHandlerPath = QDir(QCoreApplication::applicationDirPath()).filePath(getCrashpadHandlerExecutableName());
+
+#ifdef Q_OS_WIN
+    sentry_options_set_handler_pathw(options, reinterpret_cast<const wchar_t*>(crashpadHandlerPath.utf16()));
+#else
+    sentry_options_set_handler_path(options, crashpadHandlerPath.toUtf8());
+#endif
+
     sentry_options_set_database_path(options, sentryDatabasePath.toUtf8());
     sentry_options_set_shutdown_timeout(options, sentryShutdownTimeoutMilliseconds);
     // sentry-native starts its automatic session from sentry_init(), before an
@@ -194,7 +202,11 @@ void SentryErrorLogger::start()
         const auto crashReporterInfo = QFileInfo(crashReporterPath);
 
         if (crashReporterInfo.exists() && crashReporterInfo.isFile()) {
+#ifdef Q_OS_WIN
+            sentry_options_set_external_crash_reporter_pathw(options, reinterpret_cast<const wchar_t*>(crashReporterPath.utf16()));
+#else
             sentry_options_set_external_crash_reporter_path(options, crashReporterPath.toUtf8());
+#endif
         } else {
             qWarning() << "Cannot enable Sentry crash feedback: the external crash reporter was not found at" << crashReporterPath
                        << "Technical crash reports will still be sent automatically.";

--- a/ManiVault/src/private/SentryErrorLogger.h
+++ b/ManiVault/src/private/SentryErrorLogger.h
@@ -6,6 +6,9 @@
 
 #include <AbstractErrorLogger.h>
 
+#include <QElapsedTimer>
+#include <QHash>
+
 /**
  * Sentry error logger class
  *
@@ -55,5 +58,8 @@ private:
     bool isDsnValid() const override;
 
 private:
-    bool _isRunning = false;    /** Whether the Sentry SDK initialized successfully */
+    bool                    _isRunning = false;                  /** Whether the Sentry SDK initialized successfully */
+    QElapsedTimer           _handledExceptionSessionTimer;      /** Monotonic clock used for handled-exception throttling */
+    QHash<QString, qint64>  _handledExceptionLastSent;          /** Last transmission time for each handled-exception fingerprint */
+    qsizetype               _handledExceptionsSent = 0;         /** Number of handled exceptions sent during this session */
 };

--- a/ManiVault/src/private/SentryErrorLogger.h
+++ b/ManiVault/src/private/SentryErrorLogger.h
@@ -21,39 +21,64 @@ class SentryErrorLogger : public mv::AbstractErrorLogger
 public:
 
     /**
-     * Construct with pointer to \p parent object
-     * @param parent Pointer to parent object
+     * @brief Constructs a Sentry error logger.
+     * @param parent Pointer to the parent object (maybe nullptr).
      */
     SentryErrorLogger(QObject* parent = nullptr);
 
-    /** Connects to the error logging global settings */
+    /**
+     * @brief Initializes the Sentry logger and connects it to the global settings.
+     */
     void initialize() override;
 
-    /** Sends a caught exception as a non-fatal Sentry event. */
+    /**
+     * @brief Sends a caught exception as a non-fatal Sentry event.
+     * @param title User-facing title of the exception dialog.
+     * @param exceptionType Exception class or category name.
+     * @param reason Technical reason supplied by the exception.
+     * @param severity Severity assigned to the exception.
+     * @param stackTrace Structured stack trace captured for the exception.
+     * @param diagnosticId Identifier shown to the user for support correlation.
+     * @param where Optional source context in which the exception was handled.
+     */
     void reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, mv::util::SeverityLevel severity, const mv::util::StackTrace& stackTrace, const QString& diagnosticId = {}, const QString& where = {}) override;
+
+    /**
+     * @brief Sends a standalone item through Sentry's modern User Feedback API.
+     * @param type Feedback category, such as a problem report or feature request.
+     * @param message User-provided feedback description.
+     * @param email Optional email address for follow-up.
+     * @return Boolean determining whether Sentry accepted the feedback for transmission.
+     */
+    bool submitUserFeedback(const QString& type, const QString& message, const QString& email) override;
 
 private:
 
     /**
-     * Get Crashpad handler executable name
-     * @return Name of the Crashpad handler executable name
+     * @brief Gets the platform-specific Crashpad handler executable name.
+     * @return Crashpad handler executable name, or an empty string when unsupported.
      */
     QString getCrashpadHandlerExecutableName() const;
 
-    /** Start error logging to */
+    /**
+     * @brief Initializes the Sentry SDK and starts error reporting.
+     */
     void start() override;
 
+    /**
+     * @brief Closes the Sentry SDK and preserves envelopes that could not be flushed.
+     */
     void stop() override;
 
     /**
-     * Get release string for Sentry
-     * @return Release string
+     * @brief Gets the release identifier supplied to Sentry.
+     * @return Sentry release identifier for the current ManiVault version.
      */
     static QString getReleaseString();
 
     /**
-     * Get whether the Sentry data source name (DSN) is valid
-     * @return Boolean determining whether the DSN is valid
+     * @brief Determines whether the configured Sentry Data Source Name is valid.
+     * @return Boolean determining whether the DSN is structurally valid.
      */
     bool isDsnValid() const override;
 

--- a/ManiVault/src/private/SentryErrorLogger.h
+++ b/ManiVault/src/private/SentryErrorLogger.h
@@ -26,6 +26,9 @@ public:
     /** Connects to the error logging global settings */
     void initialize() override;
 
+    /** Sends a caught exception as a non-fatal Sentry event. */
+    void reportHandledException(const QString& title, const QString& exceptionType, const QString& reason, mv::util::SeverityLevel severity, const mv::util::StackTrace& stackTrace, const QString& diagnosticId = {}, const QString& where = {}) override;
+
 private:
 
     /**

--- a/ManiVault/src/private/SentryErrorLogger.h
+++ b/ManiVault/src/private/SentryErrorLogger.h
@@ -50,4 +50,7 @@ private:
      * @return Boolean determining whether the DSN is valid
      */
     bool isDsnValid() const override;
+
+private:
+    bool _isRunning = false;    /** Whether the Sentry SDK initialized successfully */
 };

--- a/ManiVault/src/private/UserFeedbackDialog.cpp
+++ b/ManiVault/src/private/UserFeedbackDialog.cpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "UserFeedbackDialog.h"
+
+#include "CoreInterface.h"
+
+#include <util/StyledIcon.h>
+
+#include <QMessageBox>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
+
+using namespace mv;
+using namespace mv::util;
+
+UserFeedbackDialog::UserFeedbackDialog(QWidget* parent) :
+    QDialog(parent),
+    _introductionLabel("Tell us about a problem you encountered or an improvement you would like to see in ManiVault Studio."),
+    _typeLabel("Feedback type:"),
+    _messageLabel("Description:"),
+    _emailLabel("Your email (optional):"),
+    _privacyLabel("Your feedback is sent to Sentry and processed according to the <a href=\"https://sentry.io/privacy/\">Sentry privacy policy</a>."),
+    _submitButton("Submit feedback"),
+    _cancelButton("Cancel")
+{
+    setWindowTitle("Send feedback");
+    setWindowIcon(StyledIcon("comment-dots"));
+    setMinimumSize(600, 440);
+
+    _introductionLabel.setWordWrap(true);
+    _typeComboBox.addItem(StyledIcon("bug"), "Report a problem", "Problem report");
+    _typeComboBox.addItem(StyledIcon("lightbulb"), "Request a feature", "Feature request");
+    _messageTextEdit.setPlaceholderText("Describe what happened, or explain the feature and how it would help...");
+    _emailLineEdit.setPlaceholderText("Enter your email if you would like us to follow up...");
+    _emailLineEdit.setValidator(new QRegularExpressionValidator(QRegularExpression("\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,63}\\b", QRegularExpression::CaseInsensitiveOption), this));
+    _privacyLabel.setOpenExternalLinks(true);
+    _privacyLabel.setTextInteractionFlags(Qt::TextBrowserInteraction);
+
+    _layout.addWidget(&_introductionLabel);
+    _layout.addSpacing(8);
+    _layout.addWidget(&_typeLabel);
+    _layout.addWidget(&_typeComboBox);
+    _layout.addWidget(&_messageLabel);
+    _layout.addWidget(&_messageTextEdit, 1);
+    _layout.addWidget(&_emailLabel);
+    _layout.addWidget(&_emailLineEdit);
+    _layout.addWidget(&_privacyLabel);
+
+    _buttonsLayout.addStretch(1);
+    _buttonsLayout.addWidget(&_submitButton);
+    _buttonsLayout.addWidget(&_cancelButton);
+    _layout.addLayout(&_buttonsLayout);
+    setLayout(&_layout);
+
+    connect(&_messageTextEdit, &QPlainTextEdit::textChanged, this, &UserFeedbackDialog::updateSubmitButton);
+    connect(&_emailLineEdit, &QLineEdit::textChanged, this, &UserFeedbackDialog::updateSubmitButton);
+    connect(&_submitButton, &QPushButton::clicked, this, &UserFeedbackDialog::submit);
+    connect(&_cancelButton, &QPushButton::clicked, this, &UserFeedbackDialog::reject);
+    updateSubmitButton();
+}
+
+void UserFeedbackDialog::updateSubmitButton()
+{
+    const auto emailIsValid = _emailLineEdit.text().trimmed().isEmpty() || _emailLineEdit.hasAcceptableInput();
+    _submitButton.setEnabled(!_messageTextEdit.toPlainText().trimmed().isEmpty() && emailIsValid);
+}
+
+void UserFeedbackDialog::submit()
+{
+    const auto type = _typeComboBox.currentData().toString();
+
+    if (!errors().submitUserFeedback(type, _messageTextEdit.toPlainText(), _emailLineEdit.text())) {
+        QMessageBox::warning(this, "Feedback could not be sent", "Error reporting is disabled or unavailable. Enable error reporting in the application settings and try again.");
+        return;
+    }
+
+    QMessageBox::information(this, "Feedback submitted", "Thank you. Your feedback has been submitted successfully.");
+    accept();
+}

--- a/ManiVault/src/private/UserFeedbackDialog.h
+++ b/ManiVault/src/private/UserFeedbackDialog.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <QComboBox>
+#include <QDialog>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+/**
+ * @brief Collects a standalone problem report or feature request from the user.
+ *
+ * The dialog validates the description and optional email address, then sends
+ * the submission through the application's configured error logger.
+ *
+ * @author Thomas Kroes
+ */
+class UserFeedbackDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+
+    /**
+     * @brief Constructs the standalone user-feedback dialog.
+     * @param parent Pointer to the parent widget (maybe nullptr).
+     */
+    explicit UserFeedbackDialog(QWidget* parent = nullptr);
+
+private:
+
+    /**
+     * @brief Updates submission availability from the current form contents.
+     */
+    void updateSubmitButton();
+
+    /**
+     * @brief Submits the form through the active error logger and reports the result.
+     */
+    void submit();
+
+private:
+    QVBoxLayout     _layout;                /**< Main dialog layout. */
+    QLabel          _introductionLabel;     /**< Introductory explanation. */
+    QLabel          _typeLabel;             /**< Feedback-type field label. */
+    QComboBox       _typeComboBox;          /**< Problem or feature-request selector. */
+    QLabel          _messageLabel;          /**< Description field label. */
+    QPlainTextEdit  _messageTextEdit;       /**< User-provided feedback description. */
+    QLabel          _emailLabel;            /**< Optional email field label. */
+    QLineEdit       _emailLineEdit;         /**< Optional validated follow-up email. */
+    QLabel          _privacyLabel;          /**< Link to the Sentry privacy policy. */
+    QHBoxLayout     _buttonsLayout;          /**< Bottom action-button layout. */
+    QPushButton     _submitButton;           /**< Submits the feedback. */
+    QPushButton     _cancelButton;           /**< Closes the dialog without submission. */
+};

--- a/ManiVault/src/util/Exception.cpp
+++ b/ManiVault/src/util/Exception.cpp
@@ -24,6 +24,8 @@
 #include <QHeaderView>
 #include <QTreeWidget>
 
+#include <typeinfo>
+
 namespace mv::util {
 
 namespace
@@ -230,6 +232,8 @@ void exceptionMessageBox(const QString& title, const QString& reason, QWidget* p
 {
     const auto stackTrace = mv::errors().getDebugStackTrace();
 
+    mv::errors().reportHandledException(title, "UnknownException", reason, SeverityLevel::Error, stackTrace);
+
     exceptionDialog(title, reason, stackTrace, parent);
 
     qDebug() << title << reason;
@@ -245,12 +249,24 @@ void exceptionMessageBox(const QString& title, QWidget* parent)
 
 void exceptionMessageBox(const QString& title, const std::exception& exception, QWidget* parent)
 {
-    exceptionMessageBox(title, exception.what(), parent);
+    const auto reason     = QString::fromUtf8(exception.what());
+    const auto stackTrace = mv::errors().getDebugStackTrace();
+
+    mv::errors().reportHandledException(title, QString::fromLatin1(typeid(exception).name()), reason, SeverityLevel::Error, stackTrace);
+
+    exceptionDialog(title, reason, stackTrace, parent);
+
+    qDebug() << title << reason;
+
+    for (const auto& frame : stackTrace)
+        qDebug() << stackFrameToString(frame);
 }
 
 void exceptionMessageBox(const QString& title, const ManiVaultException& exception, QWidget* parent)
 {
     const auto stackTrace = exception.getStackTrace();
+
+    mv::errors().reportHandledException(title, "ManiVaultException", exception.getWhat(), exception.getSeverity(), stackTrace, exception.getDiagnosticId().toString(QUuid::WithoutBraces), exception.getWhere());
 
     exceptionDialog(title, exception.getMessage(), stackTrace, parent);
 

--- a/ManiVault/src/util/Exception.cpp
+++ b/ManiVault/src/util/Exception.cpp
@@ -23,6 +23,7 @@
 #include <QVBoxLayout>
 #include <QHeaderView>
 #include <QTreeWidget>
+#include <QUuid>
 
 #include <typeinfo>
 
@@ -77,14 +78,16 @@ namespace
      * @brief Copies an exception report to the clipboard.
      * @param title Title of the exception.
      * @param reason Reason for the exception.
+     * @param diagnosticId Reference ID associated with the exception.
      * @param stackTrace Stack trace associated with the exception.
      */
-    void copyExceptionReportToClipboard(const QString& title, const QString& reason, const StackTrace& stackTrace)
+    void copyExceptionReportToClipboard(const QString& title, const QString& reason, const QString& diagnosticId, const StackTrace& stackTrace)
     {
         QString report;
 
         report += title + "\n\n";
         report += reason + "\n\n";
+        report += "Reference ID: " + diagnosticId + "\n\n";
 
         const auto stackTraceLines = stackTraceToStringList(stackTrace);
 
@@ -102,10 +105,11 @@ namespace
      * @brief Displays an exception dialog with details and stack trace.
      * @param title Title of the exception dialog.
      * @param reason Reason for the exception.
+     * @param diagnosticId Reference ID associated with the exception.
      * @param stackTrace Stack trace associated with the exception.
      * @param parent Parent widget for the dialog.
      */
-    void exceptionDialog(const QString& title, const QString& reason, const StackTrace& stackTrace, QWidget* parent)
+    void exceptionDialog(const QString& title, const QString& reason, const QString& diagnosticId, const StackTrace& stackTrace, QWidget* parent)
     {
         QDialog dialog(parent);
 
@@ -126,6 +130,14 @@ namespace
         reasonLabel.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
         layout.addWidget(&reasonLabel);
+
+        QLabel referenceLabel(QString("Reference ID: <code>%1</code>").arg(diagnosticId.toHtmlEscaped()), &dialog);
+
+        referenceLabel.setTextFormat(Qt::RichText);
+        referenceLabel.setTextInteractionFlags(Qt::TextSelectableByMouse);
+        referenceLabel.setToolTip("Include this reference ID when reporting the problem");
+
+        layout.addWidget(&referenceLabel);
 
         if (!stackTrace.isEmpty()) {
             auto detailsWidget  = new QWidget(&dialog);
@@ -216,7 +228,7 @@ namespace
         buttons.addButton(QDialogButtonBox::Ok);
 
         QObject::connect(copyReportButton, &QPushButton::clicked, &dialog, [&] {
-            copyExceptionReportToClipboard(title, reason, stackTrace);
+            copyExceptionReportToClipboard(title, reason, diagnosticId, stackTrace);
         });
 
         QObject::connect(&buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
@@ -230,13 +242,14 @@ namespace
 
 void exceptionMessageBox(const QString& title, const QString& reason, QWidget* parent)
 {
-    const auto stackTrace = mv::errors().getDebugStackTrace();
+    const auto diagnosticId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    const auto stackTrace   = mv::errors().getDebugStackTrace();
 
-    mv::errors().reportHandledException(title, "UnknownException", reason, SeverityLevel::Error, stackTrace);
+    mv::errors().reportHandledException(title, "UnknownException", reason, SeverityLevel::Error, stackTrace, diagnosticId);
 
-    exceptionDialog(title, reason, stackTrace, parent);
+    exceptionDialog(title, reason, diagnosticId, stackTrace, parent);
 
-    qDebug() << title << reason;
+    qDebug() << title << reason << "Reference ID:" << diagnosticId;
 
     for (const auto& frame : stackTrace)
         qDebug() << stackFrameToString(frame);
@@ -250,13 +263,14 @@ void exceptionMessageBox(const QString& title, QWidget* parent)
 void exceptionMessageBox(const QString& title, const std::exception& exception, QWidget* parent)
 {
     const auto reason     = QString::fromUtf8(exception.what());
+    const auto diagnosticId = QUuid::createUuid().toString(QUuid::WithoutBraces);
     const auto stackTrace = mv::errors().getDebugStackTrace();
 
-    mv::errors().reportHandledException(title, QString::fromLatin1(typeid(exception).name()), reason, SeverityLevel::Error, stackTrace);
+    mv::errors().reportHandledException(title, QString::fromLatin1(typeid(exception).name()), reason, SeverityLevel::Error, stackTrace, diagnosticId);
 
-    exceptionDialog(title, reason, stackTrace, parent);
+    exceptionDialog(title, reason, diagnosticId, stackTrace, parent);
 
-    qDebug() << title << reason;
+    qDebug() << title << reason << "Reference ID:" << diagnosticId;
 
     for (const auto& frame : stackTrace)
         qDebug() << stackFrameToString(frame);
@@ -264,13 +278,14 @@ void exceptionMessageBox(const QString& title, const std::exception& exception, 
 
 void exceptionMessageBox(const QString& title, const ManiVaultException& exception, QWidget* parent)
 {
-    const auto stackTrace = exception.getStackTrace();
+    const auto diagnosticId = exception.getDiagnosticId().toString(QUuid::WithoutBraces);
+    const auto stackTrace   = exception.getStackTrace();
 
-    mv::errors().reportHandledException(title, "ManiVaultException", exception.getWhat(), exception.getSeverity(), stackTrace, exception.getDiagnosticId().toString(QUuid::WithoutBraces), exception.getWhere());
+    mv::errors().reportHandledException(title, "ManiVaultException", exception.getWhat(), exception.getSeverity(), stackTrace, diagnosticId, exception.getWhere());
 
-    exceptionDialog(title, exception.getMessage(), stackTrace, parent);
+    exceptionDialog(title, exception.getMessage(), diagnosticId, stackTrace, parent);
 
-    qDebug() << title << exception.getMessage();
+    qDebug() << title << exception.getMessage() << "Reference ID:" << diagnosticId;
 
     for (const auto& frame : stackTrace)
         qDebug() << stackFrameToString(frame);


### PR DESCRIPTION
## Summary

This PR substantially improves ManiVault Studio’s Sentry integration and error-reporting workflow. It adds a polished crash-feedback experience, optional handled-exception reporting, privacy safeguards, developer testing tools, anonymous Release Health sessions, and a general feedback dialog.

It also fixes a shutdown crash caused by conflicting Qt and shared-pointer ownership in the project models.

## Highlights

### Crash reporting and feedback

- Preserve the crash-report dialog when Sentry reporting is enabled.
- Automatically send the technical crash report before requesting user feedback.
- Associate submitted feedback with the corresponding Sentry crash event.
- Add a standalone crash reporter with consistent styling and application icon.
- Display the crash event ID with a copy-to-clipboard action.
- Add restart, privacy-policy, and feedback validation controls.
- Improve reporting when Sentry or the external crash reporter is unavailable.
- Modernize and document Sentry DSN validation.

### Exception reporting

- Always retain local exception dialogs.
- Make handled-exception reporting to Sentry optional and disabled by default.
- Add reference IDs to reported exception dialogs.
- Sanitize exception payloads to remove privacy-sensitive values.
- Improve Sentry startup-state and shutdown-timeout handling.

### User feedback

- Add a Help menu action for submitting general feedback.
- Introduce a dedicated feedback dialog integrated with Sentry.
- Improve error handling and user-facing status reporting when feedback cannot be sent.

### Developer tools

- Add a hidden, Windows-only developer menu activated with `Ctrl+Alt+Shift+D`.
- Consolidate workflow, handled-exception, and fatal-crash testing actions.
- Add appropriate Font Awesome icons.
- Preserve the developer menu for the remainder of the application session.

### Anonymous Release Health

- Record Sentry sessions when ManiVault Studio launches.
- Generate a random anonymous installation UUID.
- Persist the UUID using the application-specific settings system.
- Reuse the same UUID across launches and normal upgrades.
- Set the UUID only as the anonymous Sentry user ID.
- Report sessions against the existing ManiVault Studio release naming convention.
- Avoid machine fingerprinting and personally identifiable installation identifiers.

### Shutdown stability

- Fix competing ownership of `ProjectsModelProject` objects by removing QObject parenting from shared-pointer-owned project records.
- Bind queued asynchronous callbacks to their owning model or project object.
- Prevent callbacks from accessing destroyed objects during application shutdown.
- Resolve the debug-heap breakpoint previously encountered while destroying `ProjectManager`.

### Documentation and build integration

- Expand API documentation for the error-management and logging classes.
- Document parameters and return values in the existing project style.
- Add the new dialogs, reporter, and developer menu to the build configuration.
- Preserve the existing Sentry initialization path and DSN configuration.
