### PR TITLE
Fix some apple clang warnings

### DIFF
--- a/ManiVault/src/PluginMetadata.h
+++ b/ManiVault/src/PluginMetadata.h
@@ -152,7 +152,7 @@ public:
             auto rolesString = _roles.isEmpty() ? "" : QString("(%1)").arg(_roles.join(", "));
 
             if (!_roles.isEmpty()) {
-                int lastCommaIndex = rolesString.lastIndexOf(',');
+                const qsizetype lastCommaIndex = rolesString.lastIndexOf(',');
 
                 if (lastCommaIndex != -1)
                     rolesString.replace(lastCommaIndex, 1, " & ");

--- a/ManiVault/src/util/Miscellaneous.cpp
+++ b/ManiVault/src/util/Miscellaneous.cpp
@@ -9,24 +9,26 @@
 
 #include <QAction>
 #include <QBuffer>
-#include <QResource>
 #include <QEventLoop>
+#include <QFileInfo>
+#include <QImageReader>
+#include <QJsonDocument>
 #include <QLayout>
 #include <QLayoutItem>
 #include <QPainter>
 #include <QPixmap>
-#include <QJsonDocument>
+#include <QRegularExpression>
+#include <QResource>
 #include <QString>
-#include <QTimer>
+#include <QStringDecoder>
 #include <QTcpSocket>
+#include <QTimer>
+#include <QToolTip>
 #include <QUrl>
 #include <QVariant>
-#include <QRegularExpression>
-#include <QFileInfo>
-#include <QToolTip>
 
-#include <exception>
 #include <algorithm>
+#include <exception>
 
 namespace mv::util
 {

--- a/ManiVault/src/util/Miscellaneous.h
+++ b/ManiVault/src/util/Miscellaneous.h
@@ -14,10 +14,6 @@
 #include <QWidget>
 #include <QPixmap>
 #include <QByteArray>
-#include <QBuffer>
-#include <QImageReader>
-#include <QRegularExpression>
-#include <QStringDecoder>
 
 #include <algorithm>
 

--- a/ManiVault/src/util/Miscellaneous.h
+++ b/ManiVault/src/util/Miscellaneous.h
@@ -287,9 +287,10 @@ inline auto isLikelyUtf16 = [](const QByteArray& byteArray) {
     if (byteArray.size() < 2)
         return false;
     
-    return static_cast<uchar>(byteArray[0]) == 0xFF && static_cast<uchar>(byteArray[1]) == 0xFE
-        || static_cast<uchar>(byteArray[0]) == 0xFE && static_cast<uchar>(byteArray[1]) == 0xFF
-        || (byteArray[0] == 0x00 && byteArray[1] == '{') || (byteArray[0] == '{' && byteArray[1] == 0x00);
+    return (static_cast<uchar>(byteArray[0]) == 0xFF && static_cast<uchar>(byteArray[1]) == 0xFE)
+        || (static_cast<uchar>(byteArray[0]) == 0xFE && static_cast<uchar>(byteArray[1]) == 0xFF)
+        || (byteArray[0] == 0x00 && byteArray[1] == '{') 
+        || (byteArray[0] == '{' && byteArray[1] == 0x00);
 };
 
 /**


### PR DESCRIPTION
- Fixes two warnings that Apple Clang emits on each CI run for every plugin
- Remove some Qt headers that are not used in `Miscellaneous.h` and move them to `Miscellaneous.cpp`