### PR TITLE
Restore “Allow edit of published project” when opening projects

### DIFF
--- a/ManiVault/src/AbstractProjectManager.h
+++ b/ManiVault/src/AbstractProjectManager.h
@@ -101,7 +101,8 @@ public:
     /** Parameters for opening a project */
     struct ProjectOpenParameters : ProjectOperationParameters
     {
-        QString filePath = "";  /** File path of the project to open (choose file path when empty) */
+        QString filePath                    = "";     /** File path of the project to open (choose file path when empty) */
+        bool    allowEditOfPublishedProject = false;  /** Whether to disable read-only mode after opening a published project */
 
         /**
          * Determine whether the parameters are valid

--- a/ManiVault/src/private/ProjectManager.cpp
+++ b/ManiVault/src/private/ProjectManager.cpp
@@ -394,7 +394,10 @@ void ProjectManager::openProject(QString filePath /*= ""*/, bool importDataOnly 
             }
         }));
         
-        future.onFinished(this, [this](SharedWorkflowResult result) {
+        future.onFinished(this, [this, allowEditOfPublishedProject = parameters.allowEditOfPublishedProject](SharedWorkflowResult result) {
+            if (allowEditOfPublishedProject)
+                _project->getReadOnlyAction().setChecked(false);
+
             setState(State::Idle);
             emit projectOpened(*_project);
         });
@@ -1188,6 +1191,7 @@ AbstractProjectManager::ProjectOpenParameters ProjectManager::getProjectOpenPara
 	        throw std::runtime_error("Only one file may be selected");
 
         parameters.filePath            = fileDialog.selectedFiles().first();
+        parameters.allowEditOfPublishedProject = disableReadOnlyAction.isEnabled() && disableReadOnlyAction.isChecked();
         parameters.parallel            = parallelToggleAction.isChecked();
         parameters.maxParallelThreads  = maximumNumberOfThreadsAction.getValue();
         parameters.maxLoggingDepth      = maxLoggingDepthAction.getValue();


### PR DESCRIPTION
## Summary

Restores the **Allow edit of published project** option in the project-open dialog.

The option was still displayed and enabled for published projects, but its value was no longer propagated through the workflow-based project-opening path. As a result, published projects remained read-only even when the option was checked.

## Changes

- Add `allowEditOfPublishedProject` to `ProjectOpenParameters`.
- Store the dialog toggle value in the open parameters.
- Disable the project’s read-only state after deserialization and before emitting `projectOpened`.
