### PR TITLE
Add configurable point Z ordering and non-selectable point rendering

### DIFF
--- a/ManiVault/res/shaders/PointPlot.frag
+++ b/ManiVault/res/shaders/PointPlot.frag
@@ -70,6 +70,7 @@ void main()
 		discard;
 		
 	bool isSelectionHighlighted	= vHighlight == 1;
+	bool isSelectionExcluded	= vHighlight < 0;
 	bool isFocusHighlighted 	= vFocusHighlight == 1;
 	bool isHighlighted			= isSelectionHighlighted || isFocusHighlighted;
     float len 					= length(vTexCoord);	
@@ -125,6 +126,9 @@ void main()
 		color = vec3(vScalar, vScalar2, vScalar3);
 	}
 
+	if (isSelectionExcluded)
+		color = vec3(0.5);
+
 	float opacity = 1.0;
 	
 	switch (selectionDisplayMode) {
@@ -142,7 +146,7 @@ void main()
 				if (selectionHaloEnabled)
 					opacity *= 1.0 - smoothstep(selectionOutlineStart, 1.0, len);
 			} else {
-				opacity *= a * vOpacity;
+				opacity *= a * (isSelectionExcluded ? 1.0 : vOpacity);
 			}		
 			
 			fragColor = vec4(color, opacity);
@@ -154,7 +158,7 @@ void main()
 			if (isHighlighted)
 				fragColor = vec4(selectionOutlineColor, a);
 			else
-				fragColor = vec4(color, a * vOpacity);
+				fragColor = vec4(color, a * (isSelectionExcluded ? 1.0 : vOpacity));
 				
 			break;
 		}

--- a/ManiVault/res/shaders/PointPlot.vert
+++ b/ManiVault/res/shaders/PointPlot.vert
@@ -31,12 +31,12 @@ uniform bool 	hasSizes;          		/** Whether a point size buffer is used */
 uniform bool 	hasOpacities;			/** Whether an opacity buffer is used */
 
 // Selection visualization
-uniform int	selectionDisplayMode;		/** Type of selection display (e.g. outline, override) */
+uniform int		selectionDisplayMode;		/** Type of selection display (e.g. outline, override) */
 uniform float 	selectionOutlineScale;     	/** Selection outline scale */
-uniform float 	selectionOutlineOpacity;     	/** Selection outline opacity */
+uniform float 	selectionOutlineOpacity;	/** Selection outline opacity */
 uniform vec3  	selectionOutlineColor;		/** Selection outline color */
 uniform bool 	selectionHaloEnabled; 		/** Whether selection halo is enabled */
-uniform float 	selectionHaloScale;		/** Selection halo scale */
+uniform float 	selectionHaloScale;			/** Selection halo scale */
 
 // Focus visualization
 uniform vec3  	focusRegionColor;			/** Focus region color */
@@ -45,10 +45,16 @@ uniform vec3  	focusOutlineColor;			/** Focus outline color */
 uniform float 	focusOutlineScale;     		/** Focus outline scale */
 uniform float 	focusOutlineOpacity;		/** Focus outline opacity */
 
-uniform bool 	randomizedDepthEnabled;		/** Whether to randomize the z-order */
+#define Z_ORDER_INSERTION  0
+#define Z_ORDER_DIMENSION  1
+#define Z_ORDER_RANDOMIZED 2
+
+uniform int   zOrderMode;                  	/** How point depth is determined */
+uniform bool  hasZOrderScalars;            	/** Whether a z-order scalar buffer is used */
+uniform vec3  zOrderScalarsRange;			/** Minimum, maximum and span of the z-order scalars */
 
 // Miscellaneous
-uniform float 	windowAspectRatio;			/** Window aspect ratio (width / height) */
+uniform float 	windowAspectRatio;					/** Window aspect ratio (width / height) */
 
 layout(location = 0) in vec2    vertex;         	/** Vertex input, always a [-1, 1] quad */
 layout(location = 1) in vec2    position;       	/** 2-Dimensional positions of points */
@@ -60,6 +66,7 @@ layout(location = 6) in float   size;           	/** Point size */
 layout(location = 7) in float   opacity;        	/** Point opacity */
 layout(location = 8) in float   scalar2;        	/** Point scalar (color channel 2) */
 layout(location = 9) in float   scalar3;        	/** Point scalar (color channel 3) */
+layout(location = 10) in float  zOrderScalar;    	/** Point scalar used for z ordering */
 
 // Output variables
 smooth out vec2  vTexCoord;
@@ -149,8 +156,15 @@ void main()
 //	if (pointSizeAbsolute)
 //		finalPos = (mvp * vec4(position + scaledVertex, 0.0, 1.0)).xy;
 		
