### PR TITLE
Restore project publishing with workflow-based serialization

### DIFF
--- a/ManiVault/src/private/MainWindow.cpp
+++ b/ManiVault/src/private/MainWindow.cpp
@@ -307,15 +307,19 @@ void MainWindow::initialize()
         });
     
     const auto updateMenuVisibility = [fileMenuAction, projectsMenuAction]() -> void {
-        const auto projectIsReadOnly = projects().getCurrentProject()->getReadOnlyAction().isChecked();
+        const auto projectIsReadOnly = projects().hasProject() && projects().getCurrentProject()->getReadOnlyAction().isChecked();
     
-        //fileMenuAction->setVisible(!projectIsReadOnly);
+        fileMenuAction->setVisible(!projectIsReadOnly);
         projectsMenuAction->setVisible(projectIsReadOnly ? projects().getCurrentProject()->getAllowProjectSwitchingAction().isChecked() : true);
-        };
+    };
     
     connect(&projects(), &AbstractProjectManager::projectCreated, this, [this, updateMenuVisibility]() -> void {
         connect(&projects().getCurrentProject()->getReadOnlyAction(), &ToggleAction::toggled, this, updateMenuVisibility);
-        });
+        updateMenuVisibility();
+    });
+
+    connect(&projects(), &AbstractProjectManager::projectOpened, this, updateMenuVisibility);
+    connect(&projects(), &AbstractProjectManager::projectDestroyed, this, updateMenuVisibility);
     
     loadGuiTask.setFinished();
     

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -799,60 +799,80 @@ void ProjectManager::publishProject(QString filePath /*= ""*/)
         if (!hasProject())
             return;
 
+        if (QFileInfo(filePath).isDir())
+            throw std::runtime_error("Project file path may not be a directory");
+
+        const auto parameters = getProjectPublishParameters(filePath);
+
+        if (!parameters.isValid())
+            return;
+
+        filePath = parameters.filePath;
+
         emit projectAboutToBePublished(*_project);
