### PR TITLE
Enable tooltips for view plugin menu actions

### DIFF
--- a/ManiVault/src/private/LoadSystemViewMenu.cpp
+++ b/ManiVault/src/private/LoadSystemViewMenu.cpp
@@ -25,6 +25,7 @@ LoadSystemViewMenu::LoadSystemViewMenu(QWidget *parent /*= nullptr*/, ads::CDock
 {
     setTitle("System views");
     setToolTip("Manage system view plugins");
+    setToolTipsVisible(true);
     //setEnabled(mayProducePlugins());
     setIcon(StyledIcon("gears"));
 
@@ -33,6 +34,9 @@ LoadSystemViewMenu::LoadSystemViewMenu(QWidget *parent /*= nullptr*/, ads::CDock
     _loadViewsDockedMenus.insert(gui::DockAreaFlag::Top, QSharedPointer<QMenu>(new QMenu(gui::dockAreaMap.key(gui::DockAreaFlag::Top), this)));
     _loadViewsDockedMenus.insert(gui::DockAreaFlag::Bottom, QSharedPointer<QMenu>(new QMenu(gui::dockAreaMap.key(gui::DockAreaFlag::Bottom), this)));
     _loadViewsDockedMenus.insert(gui::DockAreaFlag::Center, QSharedPointer<QMenu>(new QMenu(gui::dockAreaMap.key(gui::DockAreaFlag::Center), this)));
+
+    for (auto& loadViewsDockedMenu : _loadViewsDockedMenus)
+        loadViewsDockedMenu->setToolTipsVisible(true);
 
     populate();
 }
@@ -97,6 +101,7 @@ QVector<QPointer<TriggerAction>> LoadSystemViewMenu::getLoadSystemViewsActions(m
         auto action = new TriggerAction(this, viewPluginFactory->getKind());
 
         action->setIcon(pluginTriggerAction->icon());
+        action->setToolTip(pluginTriggerAction->toolTip());
         action->setEnabled(pluginTriggerAction->isEnabled());
 
         connect(pluginTriggerAction, &PluginTriggerAction::enabledChanged, action, [action, pluginTriggerAction](bool enabled) -> void {

--- a/ManiVault/src/private/ViewMenu.cpp
+++ b/ManiVault/src/private/ViewMenu.cpp
@@ -27,6 +27,7 @@ ViewMenu::ViewMenu(QWidget *parent /*= nullptr*/, const Options& options /*= Opt
 {
     setTitle("View");
     setToolTip("Manage view plugins");
+    setToolTipsVisible(true);
     
     // the menu needs to be updated, e.g. for when new view actions are opened
     connect(this, &QMenu::aboutToShow, this, &ViewMenu::populate);
@@ -40,6 +41,9 @@ ViewMenu::ViewMenu(QWidget *parent /*= nullptr*/, const Options& options /*= Opt
     _loadViewsDockedMenus.insert(gui::DockAreaFlag::Top,    QSharedPointer<QMenu>(new QMenu(gui::dockAreaMap.key(gui::DockAreaFlag::Top), this)));
     _loadViewsDockedMenus.insert(gui::DockAreaFlag::Bottom, QSharedPointer<QMenu>(new QMenu(gui::dockAreaMap.key(gui::DockAreaFlag::Bottom), this)));
     _loadViewsDockedMenus.insert(gui::DockAreaFlag::Center, QSharedPointer<QMenu>(new QMenu(gui::dockAreaMap.key(gui::DockAreaFlag::Center), this)));
+
+    for (auto& loadViewsDockedMenu : _loadViewsDockedMenus)
+        loadViewsDockedMenu->setToolTipsVisible(true);
 
     populate();
 


### PR DESCRIPTION
### Summary

Enable tooltip display for plugin creation actions in the View menu.

### Changes

- Enable tooltips on the main View menu.
- Enable tooltips on the System Views menu.
- Enable tooltips on dock-position submenus.
- Preserve plugin trigger action tooltips when creating system-view wrapper actions.

### Rationale

`PluginTriggerAction` instances already provide descriptive tooltips, but `QMenu` does not display action tooltips by default. System-view wrapper actions also did not copy the tooltip from their source action.

This keeps tooltip behavior scoped to plugin-creation menus, where the descriptions provide useful information beyond the visible action label.

Depends on #1326 