### PR TITLE
Add heads-up display toggle for view plugins

### DIFF
--- a/ManiVault/src/ViewPlugin.cpp
+++ b/ManiVault/src/ViewPlugin.cpp
@@ -94,6 +94,12 @@ ViewPlugin::ViewPlugin(const PluginFactory* factory) :
     _samplerAction.setConfigurationFlag(WidgetAction::ConfigurationFlag::HiddenInActionContextMenu, false);
     _samplerAction.setConnectionPermissionsToForceNone();
 
+    _headsUpDisplayAction.setCheckable(true);
+    _headsUpDisplayAction.setChecked(true);
+    _headsUpDisplayAction.setToolTip("Show or hide the heads-up display");
+    _headsUpDisplayAction.setConfigurationFlag(WidgetAction::ConfigurationFlag::HiddenInActionContextMenu);
+    _headsUpDisplayAction.setConnectionPermissionsToForceNone();
+
     connect(&_editorAction, &TriggerAction::triggered, this, [this]() -> void {
         auto* viewPluginEditorDialog = new ViewPluginEditorDialog(nullptr, this);
         connect(viewPluginEditorDialog, &ViewPluginEditorDialog::finished, viewPluginEditorDialog, &ViewPluginEditorDialog::deleteLater);
@@ -326,7 +332,15 @@ void ViewPlugin::addOverlayAction(WidgetAction* overlayAction, const Qt::Alignme
     if (overlayAction == nullptr)
         return;
 
-    _actionsWidgets.push_back({ overlayAction, new ActionOverlayWidget(&_widget, overlayAction, alignment) });
+    auto actionOverlayWidget = new ActionOverlayWidget(&_widget, overlayAction, alignment);
+
+    _actionsWidgets.push_back({ overlayAction, actionOverlayWidget });
+
+    if (overlayAction->isCheckable()) {
+        actionOverlayWidget->setVisible(overlayAction->isChecked());
+
+        connect(overlayAction, &QAction::toggled, actionOverlayWidget, &QWidget::setVisible);
+    }
 
     connect(overlayAction, &WidgetAction::destroyed, this, [this, overlayAction]() -> void {
         removeOverlayAction(overlayAction);

--- a/ManiVault/src/actions/ViewPluginHeadsUpDisplayAction.cpp
+++ b/ManiVault/src/actions/ViewPluginHeadsUpDisplayAction.cpp
@@ -170,11 +170,19 @@ void ViewPluginHeadsUpDisplayAction::removeAllHeadsUpDisplayItems()
 void ViewPluginHeadsUpDisplayAction::fromVariantMap(const QVariantMap& variantMap)
 {
     WidgetAction::fromVariantMap(variantMap);
+
+    // Before the HUD became toggleable, WidgetAction serialized IsChecked as
+    // false. Treat projects without an explicit HUD visibility value as visible.
+    setChecked(variantMap.value("Visible", true).toBool());
 }
 
 QVariantMap ViewPluginHeadsUpDisplayAction::toVariantMap() const
 {
-    return WidgetAction::toVariantMap();
+    auto variantMap = WidgetAction::toVariantMap();
+
+    variantMap.insert("Visible", isChecked());
+
+    return variantMap;
 }
 
 }

--- a/ManiVault/src/private/ViewPluginDockWidget.cpp
+++ b/ManiVault/src/private/ViewPluginDockWidget.cpp
@@ -102,6 +102,7 @@ void ViewPluginDockWidget::initialize()
         if (_viewPlugin->getFactory()->getReadmeMarkdownUrl().isValid())
             _settingsMenu.addAction(&const_cast<PluginFactory*>(_viewPlugin->getFactory())->getPluginMetadata().getTriggerReadmeAction());
 
+        _settingsMenu.addAction(&_viewPlugin->getHeadsUpDisplayAction());
         _settingsMenu.addAction(&_viewPlugin->getScreenshotAction());
 
         if (!_viewPlugin->isSystemViewPlugin())


### PR DESCRIPTION
Adds a “Heads-up display” toggle to each view plugin’s hamburger menu. The HUD is visible by default, its visibility can be changed per view plugin, and the selected state is preserved when saving and reopening a project. Existing projects remain compatible and show the HUD by default.