### PR TITLE
Continue restoring view plugins after individual state restoration failures

### DIFF
--- a/ManiVault/src/private/ViewPluginDockWidget.cpp
+++ b/ManiVault/src/private/ViewPluginDockWidget.cpp
@@ -171,10 +171,8 @@ void ViewPluginDockWidget::restoreViewPluginState()
         return;
 
     //_progressTask.setRunningIndeterminate();
-    {
-        _viewPlugin->fromVariantMap(_viewPluginMap);
-        //_dockManager.centralWidget()->setWidget(&_viewPlugin->getWidget(), eInsertMode::ForceNoScrollArea);
-    }
+    _viewPlugin->fromVariantMap(_viewPluginMap);
+    //_dockManager.centralWidget()->setWidget(&_viewPlugin->getWidget(), eInsertMode::ForceNoScrollArea);
     //_progressTask.setFinished();
 }
 

--- a/ManiVault/src/private/WorkspaceManager.cpp
+++ b/ManiVault/src/private/WorkspaceManager.cpp
@@ -565,7 +565,7 @@ UniqueWorkflowPlan WorkspaceManager::fromVariantMapWorkflow(QVariantMap variantM
 {
     UniqueWorkflowPlan plan = std::make_unique<WorkflowPlan>(QString("%1 (%2)").arg(__FUNCTION__).arg(getSerializationName()));
 
-    plan->addSequentialStage("Load", [this, variantMap](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext&) {
+    plan->addSequentialStage("Load", [this, variantMap](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext& executionContext) {
         getCurrentWorkspace()->fromVariantMap(variantMap);
 
         variantMapMustContain(variantMap, "DockManagers");
@@ -578,11 +578,44 @@ UniqueWorkflowPlan WorkspaceManager::fromVariantMapWorkflow(QVariantMap variantM
         _mainDockManager->fromVariantMap(dockingManagersMap["Main"].toMap());
         _viewPluginsDockManager->fromVariantMap(dockingManagersMap["ViewPlugins"].toMap());
 
+        const auto restoreViewPluginState = [&executionContext](ViewPluginDockWidget* viewPluginDockWidget) {
+            const auto viewPlugin = viewPluginDockWidget->getViewPlugin();
+
+            try {
+                viewPluginDockWidget->restoreViewPluginState();
+            }
+            catch (const std::exception& exception) {
+                const auto guiName = viewPlugin ? viewPlugin->getGuiName() : QStringLiteral("Unknown");
+                const auto id      = viewPlugin ? viewPlugin->getId() : QString{};
+
+                executionContext->warning(
+                    QString("Unable to restore state for view plugin '%1' (%2): %3").arg(guiName, id, exception.what()),
+                    {},
+                    {
+                        { "ViewPluginGuiName", guiName },
+                        { "ViewPluginId", id },
+                        { "Exception", exception.what() }
+                    });
+            }
+            catch (...) {
+                const auto guiName = viewPlugin ? viewPlugin->getGuiName() : QStringLiteral("Unknown");
+                const auto id      = viewPlugin ? viewPlugin->getId() : QString{};
+
+                executionContext->warning(
+                    QString("Unable to restore state for view plugin '%1' (%2): Unknown error").arg(guiName, id),
+                    {},
+                    {
+                        { "ViewPluginGuiName", guiName },
+                        { "ViewPluginId", id }
+                    });
+            }
+        };
+
         for (auto viewPluginDockWidget : _mainDockManager->getViewPluginDockWidgets(true))
-            viewPluginDockWidget->restoreViewPluginState();
+            restoreViewPluginState(viewPluginDockWidget);
 
         for (auto viewPluginDockWidget : _viewPluginsDockManager->getViewPluginDockWidgets(true))
-            viewPluginDockWidget->restoreViewPluginState();
+            restoreViewPluginState(viewPluginDockWidget);
     }, WorkflowPlan::JobThreadAffinity::GuiThread);
 
     return plan;


### PR DESCRIPTION
## Description

This PR makes project loading more resilient when restoring serialized view-plugin state.

Previously, when a view plugin threw an exception during `fromVariantMap()`—for example, because `variantMapMustContain()` encountered a missing key—the exception aborted workspace restoration. Consequently, all remaining view plugins were skipped.

View-plugin state restoration is now isolated per plugin:

- Exceptions from an individual view plugin no longer abort restoration of subsequent plugins.
- Each failure is reported as a warning through the active workflow execution context.
- Workflow warnings include the affected plugin’s name, ID, and exception details.
- Project loading completes with warnings, allowing users to inspect the problem through the workflow report.
- Process-level crashes remain fatal.