### PR TITLE
Restore configurable BLOB storage location during project serialization

### DIFF
--- a/ManiVault/src/util/Serialization.cpp
+++ b/ManiVault/src/util/Serialization.cpp
@@ -28,12 +28,12 @@ namespace
 {
 
 /**
- * Encode a single raw data block and store the encoded payload on disk.
+ * Encode a single raw data block and store the encoded payload at the requested location.
  *
  * The function encodes the byte range described by `job._offset` and
  * `job._size` from the source buffer `job._data`. The encoded payload is
- * written to a uniquely named file inside `saveDir`, using the file extension
- * provided by the block codec.
+ * stored either in a uniquely named file inside `saveDir` or as base64 data in
+ * the returned block map.
  *
  * The returned result contains a block variant map with the metadata required
  * to decode the block later, including offset, decoded size, compressed size,
@@ -41,11 +41,12 @@ namespace
  *
  * @param job Encode job describing the source buffer, byte range, and codec.
  * @param saveDir Directory where the encoded block file should be written.
+ * @param storageLocation Location used to store the encoded block payload.
  * @return Encode result containing the serialized block descriptor.
  *
  * @throws ManiVaultException If the block cannot be encoded.
  */
-EncodeBlockResult encodeBlock(const EncodeBlockJob& job, const QString& saveDir)
+EncodeBlockResult encodeBlock(const EncodeBlockJob& job, const QString& saveDir, BlobStorageLocation storageLocation)
 {
     EncodeBlockResult result;
 
@@ -61,15 +62,29 @@ EncodeBlockResult encodeBlock(const EncodeBlockJob& job, const QString& saveDir)
         blockVariantMap["Offset"]   = QVariant::fromValue(job._offset);
         blockVariantMap["Size"]     = QVariant::fromValue(job._size);
 
-        const auto fileName = QUuid::createUuid().toString(QUuid::WithoutBraces) + job._codec->getFileExtension();
-        const auto filePath = QDir::cleanPath(saveDir + QDir::separator() + fileName);
+        switch (storageLocation) {
+            case BlobStorageLocation::FileInProject: {
+                const auto fileName = QUuid::createUuid().toString(QUuid::WithoutBraces) + job._codec->getFileExtension();
+                const auto filePath = QDir::cleanPath(saveDir + QDir::separator() + fileName);
 
-        std::uint64_t numberOfEncodedBytes = 0;
+                std::uint64_t numberOfEncodedBytes = 0;
 
-        job._codec->encodeToFile(job._data + job._offset, static_cast<qsizetype>(job._size), filePath, &numberOfEncodedBytes);
+                job._codec->encodeToFile(job._data + job._offset, static_cast<qsizetype>(job._size), filePath, &numberOfEncodedBytes);
 
-        blockVariantMap["CompressedSize"]   = QVariant::fromValue<std::uint64_t>(numberOfEncodedBytes);
-        blockVariantMap["URI"]              = fileName;
+                blockVariantMap["CompressedSize"] = QVariant::fromValue(numberOfEncodedBytes);
+                blockVariantMap["URI"]            = fileName;
+                break;
+            }
+            case BlobStorageLocation::InlineInProjectJson: {
+                const auto encodedData = job._codec->encode(job._data + job._offset, static_cast<qsizetype>(job._size));
+
+                blockVariantMap["CompressedSize"] = QVariant::fromValue(static_cast<std::uint64_t>(encodedData.size()));
+                blockVariantMap["Data"]           = QString::fromLatin1(encodedData.toBase64());
+                break;
+            }
+            default:
+                throw std::invalid_argument("Unsupported blob storage location");
+        }
 
         result._block = std::move(blockVariantMap);
     }
@@ -606,7 +621,7 @@ std::uint64_t getRawBlockObjectSize(const QVariantMap& map)
 
 }
 