-        {
-            if (QFileInfo(filePath).isDir())
-                throw std::runtime_error("Project file path may not be a directory");
+        setState(State::PublishingProject);
 
-            setState(State::PublishingProject);
+        auto currentProject = getCurrentProject();
+        auto workspaceLockingAction = &workspaces().getCurrentWorkspace()->getLockingAction();
+        auto& readOnlyAction = currentProject->getReadOnlyAction();
+        auto& statusBarOverrideAction = currentProject->getOverrideApplicationStatusBarAction();
 
-            const auto stateGuard = qScopeGuard([this]() { setState(State::Idle); });
+        const auto workspaceWasLocked = workspaceLockingAction->isLocked();
 
-            QTemporaryDir temporaryDirectory(QDir::cleanPath(Application::current()->getTemporaryDir().path() + QDir::separator() + "PublishProject"));
-
-            setTemporaryDirPath(TemporaryDirType::Publish, temporaryDirectory.path());
-
-            const auto temporaryDirectoryPath = temporaryDirectory.path();
-
-            _project->getAllowedPluginsAction().addStrings(mv::plugins().getUsedPluginKinds());
-            _project->getOverrideApplicationStatusBarAction().cacheState();
-            _project->getOverrideApplicationStatusBarAction().setChecked(true);
-
-            const auto parameters = getProjectPublishParameters(filePath);
-
-            if (parameters.isValid())
-                filePath = parameters.filePath;
-            else
-                return;
-
-            Application::requestOverrideCursor(Qt::WaitCursor);
-
-            auto& workspaceLockingAction = workspaces().getCurrentWorkspace()->getLockingAction();
-
-            const auto cacheWorkspaceLocked = workspaceLockingAction.isLocked();
-
-            workspaceLockingAction.setLocked(true);
-            {
-                auto& readOnlyAction            = getCurrentProject()->getReadOnlyAction();
-
-                QSignalBlocker readOnlyActionSignalBlocker(&readOnlyAction);
-
-                readOnlyAction.cacheState();
-                readOnlyAction.setChecked(true);
-
-                saveProject(filePath);
-
-                readOnlyAction.restoreState();
-            }
-            workspaceLockingAction.setLocked(cacheWorkspaceLocked);
-
-            _project->getProjectMetaAction().getApplicationVersionAction().setVersion(Application::current()->getVersion());
-
+        const auto restoreProjectState = [this, currentProject, workspaceLockingAction, workspaceWasLocked]() {
+            currentProject->getReadOnlyAction().restoreState("publishProject");
+            currentProject->getOverrideApplicationStatusBarAction().restoreState("publishProject");
+            workspaceLockingAction->setLocked(workspaceWasLocked);
+            unsetTemporaryDirPath(TemporaryDirType::Save);
             unsetTemporaryDirPath(TemporaryDirType::Publish);
+            setState(State::Idle);
+        };
 
-            Application::restoreOverrideCursor();
+        auto setupGuard = qScopeGuard(restoreProjectState);
+
+        currentProject->getAllowedPluginsAction().addStrings(mv::plugins().getUsedPluginKinds());
+        statusBarOverrideAction.cacheState("publishProject");
+        statusBarOverrideAction.setChecked(true);
+        readOnlyAction.cacheState("publishProject");
+        {
+            const QSignalBlocker blocker(&readOnlyAction);
+            readOnlyAction.setChecked(true);
         }
-        emit projectPublished(*_project);
+        workspaceLockingAction->setLocked(true);
+        auto workflowPlan = createProjectSaveWorkflowPlan(filePath);
+        const auto temporaryDirectoryPath = workflowPlan->getWorkflowContextAs<ProjectSaveContext>()->getTemporaryDirectoryPath();
+
+        // The serialization layer still resolves blobs through the save directory.
+        // Also expose the directory as the publish directory for publish-specific clients.
+        setTemporaryDirPath(TemporaryDirType::Save, temporaryDirectoryPath);
+        setTemporaryDirPath(TemporaryDirType::Publish, temporaryDirectoryPath);
+
+        auto future = Application::getWorkflowPlanExecutor().execute(std::move(workflowPlan), nullptr, WorkflowOptions({
+            .execution = {
+                .parallel = parameters.parallel,
+                .maxWorkerThreadCount = parameters.maxParallelThreads
+            },
+            .reporting = {
+                .progress             = true,
+                .finishedNotification = true,
+                .maxLoggingDepth      = parameters.maxLoggingDepth,
+                .resultDetails = {
+                    .operationName = "Publish project",
+                    .subjectName   = QFileInfo(filePath).fileName()
+                }
+            }
+        }));
+
+        future.onFinished(this, [this, currentProject, restoreProjectState](SharedWorkflowResult result) {
+            restoreProjectState();
+
+            if (result && !result->hasErrors() && !result->hasCriticalErrors()) {
+                currentProject->getProjectMetaAction().getApplicationVersionAction().setVersion(Application::current()->getVersion());
+                emit projectPublished(*currentProject);
+            }
+        });
+
+        setupGuard.dismiss();
     }
     catch (std::exception& e)
     {
@@ -1298,7 +1318,15 @@ AbstractProjectManager::ProjectSaveParameters ProjectManager::getProjectSavePara
 
 AbstractProjectManager::ProjectPublishParameters ProjectManager::getProjectPublishParameters(const QString& filePath) const
 {
-    ProjectPublishParameters parameters;
+    ProjectPublishParameters parameters {
+        true,
+        static_cast<std::uint32_t>(std::max(1, QThread::idealThreadCount() - 1))
+    };
+
+    if (!filePath.isEmpty()) {
+        parameters.filePath = filePath;
+        return parameters;
+    }
 
     FileSaveDialog fileDialog;
 

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -1318,9 +1318,21 @@ AbstractProjectManager::ProjectSaveParameters ProjectManager::getProjectSavePara
 
 AbstractProjectManager::ProjectPublishParameters ProjectManager::getProjectPublishParameters(const QString& filePath) const
 {
+    const auto getSettingsPrefix = [](const QString& setting) -> QString {
+        return "ProjectPublishParameters/Default/" + setting;
+    };
+
+    const auto getSetting = [getSettingsPrefix](const QString& setting, const QVariant& defaultValue = QVariant()) -> QVariant {
+        return Application::current()->getSetting(getSettingsPrefix(setting), defaultValue);
+    };
+
+    const auto setSetting = [getSettingsPrefix](const QString& setting, const QVariant& value) {
+        Application::current()->setSetting(getSettingsPrefix(setting), value);
+    };
+
     ProjectPublishParameters parameters {
-        true,
-        static_cast<std::uint32_t>(std::max(1, QThread::idealThreadCount() - 1))
+        getSetting("Parallel", true).toBool(),
+        getSetting("MaxNumberOfThreads", std::max(1, QThread::idealThreadCount() - 1)).toUInt()
     };
 
     if (!filePath.isEmpty()) {
@@ -1334,16 +1346,20 @@ AbstractProjectManager::ProjectPublishParameters ProjectManager::getProjectPubli
     fileDialog.setWindowTitle("Publish ManiVault Project");
     fileDialog.setNameFilters({ "ManiVault project files (*.mv)" });
     fileDialog.setDefaultSuffix(".mv");
-    fileDialog.setDirectory(Application::current()->getSetting("Projects/WorkingDirectory/Publish", StandardPaths::getProjectsDirectory()).toString());
+    fileDialog.setDirectory(getSetting("Directory", Application::current()->getSetting("Projects/WorkingDirectory/Publish", StandardPaths::getProjectsDirectory())).toString());
 
     GroupAction settingsAction(&fileDialog, "Settings");
     HorizontalGroupAction projectSettingsAction(&fileDialog, "Project settings");
     VerticalGroupAction additionalProjectSettingsAction(&fileDialog, "Additional settings");
-    ToggleAction multiThreadingAction(&fileDialog, "Multi-threading", true);
+
+    HorizontalGroupAction parallelSettingsAction(&fileDialog, "Parallel settings");
+    ToggleAction parallelToggleAction(&fileDialog, "Parallel", getSetting("Parallel", true).toBool());
+    IntegralAction maximumNumberOfThreadsAction(&fileDialog, "Maximum number of threads", 1, QThread::idealThreadCount(), getSetting("MaxNumberOfThreads", std::max(1, QThread::idealThreadCount() - 1)).toInt());
+    IntegralAction maxLoggingDepthAction(&fileDialog, "Maximum logging depth", 1, 15, getSetting("MaxLogDepth", 8).toInt());
 
     settingsAction.setIconByName("gear");
     settingsAction.setToolTip("Edit project settings");
-    settingsAction.setPopupSizeHint(QSize(420, 0));
+    settingsAction.setPopupSizeHint(QSize(420, 320));
     settingsAction.setLabelSizingType(GroupAction::LabelSizingType::Auto);
 
     projectSettingsAction.setShowLabels(false);
@@ -1363,12 +1379,34 @@ AbstractProjectManager::ProjectPublishParameters ProjectManager::getProjectPubli
     projectSettingsAction.addAction(&_project->getTitleAction());
     projectSettingsAction.addAction(&additionalProjectSettingsAction);
 
+    maxLoggingDepthAction.setDefaultWidgetFlags(IntegralAction::WidgetFlag::SpinBox);
+
     settingsAction.addAction(&_project->getCompressionAction());
     settingsAction.addAction(&projectSettingsAction);
-    settingsAction.addAction(&multiThreadingAction);
+    settingsAction.addAction(&parallelSettingsAction);
+    settingsAction.addAction(&maxLoggingDepthAction);
+
+    parallelSettingsAction.addAction(&parallelToggleAction);
+    parallelSettingsAction.addAction(&maximumNumberOfThreadsAction);
 
     for (auto action : settingsAction.getActions())
         addActionToFileDialog(action, &fileDialog);
+
+    const auto parallelToggled = [&]() {
+        maximumNumberOfThreadsAction.setEnabled(parallelToggleAction.isChecked());
+    };
+
+    parallelToggled();
+
+    connect(&parallelToggleAction, &ToggleAction::toggled, this, parallelToggled);
+
+    const auto updateSuffix = [&maximumNumberOfThreadsAction]() {
+        maximumNumberOfThreadsAction.setSuffix(QString(" thread%1").arg((maximumNumberOfThreadsAction.getValue() == 1 ? "" : "s")));
+    };
+
+    updateSuffix();
+
+    connect(&maximumNumberOfThreadsAction, &IntegralAction::valueChanged, this, updateSuffix);
 
     connect(&fileDialog, &QFileDialog::currentChanged, this, [this](const QString& filePath) -> void {
         if (!QFileInfo(filePath).isFile())
@@ -1390,9 +1428,15 @@ AbstractProjectManager::ProjectPublishParameters ProjectManager::getProjectPubli
     if (fileDialog.selectedFiles().count() != 1)
         throw std::runtime_error("Only one file may be selected");
 
-    parameters.filePath = fileDialog.selectedFiles().first();
-    parameters.parallel = multiThreadingAction.isChecked();
+    parameters.filePath             = fileDialog.selectedFiles().first();
+    parameters.parallel             = parallelToggleAction.isChecked();
+    parameters.maxParallelThreads   = maximumNumberOfThreadsAction.getValue();
+    parameters.maxLoggingDepth      = maxLoggingDepthAction.getValue();
 
+    setSetting("Directory", QFileInfo(parameters.filePath).absolutePath());
+    setSetting("Parallel", parameters.parallel);
+    setSetting("MaxNumberOfThreads", parameters.maxParallelThreads);
+    setSetting("MaxLogDepth", parameters.maxLoggingDepth);
     Application::current()->setSetting("Projects/WorkingDirectory/Publish", QFileInfo(parameters.filePath).absolutePath());
 
     return parameters;


### PR DESCRIPTION
## Summary

Restores the **Publish Project** functionality after the workflow-based serialization and parallel execution changes introduced in #1229.

## Changes

- Run project publishing through the current parallel project-save workflow.
- Keep the project read-only and the workspace locked until asynchronous serialization completes.
- Expose the temporary directory through both the save and publish paths during serialization.
- Restore the original project and workspace state after successful or failed publishing.
- Emit `projectPublished` only after successful workflow completion.
- Preserve support for publishing directly to a supplied file path.
- Initialize the parallel worker count correctly.
- Restore read-only project menu behavior:
  - Hide the **File** menu.
  - Respect the **Allow project switching** setting for the **Projects** menu.
  - Refresh menu visibility after project creation, opening, and destruction.

The **View** menu remains available as intended, while plugin creation and destructive view actions continue to be restricted for published projects.

Closes #1315