### PR TITLE
Defer and coalesce dimension picker summary updates

### DIFF
--- a/ManiVault/src/plugins/PointData/src/DimensionsPickerAction.cpp
+++ b/ManiVault/src/plugins/PointData/src/DimensionsPickerAction.cpp
@@ -9,7 +9,7 @@
 #include <QTableView>
 #include <QHeaderView>
 #include <QTime>
-#include <QAbstractEventDispatcher>
+#include <QTimer>
 #include <QVBoxLayout>
 
 #include <deque>
@@ -45,10 +45,6 @@ DimensionsPickerAction::DimensionsPickerAction(QObject* parent, const QString& t
 
     updateSummary();
 
-    _summaryUpdateAwakeConnection = connect(QAbstractEventDispatcher::instance(), &QAbstractEventDispatcher::awake,[this] {
-        updateSummary();
-    });
-
     /*
     const auto updateReadOnly = [this]() -> void {
         const auto enable = !isReadOnly();
@@ -73,7 +69,6 @@ DimensionsPickerAction::DimensionsPickerAction(QObject* parent, const QString& t
 
 DimensionsPickerAction::~DimensionsPickerAction()
 {
-    disconnect(_summaryUpdateAwakeConnection);
 }
 
 void DimensionsPickerAction::fromVariantMap(const QVariantMap& variantMap)
@@ -151,8 +146,15 @@ void DimensionsPickerAction::setDimensions(const std::uint32_t numDimensions, co
     updateSlider();
 
     connect(_itemModel.get(), &QAbstractItemModel::dataChanged, this, [this](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles) -> void {
+        scheduleSummaryUpdate();
         emit selectedDimensionsChanged(getSelectedDimensions());
     });
+
+    connect(_proxyModel.get(), &QAbstractItemModel::rowsInserted, this, &DimensionsPickerAction::scheduleSummaryUpdate);
+    connect(_proxyModel.get(), &QAbstractItemModel::rowsRemoved, this, &DimensionsPickerAction::scheduleSummaryUpdate);
+    connect(_proxyModel.get(), &QAbstractItemModel::modelReset, this, &DimensionsPickerAction::scheduleSummaryUpdate);
+
+    scheduleSummaryUpdate();
 
     emit proxyModelChanged(_proxyModel.get());
 }
@@ -530,6 +532,19 @@ void DimensionsPickerAction::updateSummary()
     const auto numberOfVisibleDimensions    = (_proxyModel == nullptr) ? 0 : _proxyModel->rowCount();
 
     _summaryAction.setString(tr("%1 available, %2 visible, %3 selected").arg(numberOfDimensions).arg(numberOfVisibleDimensions).arg(holder.getNumberOfSelectedDimensions()));
+}
+
+void DimensionsPickerAction::scheduleSummaryUpdate()
+{
+    if (_summaryUpdatePending)
+        return;
+
+    _summaryUpdatePending = true;
+
+    QTimer::singleShot(0, this, [this]() {
+        _summaryUpdatePending = false;
+        updateSummary();
+    });
 }
 
 void DimensionsPickerAction::connectToPublicAction(WidgetAction* publicAction, bool recursive)

--- a/ManiVault/src/plugins/PointData/src/DimensionsPickerAction.h
+++ b/ManiVault/src/plugins/PointData/src/DimensionsPickerAction.h
@@ -242,6 +242,9 @@ protected:
     /** Update the dimension selection summary */
     void updateSummary();
 
+    /** Schedule a deferred dimension selection summary update */
+    void scheduleSummaryUpdate();
+
 protected: // Linking
 
     /**
@@ -287,7 +290,7 @@ protected:
     mv::gui::DimensionsPickerFilterAction                   _filterAction;                      /** Filter action */
     mv::gui::DimensionsPickerSelectAction                   _selectAction;                      /** Select action */
     mv::gui::DimensionsPickerMiscellaneousAction            _miscellaneousAction;               /** Miscellaneous settings action */
-    QMetaObject::Connection                                 _summaryUpdateAwakeConnection;      /** Update summary view when idle */
+    bool                                                     _summaryUpdatePending{ false };      /** Whether a deferred summary update is pending */
 
     friend class Widget;
     friend class mv::AbstractActionsManager;


### PR DESCRIPTION
## Summary

Fixes #266 by replacing continuous dimension picker summary polling with change-driven, deferred updates.

## Changes

- Removed summary updates from `QAbstractEventDispatcher::awake`.
- Triggered summary updates only when relevant model state changes:
  - Dimension selection data changes
  - Proxy-model rows are inserted or removed
  - The proxy model is reset
  - Dataset dimensions are replaced
- Deferred summary updates using a zero-delay timer.
- Coalesced bursts of model signals into a single summary refresh.

This avoids repeatedly scanning every dimension whenever the Qt event loop wakes. It also prevents large batches of model changes from recalculating the summary for every individual signal.