### PR TITLE
lower case file names on windows

### DIFF
--- a/ManiVault/cmake/mv_install_dependencies.cmake.in
+++ b/ManiVault/cmake/mv_install_dependencies.cmake.in
@@ -1,13 +1,20 @@
 install(CODE [[
 
     if(WIN32)
-        set(PRE_EXCLUDE "Qt6.*" "api-ms.*" "ext-ms.*" "hvsi.*" "pdmutilities.*" "wpaxholder.*" "dxgi.*" "^uxtheme.*" "d3d11.*" "winmm.*" "wldp.*")
-        set(POST_EXCLUDE ".*[\\/]system32[\\/].*\\.dll" ".*[\\/]Qt6.*\\.dll" ".*[\\/]MV_Public.*\\.dll" ".*[\\/]PointData.*\\.dll" ".*[\\/]ClusterData.*\\.dll" ".*[\\/]ColorData.*\\.dll" ".*[\\/]ImageData.*\\.dll" ".*[\\/]TextData.*\\.dll")
+        set(PRE_EXCLUDE "qt6.*" "api-ms.*" "ext-ms.*" "hvsi.*" "pdmutilities.*" 
+            "wpaxholder.*" "dxgi.*" "uxtheme.*" "d3d11.*" "winmm.*" "wldp.*" 
+            "mv_public.*" "pointdata.*" "clusterdata.*" "colordata.*" "imagedata.*" "textdata.*"
+        )
+        set(POST_EXCLUDE ".*[\\/]system32[\\/].*\\.dll")
     elseif(APPLE)
-        set(PRE_EXCLUDE "libQt6.*" "Qt.*" "libomp.dylib" "libPointData.*" "libMV_Public.*" "libClusterData.*" "libColorData.*" "libImageData.*" "libTextData.*")
+        set(PRE_EXCLUDE "libQt6.*" "Qt.*" "libomp.dylib" "libPointData.*" "libMV_Public.*" 
+            "libClusterData.*" "libColorData.*" "libImageData.*" "libTextData.*"
+        )
         set(POST_EXCLUDE "macos/lib")
     else()
-        set(PRE_EXCLUDE "libQt6.*" "libMV_Public.*" "libPointData.*" "libClusterData.*" "libColorData.*" "libImageData.*" "libTextData.*")
+        set(PRE_EXCLUDE "libQt6.*" "libMV_Public.*" "libPointData.*" "libClusterData.*" 
+            "libColorData.*" "libImageData.*" "libTextData.*"
+        )
         set(POST_EXCLUDE "x86_64-linux-gnu")
     endif()
 


### PR DESCRIPTION
On Windows `mv_install_dependencies` currently results in listing unresolved dependencies even though they are listed in the `PRE_EXCLUDE` regex pattern
```
Unresolved: ImageData_p1.0.0_c1.5.0.dll
Unresolved: MV_Public.dll
Unresolved: PointData_p1.0.0_c1.5.0.dll
Unresolved: Qt6Core.dll
Unresolved: Qt6Gui.dll
Unresolved: Qt6Widgets.dll
```
This is due to CMake's handling of Window's DLL resolution (see [`file(GET_RUNTIME_DEPENDENCIES ...)`](https://cmake.org/cmake/help/latest/command/file.html#get-runtime-dependencies)):
> On Windows platforms, library resolution works as follows:
>
>   1. DLL dependency names are converted to lowercase for matching filters. Windows DLL names are case-insensitive, and some linkers mangle the case of the DLL dependency names. However, this makes it more difficult for PRE_INCLUDE_REGEXES, PRE_EXCLUDE_REGEXES, POST_INCLUDE_REGEXES, and POST_EXCLUDE_REGEXES to properly filter DLL names - every regex would have to check for both uppercase and lowercase letters. 

As suggested in the docs, we should use all lowercase names in the `PRE_EXCLUDE` regex pattern. This yields correct matches with `Qt6Core.dll`, etc.


---


Note: The warnings about [CMP0207](https://cmake.org/cmake/help/latest/policy/CMP0207.html), which are emitted for CMake version >=4.3, are annoying but do not impact us:
```
  CMake Warning (policy) at cmake_install.cmake:275 (file):
    Policy CMP0207 is not set: file(GET_RUNTIME_DEPENDENCIES) normalizes paths
    before matching.  Run "cmake --help-policy CMP0207" for policy details.
    Use the cmake_policy command to set the policy and suppress this warning.
  
    Path
  
      "C:\WINDOWS\system32/vcruntime140_1.dll"
  
    would be converted to
  
      "C:/WINDOWS/system32/vcruntime140_1.dll"
  
  This warning is for project developers.  Use -Wno-author or -Wno-policy to
  suppress it.
```
The `set(POST_EXCLUDE ".*[\\/]system32[\\/].*\\.dll")` matches either `\` or `/`. Once we update the cmake policy, these warning will not pop up anymore and we can simplify that regex pattern.