### PR TITLE
Improve view plugin state restore error handling

### DIFF
--- a/ManiVault/src/private/WorkspaceManager.cpp
+++ b/ManiVault/src/private/WorkspaceManager.cpp
@@ -15,8 +15,11 @@
 
 #include "actions/StringsAction.h"
 
+#include "exception/ManiVaultException.h"
+
 #include "util/Serialization.h"
 #include "util/Icon.h"
+#include "util/Miscellaneous.h"
 
 #include "workflow/WorkflowRuntimeScoped.h"
 
@@ -29,6 +32,7 @@
 #include <QEventLoop>
 
 #include <exception>
+#include <typeinfo>
 
 #ifdef _DEBUG
     //#define WORKSPACE_MANAGER_VERBOSE
@@ -580,34 +584,64 @@ UniqueWorkflowPlan WorkspaceManager::fromVariantMapWorkflow(QVariantMap variantM
 
         const auto restoreViewPluginState = [&executionContext](ViewPluginDockWidget* viewPluginDockWidget) {
             const auto viewPlugin = viewPluginDockWidget->getViewPlugin();
+            const auto guiName    = viewPlugin ? viewPlugin->getGuiName() : QStringLiteral("Unknown");
+            const auto kind       = viewPlugin ? viewPlugin->getKind() : QStringLiteral("Unknown");
+            const auto id         = viewPlugin ? viewPlugin->getId() : QString{};
+
+            const auto addViewPluginDetails = [&guiName, &kind, &id](QVariantMap details) {
+                details["ViewPluginGuiName"] = guiName;
+                details["ViewPluginKind"]    = kind;
+                details["ViewPluginId"]      = id;
+
+                return details;
+            };
 
             try {
                 viewPluginDockWidget->restoreViewPluginState();
             }
+            catch (const ManiVaultException& exception) {
+                auto details = addViewPluginDetails(exception.getDetails());
+
+                details["ExceptionType"]    = QStringLiteral("ManiVaultException");
+                details["ExceptionMessage"] = exception.getMessage();
+                details["ExceptionWhat"]    = exception.getWhat();
+                details["ExceptionWhere"]   = exception.getWhere();
+
+                executionContext->warning(
+                    QString("Unable to restore state for view plugin '%1' (%2): %3").arg(guiName, id, exception.getWhat()),
+                    exception.getWhere(),
+                    std::move(details));
+            }
             catch (const std::exception& exception) {
-                const auto guiName = viewPlugin ? viewPlugin->getGuiName() : QStringLiteral("Unknown");
-                const auto id      = viewPlugin ? viewPlugin->getId() : QString{};
+                const auto stackTrace = mv::errors().getDebugStackTrace();
+                const auto diagnosticId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+                auto details = addViewPluginDetails({
+                    { "DiagnosticId", diagnosticId },
+                    { "ExceptionType", QString::fromLatin1(typeid(exception).name()) },
+                    { "ExceptionWhat", QString::fromUtf8(exception.what()) },
+                    { "StackTrace", stackTraceToVariantList(stackTrace) },
+                    { "StackTraceSummary", stackTraceFunctionList(stackTrace) }
+                });
 
                 executionContext->warning(
                     QString("Unable to restore state for view plugin '%1' (%2): %3").arg(guiName, id, exception.what()),
-                    {},
-                    {
-                        { "ViewPluginGuiName", guiName },
-                        { "ViewPluginId", id },
-                        { "Exception", exception.what() }
-                    });
+                    QStringLiteral("ViewPluginDockWidget::restoreViewPluginState"),
+                    std::move(details));
             }
             catch (...) {
-                const auto guiName = viewPlugin ? viewPlugin->getGuiName() : QStringLiteral("Unknown");
-                const auto id      = viewPlugin ? viewPlugin->getId() : QString{};
+                const auto stackTrace = mv::errors().getDebugStackTrace();
+                const auto diagnosticId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+                auto details = addViewPluginDetails({
+                    { "DiagnosticId", diagnosticId },
+                    { "ExceptionType", QStringLiteral("Unknown exception") },
+                    { "StackTrace", stackTraceToVariantList(stackTrace) },
+                    { "StackTraceSummary", stackTraceFunctionList(stackTrace) }
+                });
 
                 executionContext->warning(
                     QString("Unable to restore state for view plugin '%1' (%2): Unknown error").arg(guiName, id),
-                    {},
-                    {
-                        { "ViewPluginGuiName", guiName },
-                        { "ViewPluginId", id }
-                    });
+                    QStringLiteral("ViewPluginDockWidget::restoreViewPluginState"),
+                    std::move(details));
             }
         };
 


### PR DESCRIPTION
Enhance exception handling in `restoreViewPluginState` lambda:
- Add dedicated catch block for `ManiVaultException` with structured details
- Include stack traces and diagnostic IDs for std and unknown exceptions
- Extract view plugin details (guiName, kind, id) before try block to avoid duplication
- Add source location to warning calls instead of empty strings
- Include ExceptionType field using typeid for std exceptions