### PR TITLE
Refine PRE_EXCLUDE patterns for Apple and Linux

### DIFF
--- a/ManiVault/cmake/mv_install_dependencies.cmake.in
+++ b/ManiVault/cmake/mv_install_dependencies.cmake.in
@@ -2,7 +2,7 @@ install(CODE [[
 
     if(WIN32)
         set(PRE_EXCLUDE "Qt6.*" "api-ms.*" "ext-ms.*" "hvsi.*" "pdmutilities.*" "wpaxholder.*" "dxgi.*" "^uxtheme.*" "d3d11.*" "winmm.*" "wldp.*")
-        set(POST_EXCLUDE ".*[\\/]system32[\\/].*\\.dll" ".*[\\/]Qt6.dll" ".*[\\/]MV_Public.dll" ".*[\\/]PointData.dll" ".*[\\/]ClusterData.dll" ".*[\\/]ColorData.dll" ".*[\\/]ImageData.dll" ".*[\\/]TextData.dll")
+        set(POST_EXCLUDE ".*[\\/]system32[\\/].*\\.dll" ".*[\\/]Qt6.*\\.dll" ".*[\\/]MV_Public.*\\.dll" ".*[\\/]PointData.*\\.dll" ".*[\\/]ClusterData.*\\.dll" ".*[\\/]ColorData.*\\.dll" ".*[\\/]ImageData.*\\.dll" ".*[\\/]TextData.*\\.dll")
     elseif(APPLE)
         set(PRE_EXCLUDE "libQt6.*" "Qt.*" "libomp.dylib" "libPointData.*" "libMV_Public.*" "libClusterData.*" "libColorData.*" "libImageData.*" "libTextData.*")
         set(POST_EXCLUDE "macos/lib")

--- a/ManiVault/cmake/mv_install_dependencies.cmake.in
+++ b/ManiVault/cmake/mv_install_dependencies.cmake.in
@@ -4,10 +4,10 @@ install(CODE [[
         set(PRE_EXCLUDE "Qt6.*" "api-ms.*" "ext-ms.*" "hvsi.*" "pdmutilities.*" "wpaxholder.*" "dxgi.*" "^uxtheme.*" "d3d11.*" "winmm.*" "wldp.*")
         set(POST_EXCLUDE ".*[\\/]system32[\\/].*\\.dll" ".*[\\/]Qt6.dll" ".*[\\/]MV_Public.dll" ".*[\\/]PointData.dll" ".*[\\/]ClusterData.dll" ".*[\\/]ColorData.dll" ".*[\\/]ImageData.dll" ".*[\\/]TextData.dll")
     elseif(APPLE)
-        set(PRE_EXCLUDE "libQt6.*" "libomp.dylib" "libPointData.dylib" "libMV_Public.dylib" "libClusterData.dylib" "libColorData.dylib" "libImageData.dylib" "libTextData.dylib")
+        set(PRE_EXCLUDE "libQt6.*" "Qt.*" "libomp.dylib" "libPointData.*" "libMV_Public.*" "libClusterData.*" "libColorData.*" "libImageData.*" "libTextData.*")
         set(POST_EXCLUDE "macos/lib")
     else()
-        set(PRE_EXCLUDE "libQt6.*" "libMV_Public.so" "libPointData.so" "libClusterData.so" "libColorData.so" "libImageData.so" "libTextData.so")
+        set(PRE_EXCLUDE "libQt6.*" "libMV_Public.*" "libPointData.*" "libClusterData.*" "libColorData.*" "libImageData.*" "libTextData.*")
         set(POST_EXCLUDE "x86_64-linux-gnu")
     endif()
 


### PR DESCRIPTION
With https://github.com/ManiVaultStudio/core/pull/1244 and https://github.com/ManiVaultStudio/core/pull/1246 the core plugin names changed but we did not update the cmake helper `mv_install_dependencies` accordingly. 
The results in the data plugins being installed as plugin specific dependencies, see e.g. [this CI run](https://github.com/ManiVaultStudio/ExamplePlugins/actions/runs/30533438959/job/90841286429).

I think https://github.com/ManiVaultStudio/core/pull/1249 (but it could also be a different change) lead to the above cmake helper also install Qt libraries framework bundles, which we do not want.

This PR updates the exclude list to ignore all those files.