### PR TITLE
Run dataset `fromVariantMap()` on the GUI thread

### DIFF
--- a/ManiVault/src/util/Serializable.cpp
+++ b/ManiVault/src/util/Serializable.cpp
@@ -72,9 +72,9 @@ UniqueWorkflowPlan Serializable::fromVariantMapWorkflow(QVariantMap variantMap)
     UniqueWorkflowPlan plan = std::make_unique<WorkflowPlan>(QString("%1::fromVariantMap").arg(getSerializationName()));
 
     plan->addSequentialStage("Load", {
-        WorkflowPlan::Job("Load", [this, variantMap](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext&) {
+        WorkflowPlan::Job("Load", [this, variantMap = std::move(variantMap)](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext&) {
             fromVariantMap(variantMap);
-        })
+        }, WorkflowPlan::JobThreadAffinity::GuiThread)
     });
 
     return plan;


### PR DESCRIPTION
## Summary

This PR ensures that dataset `fromVariantMap()` calls are executed on the GUI thread during project loading.

Previously, dataset deserialization could run on a worker thread. Since `fromVariantMap()` may restore actions or otherwise interact with GUI-related Qt objects, this could lead to thread-affinity violations and related runtime issues.

## Changes

- Dispatch dataset `fromVariantMap()` execution to the GUI thread.
- Keep the surrounding project loading workflow parallelized where possible.
- Ensure GUI-related objects created or modified during dataset deserialization are handled from the correct thread.

## Motivation

Qt GUI objects are bound to the GUI thread and should not be created or modified from worker threads. Running dataset `fromVariantMap()` on the GUI thread avoids these thread-affinity issues while preserving parallel loading for work that does not require GUI access.