-	// Compute random depth
-	float depth = randomizedDepthEnabled ? random(vec2(gl_InstanceID, 0)) : 0;
+	// Compute point depth for the selected z-ordering mode
+    float depth = 0.0;
+
+    if (zOrderMode == Z_ORDER_DIMENSION && hasZOrderScalars) {
+        float normalizedZOrder = clamp((zOrderScalar - zOrderScalarsRange.x) / zOrderScalarsRange.z, 0.0, 1.0);
+        depth = mix(-0.999999, 0.999999, normalizedZOrder);
+    }
+    else if (zOrderMode == Z_ORDER_RANDOMIZED)
+        depth = random(vec2(gl_InstanceID, 0));
 	
 	// Set the final position
     gl_Position = vec4(finalPos, depth, 1.0); // Convert to NDC [-1,1]

--- a/ManiVault/src/models/AbstractHeadsUpDisplayModel.cpp
+++ b/ManiVault/src/models/AbstractHeadsUpDisplayModel.cpp
@@ -149,7 +149,7 @@ void AbstractHeadsUpDisplayModel::addHeadsUpDisplayItem(HeadsUpDisplayItemShared
         const auto parentIndex = headsUpDisplayItem->getParent() ? QPersistentModelIndex(indexFromHeadsUpDisplayItem(headsUpDisplayItem->getParent())) : QPersistentModelIndex();
 
         if (parentIndex.isValid()) {
-            if (auto parentItem = dynamic_cast<Item*>(itemFromIndex(parentIndex.sibling(0, 0))))
+            if (auto parentItem = dynamic_cast<Item*>(itemFromIndex(parentIndex.sibling(parentIndex.row(), 0))))
                 parentItem->appendRow(Row(headsUpDisplayItem));
             else
                 throw std::runtime_error("Parent index is not a valid item");

--- a/ManiVault/src/renderers/PointRenderer.cpp
+++ b/ManiVault/src/renderers/PointRenderer.cpp
@@ -4,6 +4,7 @@
 
 #include "PointRenderer.h"
 
+#include <algorithm>
 #include <limits>
 
 namespace mv
@@ -101,6 +102,13 @@ namespace mv
 
             glVertexAttribPointer(ATTRIBUTE_SCALARS_OPACITY, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
             glVertexAttribDivisor(ATTRIBUTE_SCALARS_OPACITY, 1);
+
+            // Scalar buffer for z ordering, disabled by default
+            _zOrderScalarBuffer.create();
+            _zOrderScalarBuffer.bind();
+
+            glVertexAttribPointer(ATTRIBUTE_SCALARS_Z_ORDER, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+            glVertexAttribDivisor(ATTRIBUTE_SCALARS_Z_ORDER, 1);
         }
 
         void PointArrayObject::setPositions(const std::vector<Vector2f>& positions)
@@ -222,6 +230,26 @@ namespace mv
             _dirtyOpacityScalars = true;
         }
 
+        void PointArrayObject::setZOrderScalars(const std::vector<float>& scalars)
+        {
+            _zOrderScalarsRange = Vector3f(0, 1, 1);
+
+            if (!scalars.empty()) {
+                _zOrderScalarsRange.x = std::numeric_limits<float>::max();
+                _zOrderScalarsRange.y = -std::numeric_limits<float>::max();
+
+                for (const auto scalar : scalars) {
+                    _zOrderScalarsRange.x = std::min(_zOrderScalarsRange.x, scalar);
+                    _zOrderScalarsRange.y = std::max(_zOrderScalarsRange.y, scalar);
+                }
+
+                _zOrderScalarsRange.z = std::max(_zOrderScalarsRange.y - _zOrderScalarsRange.x, 1e-07f);
+            }
+
+            _zOrderScalars = scalars;
+            _dirtyZOrderScalars = true;
+        }
+
         void PointArrayObject::setColors(const std::vector<Vector3f>& colors)
         {
             _colors = colors;
@@ -330,6 +358,16 @@ namespace mv
                 _dirtyOpacityScalars = false;
             }
 
+            if (_dirtyZOrderScalars)
+            {
+                _zOrderScalarBuffer.bind();
+                _zOrderScalarBuffer.setData(_zOrderScalars);
+
+                enableAttribute(ATTRIBUTE_SCALARS_Z_ORDER, !_zOrderScalars.empty());
+
+                _dirtyZOrderScalars = false;
+            }
+
             // Before calling glDrawArraysInstanced, check if _positions is non-empty, to
             // prevent a crash on some (older) computers, see ManiVault core pull request #42,
             // "Fix issue #34: Crash when opening scatterplot plugin", March 2020.
@@ -433,6 +471,11 @@ namespace mv
         void PointRenderer::setOpacityChannelScalars(const std::vector<float>& scalars)
         {
             _gpuPoints.setOpacityScalars(scalars);
+        }
+
+        void PointRenderer::setZOrderChannelScalars(const std::vector<float>& scalars)
+        {
+            _gpuPoints.setZOrderScalars(scalars);
         }
 
         void PointRenderer::setColors(const std::vector<Vector3f>& colors)
@@ -549,12 +592,22 @@ namespace mv
 
         bool PointRenderer::getRandomizedDepthEnabled() const
         {
-            return _randomizedDepthEnabled;
+            return _zOrderMode == PointZOrderMode::Randomized;
         }
 
         void PointRenderer::setRandomizedDepthEnabled(bool randomizedDepth)
         {
-            _randomizedDepthEnabled = randomizedDepth;
+            _zOrderMode = randomizedDepth ? PointZOrderMode::Randomized : PointZOrderMode::InsertionOrder;
+        }
+
+        PointZOrderMode PointRenderer::getZOrderMode() const
+        {
+            return _zOrderMode;
+        }
+
+        void PointRenderer::setZOrderMode(PointZOrderMode zOrderMode)
+        {
+            _zOrderMode = zOrderMode;
         }
 
         void PointRenderer::initView()
@@ -597,7 +650,8 @@ namespace mv
                 _shader.uniform1i("selectionOutlineOverrideColor", _selectionOutlineOverrideColor);
                 _shader.uniform1f("selectionOutlineOpacity", _selectionOutlineOpacity);
                 _shader.uniform1i("selectionHaloEnabled", _selectionHaloEnabled);
-                _shader.uniform1i("randomizedDepthEnabled", _randomizedDepthEnabled);
+                _shader.uniform1i("zOrderMode", static_cast<std::int32_t>(_zOrderMode));
+                _shader.uniform1i("hasZOrderScalars", _gpuPoints.hasZOrderScalars());
                 _shader.uniform1i("hasHighlights", _gpuPoints.hasHighlights());
                 _shader.uniform1i("hasFocusHighlights", _gpuPoints.hasFocusHighlights());
                 _shader.uniform1i("hasScalars", _gpuPoints.hasColorScalars());
@@ -616,6 +670,9 @@ namespace mv
 
                 if (_gpuPoints.hasColorScalars3())
                     _shader.uniform3f("colorMapRange3", _gpuPoints.getColorMapRange3());
+
+                if (_gpuPoints.hasZOrderScalars())
+                    _shader.uniform3f("zOrderScalarsRange", _gpuPoints.getZOrderScalarsRange());
 
                 // Color space for RGB coloring (0 = RGB; placeholder for future HSL/LAB)
                 _shader.uniform1i("colorSpace", 0);

--- a/ManiVault/src/renderers/PointRenderer.h
+++ b/ManiVault/src/renderers/PointRenderer.h
@@ -29,6 +29,13 @@ namespace mv
             Outline, Override
         };
 
+        /** Determines how point depth is assigned during rendering. */
+        enum class PointZOrderMode {
+            InsertionOrder,     /** All points have equal depth; draw/insertion order determines visibility */
+            Dimension,          /** Point depth is derived from a scalar data channel */
+            Randomized          /** Point depth is generated deterministically from the point index */
+        };
+
         struct CORE_EXPORT PointArrayObject : private QOpenGLFunctions_3_3_Core
         {
         public:
@@ -42,9 +49,10 @@ namespace mv
             BufferObject _colorScalarBuffer3;
             BufferObject _sizeScalarBuffer;
             BufferObject _opacityScalarBuffer;
+            BufferObject _zOrderScalarBuffer;
             BufferObject _colorBuffer;
 
-            PointArrayObject() : QOpenGLFunctions_3_3_Core(), _handle(0), _colorScalarsRange(0, 1, 1), _colorScalarsRange2(0, 1, 1), _colorScalarsRange3(0, 1, 1) {}
+            PointArrayObject() : QOpenGLFunctions_3_3_Core(), _handle(0), _colorScalarsRange(0, 1, 1), _colorScalarsRange2(0, 1, 1), _colorScalarsRange3(0, 1, 1), _zOrderScalarsRange(0, 1, 1) {}
             void init();
             void setPositions(const std::vector<Vector2f>& positions);
             void setHighlights(const std::vector<char>& highlights);
@@ -54,6 +62,7 @@ namespace mv
             void setScalars3(const std::vector<float>& scalars, bool adjustColorMapRange);
             void setSizeScalars(const std::vector<float>& scalars);
             void setOpacityScalars(const std::vector<float>& scalars);
+            void setZOrderScalars(const std::vector<float>& scalars);
             void setColors(const std::vector<Vector3f>& colors);
 
             const std::vector<Vector2f>& getPositions() const { return _positions; }
@@ -64,6 +73,7 @@ namespace mv
             const std::vector<float>& getScalars3() const { return _colorScalars3; }
             const std::vector<float>& getSizeScalars() const { return _sizeScalars; }
             const std::vector<float>& getOpacityScalars() const { return _opacityScalars; }
+            const std::vector<float>& getZOrderScalars() const { return _zOrderScalars; }
             const std::vector<Vector3f>& getColors() const { return _colors; }
 
             void enableAttribute(uint index, bool enable);
@@ -75,6 +85,7 @@ namespace mv
             bool hasColorScalars3() const { return !_colorScalars3.empty(); }
             bool hasSizeScalars() const { return !_sizeScalars.empty(); }
             bool hasOpacityScalars() const { return !_opacityScalars.empty(); }
+            bool hasZOrderScalars() const { return !_zOrderScalars.empty(); }
             bool hasColors() const { return !_colors.empty(); }
 
             Vector3f getColorMapRange() const {
@@ -91,6 +102,10 @@ namespace mv
 
             Vector3f getColorMapRange3() const {
                 return _colorScalarsRange3;
+            }
+
+            Vector3f getZOrderScalarsRange() const {
+                return _zOrderScalarsRange;
             }
 
             void draw();
@@ -110,6 +125,7 @@ namespace mv
             const uint ATTRIBUTE_SCALARS_OPACITY    = 7;
             const uint ATTRIBUTE_SCALARS_COLOR2     = 8;
             const uint ATTRIBUTE_SCALARS_COLOR3     = 9;
+            const uint ATTRIBUTE_SCALARS_Z_ORDER    = 10;
 
             /* Point attributes */
             std::vector<Vector2f>   _positions;
@@ -123,11 +139,13 @@ namespace mv
             std::vector<float>  _colorScalars3;     /** Point color scalar channel 3 (RGB coloring) */
             std::vector<float>  _sizeScalars;       /** Point size scalar channel */
             std::vector<float>  _opacityScalars;    /** Point opacity scalar channel */
+            std::vector<float>  _zOrderScalars;     /** Point z-order scalar channel */
 
             /** Scalar ranges */
             Vector3f    _colorScalarsRange;     /** Scalar range of the point color scalars (channel 1) */
             Vector3f    _colorScalarsRange2;    /** Scalar range of the point color scalars (channel 2) */
             Vector3f    _colorScalarsRange3;    /** Scalar range of the point color scalars (channel 3) */
+            Vector3f    _zOrderScalarsRange;    /** Scalar range of the point z-order scalars */
 
             bool _dirtyPositions        = false;
             bool _dirtyHighlights       = false;
@@ -137,6 +155,7 @@ namespace mv
             bool _dirtyColorScalars3    = false;
             bool _dirtySizeScalars      = false;
             bool _dirtyOpacityScalars   = false;
+            bool _dirtyZOrderScalars    = false;
             bool _dirtyColors           = false;
 
             BufferObject _quadBufferObject;
@@ -179,6 +198,7 @@ namespace mv
             void setColorChannel3Scalars(const std::vector<float>& scalars, bool adjustColorMapRange = true);
             void setSizeChannelScalars(const std::vector<float>& scalars);
             void setOpacityChannelScalars(const std::vector<float>& scalars);
+            void setZOrderChannelScalars(const std::vector<float>& scalars);
             void setColors(const std::vector<Vector3f>& colors);
 
             PointEffect getScalarEffect() const;
@@ -219,6 +239,9 @@ namespace mv
             bool getRandomizedDepthEnabled() const;
             void setRandomizedDepthEnabled(bool randomizedDepth);
 
+            PointZOrderMode getZOrderMode() const;
+            void setZOrderMode(PointZOrderMode zOrderMode);
+
             void init() override;
             void render() override;
             void destroy() override;
@@ -240,7 +263,7 @@ namespace mv
             bool                        _selectionHaloEnabled               = false;
 
             /* Depth control */
-            bool                        _randomizedDepthEnabled             = true;
+            PointZOrderMode             _zOrderMode                        = PointZOrderMode::InsertionOrder;
 
             /* Rendering variables */
             ShaderProgram               _shader = {};


### PR DESCRIPTION
## Summary

This PR extends the core point renderer with configurable Z ordering and visual support for non-selectable points.

## Changes

- Add three point Z-ordering modes:
  - Insertion order
  - Dimension-based ordering
  - Randomized depth
- Add a dedicated per-point Z-order scalar buffer and vertex attribute.
- Normalize dimension values for use as OpenGL depth values.
- Preserve the existing randomized-depth API through compatibility wrappers.
- Support a negative selection-highlight value to identify non-selectable points.
- Render non-selectable points as fully opaque neutral-gray points while preserving circular edge anti-aliasing.
- Fix heads-up display parent resolution so children are inserted beneath the correct root item instead of always beneath the first root item.

## Future work

The rendering style of non-selectable points is currently fixed to an opaque neutral gray. A future update will make this style customizable, including its color and potentially other visual properties.
