### PR TITLE
PluginTriggerAction: copy enabled status in copy constructor

### DIFF
--- a/ManiVault/src/actions/PluginTriggerAction.cpp
+++ b/ManiVault/src/actions/PluginTriggerAction.cpp
@@ -57,6 +57,7 @@ PluginTriggerAction::PluginTriggerAction(const PluginTriggerAction& pluginTrigge
     PluginTriggerAction::setText(title);
     setToolTip(pluginTriggerAction.toolTip());
     setIcon(pluginTriggerAction.icon());
+    setEnabled(pluginTriggerAction.isEnabled());
 
     connect(this, &TriggerAction::triggered, this, &PluginTriggerAction::requestPlugin);
 }


### PR DESCRIPTION
We should copy the "enabled" status in the copy constructor of `PluginTriggerAction`.

There are plugins that should be not opened via the main menu bar, e.g. the JupyterLauncher, but there might be other cases, e.g. when a view plugin must be opened with a dataset.

Currently, afaik, all view plugins are listed in the menu and the"enabled" status is not respected.

New possibility, e.g. with https://github.com/ManiVaultStudio/JupyterPlugin/pull/71:
<img width="230" height="373" alt="image" src="https://github.com/user-attachments/assets/59b35c5d-617a-4917-be18-be860dc996b3" />

There are more members of the `PluginTriggerAction` which are not copied in the copy-constructor, but that might be intentional?

Related: https://github.com/ManiVaultStudio/core/issues/1327 

---

Some additional context:

The JupyterLauncher plugin factory [sets the maximum number of plugins instances to 1](https://github.com/ManiVaultStudio/JupyterPlugin/blob/bf6a221996efdf0232b9614ab2928d673b1b58ce/src/JupyterLauncher/JupyterLauncher.cpp#L716). In `PluginManager::privateRequestPlugin`, there is a check for [`pluginFactory->mayProduce()`](https://github.com/ManiVaultStudio/core/blob/35857baaabd86e982a28be89d782a3dd71220d22/ManiVault/src/private/PluginManager.cpp#L406) which returns `_numberOfInstances < _maximumNumberOfInstances`, and will throw if true. This means, currently, when first opening the JupyterLauncher via the view menu, nothing happens since the plugins want to be opened via the status bar, and the second opening causes a crash.

Alternatively, instead of throwing when `mayProduce()` returns true, the respective plugin trigger action could be disabled.