-QVariantMap bytesToBlobVariantMap(const char* bytes, std::uint64_t numberOfBytes)
+QVariantMap bytesToBlobVariantMap(const char* bytes, std::uint64_t numberOfBytes, BlobStorageLocation storageLocation)
 {
     try {
         if (!mv::projects().hasProject())
@@ -623,7 +638,7 @@ QVariantMap bytesToBlobVariantMap(const char* bytes, std::uint64_t numberOfBytes
         const auto saveDir = QDir::cleanPath(projects().getTemporaryDirPath(AbstractProjectManager::TemporaryDirType::Save));
 
         for (auto& job : jobs)
-            job._result = encodeBlock(job, saveDir);
+            job._result = encodeBlock(job, saveDir, storageLocation);
 
         return makeBlobVariantMap(numberOfBytes, blockSizeInBytes, createCodec()->getName(), jobs);
     }
@@ -637,7 +652,7 @@ QVariantMap bytesToBlobVariantMap(const char* bytes, std::uint64_t numberOfBytes
     }
 }
 
-UniqueWorkflowPlan bytesToBlobVariantMapWorkflow(const char* bytes, std::uint64_t numberOfBytes)
+UniqueWorkflowPlan bytesToBlobVariantMapWorkflow(const char* bytes, std::uint64_t numberOfBytes, BlobStorageLocation storageLocation)
 {
     try {
         if (!bytes && numberOfBytes > 0)
@@ -664,10 +679,10 @@ UniqueWorkflowPlan bytesToBlobVariantMapWorkflow(const char* bytes, std::uint64_
         encodeJobs.reserve(encodeBlockJobs->size());
 
         for (qsizetype i = 0; i < encodeBlockJobs->size(); ++i) {
-            encodeJobs.emplace_back(QString("Encode block %1").arg(i), [encodeBlockJobs, i, saveDir](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext&) {
+            encodeJobs.emplace_back(QString("Encode block %1").arg(i), [encodeBlockJobs, i, saveDir, storageLocation](const WorkflowPlan::Job&, const SharedWorkflowExecutionContext&) {
                 auto& encodeBlockJob = (*encodeBlockJobs)[i];
 
-                encodeBlockJob._result = encodeBlock(encodeBlockJob, saveDir);
+                encodeBlockJob._result = encodeBlock(encodeBlockJob, saveDir, storageLocation);
             }, WorkflowPlan::JobThreadAffinity::CurrentWorkerThread, WorkflowPlan::JobProgressMode::Atomic);
         }
 

--- a/ManiVault/src/util/Serialization.h
+++ b/ManiVault/src/util/Serialization.h
@@ -21,6 +21,13 @@
 
 namespace mv::util {
 
+/** Location used to store encoded blob payloads during project serialization. */
+enum class BlobStorageLocation
+{
+    FileInProject,         /** Store each encoded block as a file in the project archive. */
+    InlineInProjectJson    /** Store each encoded block inline in the project JSON. */
+};
+
 /** Result produced by encoding a single data block. */
 struct EncodeBlockResult
 {
@@ -78,9 +85,10 @@ using DecodeBlockJobs = QVector<DecodeBlockJob>;
  *
  * @param bytes Source byte buffer.
  * @param numberOfBytes Number of bytes in the source buffer.
+ * @param storageLocation Location used to store the encoded blob payloads.
  * @return Serialized blob variant map.
  */
-CORE_EXPORT QVariantMap bytesToBlobVariantMap(const char* bytes, std::uint64_t numberOfBytes);
+CORE_EXPORT QVariantMap bytesToBlobVariantMap(const char* bytes, std::uint64_t numberOfBytes, BlobStorageLocation storageLocation = BlobStorageLocation::FileInProject);
 
 /**
  * Create a workflow that serializes a raw byte buffer into a blob variant map.
@@ -90,9 +98,10 @@ CORE_EXPORT QVariantMap bytesToBlobVariantMap(const char* bytes, std::uint64_t n
  *
  * @param bytes Source byte buffer.
  * @param numberOfBytes Number of bytes in the source buffer.
+ * @param storageLocation Location used to store the encoded blob payloads.
  * @return Workflow that produces a blob variant map.
  */
-CORE_EXPORT workflow::UniqueWorkflowPlan bytesToBlobVariantMapWorkflow(const char* bytes, std::uint64_t numberOfBytes);
+CORE_EXPORT workflow::UniqueWorkflowPlan bytesToBlobVariantMapWorkflow(const char* bytes, std::uint64_t numberOfBytes, BlobStorageLocation storageLocation = BlobStorageLocation::FileInProject);
 
 /**
  * Populate a destination buffer from a serialized blob variant map.


### PR DESCRIPTION
## Summary

Restores the ability to choose how serialized BLOB payloads are stored:

- `BlobStorageLocation::FileInProject` stores encoded blocks as files in the project archive.
- `BlobStorageLocation::InlineInProjectJson` stores encoded blocks inline in `project.json`.

The storage choice is available for both synchronous and workflow-based serialization APIs. `FileInProject` remains the default for backward compatibility.

## Motivation

PR #1229 removed the previous `toDisk` option. Replacing that boolean with a strongly typed `BlobStorageLocation` enum makes call sites clearer and allows additional storage locations to be introduced later.

Storage location remains independent of compression: the location determines where encoded data is stored, while the selected BLOB codec determines how it is encoded.